### PR TITLE
feat: add circular progress ring component for project funding

### DIFF
--- a/frontend/components/CircularProgress.tsx
+++ b/frontend/components/CircularProgress.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from "react";
+
+interface CircularProgressProps {
+  percentage: number;
+  size?: number;
+  strokeWidth?: number;
+}
+
+export default function CircularProgress({
+  percentage,
+  size = 48,
+  strokeWidth = 4,
+}: CircularProgressProps) {
+  const [offset, setOffset] = useState<number | null>(null);
+  const radius = (size - strokeWidth) / 2;
+  const circumference = radius * 2 * Math.PI;
+
+  useEffect(() => {
+    // Determine target offset
+    const p = Math.min(Math.max(percentage, 0), 100);
+    const progressOffset = ((100 - p) / 100) * circumference;
+
+    // Small delay ensures the initial render (with 0% circle) 
+    // happens, and then CSS animates it filling up.
+    const timer = setTimeout(() => {
+      setOffset(progressOffset);
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [percentage, circumference]);
+
+  const initialOffset = circumference;
+
+  let colorClass = "text-green-500";
+  if (percentage >= 50 && percentage <= 80) {
+    colorClass = "text-teal-500";
+  } else if (percentage > 80) {
+    colorClass = "text-emerald-500";
+  }
+
+  return (
+    <div className="relative inline-flex items-center justify-center font-body" style={{ width: size, height: size }}>
+      <svg className="transform -rotate-90" width={size} height={size}>
+        {/* Background rounded track */}
+        <circle
+          className="text-[#e2ece2] stroke-current"
+          strokeWidth={strokeWidth}
+          fill="transparent"
+          r={radius}
+          cx={size / 2}
+          cy={size / 2}
+        />
+        {/* Colored arc */}
+        <circle
+          className={`${colorClass} stroke-current transition-all ease-out duration-1000`}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset === null ? initialOffset : offset}
+          fill="transparent"
+          r={radius}
+          cx={size / 2}
+          cy={size / 2}
+        />
+      </svg>
+      <span className="absolute font-semibold text-forest-900" style={{ fontSize: Math.max(10, size * 0.25) }}>
+        {Math.round(percentage)}%
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/ProjectCard.tsx
+++ b/frontend/components/ProjectCard.tsx
@@ -4,6 +4,7 @@
 import Link from "next/link";
 import type { ClimateProject } from "@/utils/types";
 import { formatXLM, formatUSDEquivalent, formatCO2, progressPercent, statusClass, statusLabel, CATEGORY_ICONS } from "@/utils/format";
+import CircularProgress from "./CircularProgress";
 import { useXlmPrice } from "@/lib/priceContext";
 
 export default function ProjectCard({ project }: { project: ClimateProject }) {
@@ -52,32 +53,31 @@ export default function ProjectCard({ project }: { project: ClimateProject }) {
           {project.description}
         </p>
 
-        {/* Progress bar */}
+        {/* Progress */}
         <div className="mb-4">
           {isComplete ? (
             <div className="bg-gradient-to-r from-green-500 to-emerald-600 text-white px-4 py-2 rounded-lg text-center text-sm font-semibold shadow-sm">
               ✅ Fully Funded
             </div>
           ) : (
-            <>
-              <div className="flex justify-between text-xs text-[#8aaa8a] mb-1.5 font-body">
+            <div className="flex items-center gap-3">
+              <CircularProgress percentage={pct} size={48} strokeWidth={4} />
+              <div className="flex-1 flex justify-between text-xs text-[#8aaa8a] font-body">
                 <div>
-                  <span>{formatXLM(project.raisedXLM)} raised</span>
+                  <span className="font-semibold text-forest-700 block mb-0.5">{formatXLM(project.raisedXLM)}</span>
                   {formatUSDEquivalent(project.raisedXLM, xlmUsd) && (
-                    <span className="block text-[10px] text-[#aac0aa]">{formatUSDEquivalent(project.raisedXLM, xlmUsd)}</span>
+                    <span className="block text-[10px] text-[#aac0aa]">raised ({formatUSDEquivalent(project.raisedXLM, xlmUsd)})</span>
                   )}
+                  {!formatUSDEquivalent(project.raisedXLM, xlmUsd) && <span>raised</span>}
                 </div>
                 <div className="text-right">
-                  <span>{pct}% of {formatXLM(project.goalXLM)}</span>
+                  <span className="block mb-0.5">Goal: {formatXLM(project.goalXLM)}</span>
                   {formatUSDEquivalent(project.goalXLM, xlmUsd) && (
                     <span className="block text-[10px] text-[#aac0aa]">{formatUSDEquivalent(project.goalXLM, xlmUsd)}</span>
                   )}
                 </div>
               </div>
-              <div className="progress-bar">
-                <div className={pct >= 100 ? "progress-fill progress-fill-complete" : "progress-fill"} style={{ width: `${Math.min(pct, 100)}%` }} />
-              </div>
-            </>
+            </div>
           )}
         </div>
 

--- a/frontend/pages/projects/[id].tsx
+++ b/frontend/pages/projects/[id].tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import DonateForm from "@/components/DonateForm";
 import DonationFeed from "@/components/DonationFeed";
 import WalletConnect from "@/components/WalletConnect";
+import CircularProgress from "@/components/CircularProgress";
 import { fetchProject, fetchProjectUpdates, subscribeToProject } from "@/lib/api";
 import { formatXLM, formatCO2, progressPercent, timeAgo, statusClass, statusLabel, CATEGORY_ICONS, copyToClipboard } from "@/utils/format";
 import { accountUrl } from "@/lib/stellar";
@@ -173,15 +174,13 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
                   🎉 Goal Reached!
                 </div>
               ) : (
-                <>
-                  <div className="flex justify-between text-sm mb-2 font-body">
-                    <span className="font-semibold text-forest-700">{formatXLM(project.raisedXLM)} raised</span>
-                    <span className="text-[#5a7a5a]">{pct}% of {formatXLM(project.goalXLM)} goal</span>
+                <div className="flex items-center gap-5">
+                  <CircularProgress percentage={pct} size={64} strokeWidth={6} />
+                  <div className="flex-1">
+                    <p className="font-semibold text-forest-800 text-lg">{formatXLM(project.raisedXLM)} raised</p>
+                    <p className="text-[#5a7a5a] text-sm font-body mt-0.5">towards {formatXLM(project.goalXLM)} goal</p>
                   </div>
-                  <div className="progress-bar h-3">
-                    <div className={pct >= 100 ? "progress-fill progress-fill-complete" : "progress-fill"} style={{ width: `${Math.min(pct, 100)}%` }} />
-                  </div>
-                </>
+                </div>
               )}
             </div>
 


### PR DESCRIPTION
Fixes #65.

This PR adds a `CircularProgress` SVG component that visually shows funding progress on project cards and the project detail page. 

**Changes included:**
- Created a reusable `CircularProgress` component.
- Implemented percentage-based coloring (green < 50%, teal 50-80%, emerald > 80%).
- Used `stroke-dashoffset` for smooth filling animation on mount.
- Replaced the linear progress bars in `ProjectCard` and the `[id].tsx` single project page with the new styling layout.
