### PR TITLE
Add CO₂ impact calculator widget to donation form

### DIFF
--- a/frontend/components/DonateForm.tsx
+++ b/frontend/components/DonateForm.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from "react";
 import { buildDonationTransaction, buildContractDonationTransaction, submitTransaction, explorerUrl, getXLMBalance, getAssetBalance, getDonorStats, hashMessage, CONTRACT_ID } from "@/lib/stellar";
 import { signTransactionWithWallet } from "@/lib/wallet";
 import { recordDonation } from "@/lib/api";
-import { formatXLM } from "@/utils/format";
+import { formatXLM, formatCO2 } from "@/utils/format";
 import type { ClimateProject } from "@/utils/types";
 
 interface DonateFormProps {
@@ -66,6 +66,14 @@ export default function DonateForm({ project, publicKey, onSuccess }: DonateForm
 
   const amountNum = parseFloat(amount);
   const isValid   = !isNaN(amountNum) && amountNum >= 1;
+
+  // Calculate CO₂ impact for XLM donations
+  const co2Impact = currency === "XLM" && amount && !isNaN(amountNum) && project.co2_per_xlm
+    ? (amountNum * project.co2_per_xlm) / 1000 // Convert to kg
+    : 0;
+
+  // Calculate tree equivalent (rough estimate: 1 tree absorbs ~22kg CO₂ per year)
+  const treeEquivalent = co2Impact > 0 ? Math.round(co2Impact / 22) : 0;
 
     const charCount = message.length;
 
@@ -239,6 +247,20 @@ export default function DonateForm({ project, publicKey, onSuccess }: DonateForm
             placeholder="Or enter custom amount..." min="1" step="1"
             className="input-field" />
           {amount && !isValid && <p className="mt-1 text-xs text-red-500">Minimum donation is 1 {currency}</p>}
+          
+          {/* CO₂ Impact Calculator */}
+          {currency === "XLM" && amount && !isNaN(amountNum) && co2Impact > 0 && (
+            <div className="mt-3 p-3 bg-forest-50 border border-forest-200 rounded-xl">
+              <p className="text-sm font-medium text-forest-900 mb-1">
+                🌱 Your donation will offset approximately <span className="font-bold text-forest-700">{formatCO2(co2Impact)}</span>
+              </p>
+              {treeEquivalent > 0 && (
+                <p className="text-xs text-forest-600 mt-1">
+                  That is equivalent to planting about <span className="font-semibold">{treeEquivalent} {treeEquivalent === 1 ? 'tree' : 'trees'}</span>
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Message */}

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -28,6 +28,7 @@ export interface ClimateProject {
   raisedXLM: string;           // total raised so far
   donorCount: number;
   co2OffsetKg: number;         // estimated CO2 offset in kg
+  co2_per_xlm: number;         // CO2 offset per XLM donated
   status: ProjectStatus;
   verified: boolean;
   onChainVerified?: boolean;


### PR DESCRIPTION
- Add co2_per_xlm field to ClimateProject type
- Implement live CO₂ impact calculation for XLM donations
- Display formatted CO₂ impact using formatCO2() helper
- Add tree equivalent analogy for context
- Show calculator only when amount is entered and currency is XLM
- Update in real-time as user changes amount

Fixes #15

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
closes #15 