### PR TITLE
feat: Add Friendbot funding, CO2 offset ticker, subscription count & featured project spotlight

### DIFF
--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -22,6 +22,40 @@ const VALID_CATEGORIES = [
   "Other",
 ];
 
+/**
+ * GET /api/projects/featured
+ * Returns the project with the highest donorCount (active projects only).
+ * Result is cached in memory for 24 hours.
+ */
+let featuredCache = null;
+let featuredCacheExpiry = 0;
+
+router.get("/featured", async (req, res, next) => {
+  try {
+    const now = Date.now();
+    if (featuredCache && now < featuredCacheExpiry) {
+      return res.json({ success: true, data: featuredCache });
+    }
+
+    const result = await pool.query(
+      `SELECT * FROM projects
+       WHERE status = 'active'
+       ORDER BY donor_count DESC, raised_xlm DESC
+       LIMIT 1`,
+    );
+
+    if (!result.rows[0]) {
+      return res.status(404).json({ error: "No featured project found" });
+    }
+
+    featuredCache = mapProjectRow(result.rows[0]);
+    featuredCacheExpiry = now + 24 * 60 * 60 * 1000; // 24 hours
+    res.json({ success: true, data: featuredCache });
+  } catch (e) {
+    next(e);
+  }
+});
+
 router.get("/", async (req, res, next) => {
   try {
     const { category, status, verified, search, limit = 50 } = req.query;

--- a/backend/src/routes/stats.js
+++ b/backend/src/routes/stats.js
@@ -1,0 +1,37 @@
+/**
+ * src/routes/stats.js
+ * GET /api/stats/global — platform-wide totals (donations count, XLM raised, CO2 offset)
+ */
+"use strict";
+const express = require("express");
+const router  = express.Router();
+const pool    = require("../db/pool");
+
+// GET /api/stats/global
+router.get("/global", async (req, res, next) => {
+  try {
+    const result = await pool.query(`
+      SELECT
+        COUNT(d.id)::int            AS "totalDonations",
+        COALESCE(SUM(d.amount), 0)  AS "totalXLMRaised",
+        COALESCE(SUM(p.co2_offset_kg), 0)::int AS "totalCO2OffsetKg"
+      FROM donations d
+      JOIN projects p ON p.id = d.project_id
+      WHERE d.currency = 'XLM' OR d.currency IS NULL
+    `);
+
+    const row = result.rows[0];
+    res.json({
+      success: true,
+      data: {
+        totalDonations:  row.totalDonations,
+        totalXLMRaised:  parseFloat(row.totalXLMRaised).toFixed(7),
+        totalCO2OffsetKg: row.totalCO2OffsetKg,
+      },
+    });
+  } catch (e) {
+    next(e);
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/subscriptions.js
+++ b/backend/src/routes/subscriptions.js
@@ -27,12 +27,17 @@ router.post("/", async (req, res, next) => {
     const proj = await pool.query("SELECT id FROM projects WHERE id = $1", [projectId]);
     if (!proj.rows[0]) return res.status(404).json({ error: "Project not found" });
 
-    await pool.query(
+    const insertResult = await pool.query(
       `INSERT INTO project_subscriptions (id, project_id, email, donor_address)
        VALUES ($1, $2, $3, $4)
-       ON CONFLICT (project_id, email) DO NOTHING`,
+       ON CONFLICT (project_id, email) DO NOTHING
+       RETURNING id`,
       [uuidv4(), projectId, email.toLowerCase().trim(), donorAddress || null],
     );
+
+    if (insertResult.rowCount === 0) {
+      return res.status(409).json({ error: "Already subscribed with this email." });
+    }
 
     res.status(201).json({ success: true, message: "Subscribed successfully" });
   } catch (e) {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -33,6 +33,7 @@ app.use("/api/leaderboard", require("./routes/leaderboard"));
 app.use("/api/updates",        require("./routes/updates"));
 app.use("/api/subscriptions",  require("./routes/subscriptions"));
 app.use("/api/jobs",           require("./routes/jobs"));
+app.use("/api/stats",          require("./routes/stats"));
 
 app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
 app.use((err, req, res, next) => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -169,3 +169,29 @@ export async function fetchSubscriberCount(projectId: string) {
   );
   return data.count;
 }
+
+// ── Global Stats ─────────────────────────────────────────────────
+export interface GlobalStats {
+  totalDonations: number;
+  totalXLMRaised: string;
+  totalCO2OffsetKg: number;
+}
+
+export async function fetchGlobalStats(): Promise<GlobalStats> {
+  const { data } = await api.get<{ success: boolean; data: GlobalStats }>(
+    "/api/stats/global",
+  );
+  return data.data;
+}
+
+// ── Featured Project ─────────────────────────────────────────────
+export async function fetchFeaturedProject(): Promise<ClimateProject | null> {
+  try {
+    const { data } = await api.get<{ success: boolean; data: ClimateProject }>(
+      "/api/projects/featured",
+    );
+    return data.data;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -3,7 +3,7 @@
  */
 import { Horizon, Networks, Asset, Operation, TransactionBuilder, Transaction, Memo, rpc, Contract, scValToNative, Address, nativeToScVal, Account } from "@stellar/stellar-sdk";
 
-const NETWORK     = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet") as "testnet" | "mainnet";
+export const NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet") as "testnet" | "mainnet";
 const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org";
 const RPC_URL     = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
 
@@ -23,6 +23,31 @@ export async function getXLMBalance(publicKey: string): Promise<string> {
   } catch {
     throw new Error("Account not found or not funded.");
   }
+}
+
+/**
+ * Funds a testnet account via Stellar Friendbot.
+ * Returns the credited XLM balance after funding.
+ * Only works on testnet — throws on mainnet.
+ */
+export async function getFriendBotFunding(publicKey: string): Promise<string> {
+  if (NETWORK === "mainnet") {
+    throw new Error("Friendbot is only available on testnet.");
+  }
+  const response = await fetch(
+    `https://friendbot.stellar.org?addr=${encodeURIComponent(publicKey)}`,
+  );
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    // A 400 with "createAccountAlreadyExist" means it was already funded
+    if (response.status === 400 && body.includes("createAccountAlreadyExist")) {
+      throw new Error("Account is already funded.");
+    }
+    throw new Error(`Friendbot request failed (${response.status}).`);
+  }
+  // Wait briefly for Horizon to process the account creation
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return getXLMBalance(publicKey);
 }
 
 export async function getAssetBalance(publicKey: string, assetCode: string, assetIssuer: string): Promise<string | null> {

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -7,7 +7,7 @@ import WalletConnect from "@/components/WalletConnect";
 import EditProfileForm from "@/components/EditProfileForm";
 import ProjectCard from "@/components/ProjectCard";
 import { fetchProfile, fetchDonorHistory, fetchProjects } from "@/lib/api";
-import { getXLMBalance } from "@/lib/stellar";
+import { getXLMBalance, getFriendBotFunding, NETWORK } from "@/lib/stellar";
 import { formatXLM, formatCO2, timeAgo, shortenAddress, badgeEmoji, badgeLabel, calculateStreak } from "@/utils/format";
 import { explorerUrl } from "@/lib/stellar";
 import type { DonorProfile, Donation, ClimateProject } from "@/utils/types";
@@ -22,6 +22,9 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   const [loading,   setLoading]   = useState(true);
   const [activeTab, setActiveTab] = useState<'impact' | 'saved'>('impact');
   const [savedProjects, setSavedProjects] = useState<ClimateProject[]>([]);
+  const [isUnfunded, setIsUnfunded] = useState(false);
+  const [friendbotState, setFriendbotState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [friendbotError, setFrienbotError] = useState<string | null>(null);
   const { wishlist } = useWishlist();
 
   useEffect(() => {
@@ -29,13 +32,16 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
     Promise.all([
       fetchProfile(publicKey).catch(() => null),
       fetchDonorHistory(publicKey),
-      getXLMBalance(publicKey),
+      getXLMBalance(publicKey).catch(() => { setIsUnfunded(true); return null; }),
       fetchProjects(),
     ])
       .then(([p, d, b, allProjects]) => { 
         setProfile(p); 
         setDonations(d); 
-        setBalance(b);
+        if (b !== null) {
+          setBalance(b);
+          setIsUnfunded(false);
+        }
         setSavedProjects(allProjects.filter(proj => wishlist.includes(proj.id)));
       })
       .catch(console.error)
@@ -43,6 +49,21 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   }, [publicKey, wishlist]);
 
   const streak = calculateStreak(donations);
+  
+  const handleFriendbot = async () => {
+    if (!publicKey) return;
+    setFriendbotState('loading');
+    setFrienbotError(null);
+    try {
+      const newBalance = await getFriendBotFunding(publicKey);
+      setBalance(newBalance);
+      setIsUnfunded(false);
+      setFriendbotState('success');
+    } catch (err: unknown) {
+      setFrienbotError((err as Error).message || "Funding failed. Try again.");
+      setFriendbotState('error');
+    }
+  };
   
   // Persistence for longest streak
   useEffect(() => {
@@ -81,6 +102,38 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         </div>
         <Link href="/projects" className="btn-primary text-sm py-2.5 px-5 flex-shrink-0">🌱 Donate Now</Link>
       </div>
+
+      {/* Testnet Friendbot funding card — testnet only, shown when account is unfunded */}
+      {NETWORK === "testnet" && isUnfunded && (
+        <div className="card mb-6 bg-amber-50 border-amber-200 shadow-sm">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+            <div className="text-3xl">🚰</div>
+            <div className="flex-1">
+              <h2 className="font-display font-bold text-amber-900 text-base mb-1">
+                Your testnet wallet has no XLM
+              </h2>
+              <p className="text-amber-700 text-sm font-body">
+                Fund it instantly with Stellar Friendbot to start donating on testnet.
+              </p>
+              {friendbotState === 'success' && (
+                <p className="text-green-700 text-sm font-body mt-1 font-semibold">
+                  ✓ Funded! Your wallet received 10,000 XLM testnet tokens.
+                </p>
+              )}
+              {friendbotState === 'error' && friendbotError && (
+                <p className="text-red-600 text-sm font-body mt-1">{friendbotError}</p>
+              )}
+            </div>
+            <button
+              onClick={handleFriendbot}
+              disabled={friendbotState === 'loading' || friendbotState === 'success'}
+              className="btn-primary text-sm py-2.5 px-5 flex-shrink-0 disabled:opacity-60"
+            >
+              {friendbotState === 'loading' ? 'Funding…' : friendbotState === 'success' ? '✓ Funded!' : '💧 Fund My Testnet Wallet'}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Stats grid */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -2,9 +2,13 @@
  * pages/index.tsx — GreenPay landing page
  */
 import Link from "next/link";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import WalletConnect from "@/components/WalletConnect";
 import { useCountUp } from "@/hooks/useCountUp";
+import { fetchGlobalStats, fetchFeaturedProject } from "@/lib/api";
+import { formatCO2, formatXLM, progressPercent } from "@/utils/format";
+import type { GlobalStats } from "@/lib/api";
+import type { ClimateProject } from "@/utils/types";
 
 interface HomeProps { publicKey: string | null; onConnect: (pk: string) => void; }
 
@@ -33,6 +37,13 @@ const CATEGORIES = [
 
 export default function Home({ publicKey, onConnect }: HomeProps) {
   const [showConnect, setShowConnect] = useState(false);
+  const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null);
+  const [featuredProject, setFeaturedProject] = useState<ClimateProject | null>(null);
+
+  useEffect(() => {
+    fetchGlobalStats().then(setGlobalStats).catch(() => null);
+    fetchFeaturedProject().then(setFeaturedProject).catch(() => null);
+  }, []);
 
   return (
     <div className="relative overflow-hidden">
@@ -80,6 +91,16 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
             <StatItem key={s.label} stat={s} />
           ))}
         </div>
+
+        {/* ── Global CO2 Offset Ticker ────────────────────────────── */}
+        {globalStats !== null && (
+          <CO2OffsetTicker stats={globalStats} />
+        )}
+
+        {/* ── Featured Project Spotlight ──────────────────────────── */}
+        {featuredProject !== null && (
+          <FeaturedProjectCard project={featuredProject} />
+        )}
 
         {/* ── Features ────────────────────────────────────────────────── */}
         <div className="mb-20">
@@ -161,6 +182,95 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
     </div>
   );
 }
+function FeaturedProjectCard({ project }: { project: ClimateProject }) {
+  const pct = progressPercent(project.raisedXLM, project.goalXLM);
+  return (
+    <div className="mb-20">
+      <div className="text-center mb-8">
+        <h2 className="font-display text-3xl font-bold text-forest-900 mb-2">⭐ Featured Project</h2>
+        <p className="text-[#5a7a5a] font-body">The project making the biggest impact right now</p>
+      </div>
+      <div className="card border-forest-200 shadow-lg hover:shadow-green transition-all p-6 sm:p-8">
+        <div className="flex flex-col md:flex-row gap-6">
+          <div className="flex-1">
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <span className="text-xs font-semibold bg-amber-100 text-amber-800 px-3 py-1 rounded-full border border-amber-200 font-body">
+                🏆 Most Donors
+              </span>
+              <span className="text-xs text-[#8aaa8a] bg-forest-50 px-2.5 py-1 rounded-full border border-forest-100 font-body">
+                {project.category}
+              </span>
+            </div>
+            <h3 className="font-display text-2xl font-bold text-forest-900 mb-2">{project.name}</h3>
+            <p className="text-[#5a7a5a] text-sm leading-relaxed font-body mb-4 line-clamp-3">
+              {project.description}
+            </p>
+            <div className="flex flex-wrap gap-4 text-sm mb-5">
+              <span className="flex items-center gap-1 text-forest-700 font-body">
+                👥 <strong>{project.donorCount.toLocaleString()}</strong> donors
+              </span>
+              <span className="flex items-center gap-1 text-forest-700 font-body">
+                ♻️ <strong>{formatCO2(project.co2OffsetKg)}</strong> offset
+              </span>
+              <span className="flex items-center gap-1 text-[#5a7a5a] font-body">
+                📍 {project.location}
+              </span>
+            </div>
+            {/* Progress bar */}
+            <div className="mb-2">
+              <div className="flex justify-between text-xs mb-1 font-body">
+                <span className="font-semibold text-forest-700">{formatXLM(project.raisedXLM)} raised</span>
+                <span className="text-[#5a7a5a]">{pct}% of {formatXLM(project.goalXLM)}</span>
+              </div>
+              <div className="progress-bar h-2.5">
+                <div
+                  className={pct >= 100 ? "progress-fill progress-fill-complete" : "progress-fill"}
+                  style={{ width: `${Math.min(pct, 100)}%` }}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col justify-center gap-3 md:w-48">
+            <Link
+              href={`/projects/${project.id}`}
+              className="btn-primary text-base py-3 px-6 text-center"
+            >
+              🌍 Donate Now
+            </Link>
+            <Link
+              href={`/projects/${project.id}`}
+              className="btn-secondary text-sm py-2.5 px-4 text-center"
+            >
+              View Project →
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CO2OffsetTicker({ stats }: { stats: GlobalStats }) {
+  const { count, elementRef } = useCountUp(stats.totalCO2OffsetKg, 2500);
+  return (
+    <div
+      ref={elementRef}
+      className="card mb-20 bg-gradient-to-br from-forest-900 to-forest-700 border-none text-white text-center py-10 shadow-xl"
+    >
+      <p className="text-3xl mb-2">🍃</p>
+      <div className="font-display text-5xl sm:text-6xl font-bold text-white mb-2">
+        {formatCO2(count)}
+      </div>
+      <p className="text-forest-200 text-sm font-body uppercase tracking-widest font-bold opacity-80">
+        Total CO₂ Offset Across All Donations
+      </p>
+      <p className="text-forest-300 text-xs font-body mt-2">
+        {stats.totalDonations.toLocaleString()} donations · {parseFloat(stats.totalXLMRaised).toLocaleString()} XLM raised
+      </p>
+    </div>
+  );
+}
+
 function StatItem({ stat }: { stat: any }) {
   const { count, elementRef } = useCountUp(stat.value, stat.duration);
   return (

--- a/frontend/pages/projects/[id].tsx
+++ b/frontend/pages/projects/[id].tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import DonateForm from "@/components/DonateForm";
 import DonationFeed from "@/components/DonationFeed";
 import WalletConnect from "@/components/WalletConnect";
-import { fetchProject, fetchProjectUpdates, subscribeToProject } from "@/lib/api";
+import { fetchProject, fetchProjectUpdates, subscribeToProject, fetchSubscriberCount } from "@/lib/api";
 import { formatXLM, formatCO2, progressPercent, timeAgo, statusClass, statusLabel, CATEGORY_ICONS, copyToClipboard } from "@/utils/format";
 import { accountUrl } from "@/lib/stellar";
 import type { ClimateProject, ProjectUpdate } from "@/utils/types";
@@ -28,6 +28,7 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
   const [subEmail, setSubEmail] = useState("");
   const [subState, setSubState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [subError, setSubError] = useState<string | null>(null);
+  const [subscriberCount, setSubscriberCount] = useState<number | null>(null);
 
   const { toggleWishlist, isInWishlist } = useWishlist();
 
@@ -37,6 +38,11 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
       .then(([p, u]) => { setProject(p); setUpdates(u); })
       .catch(() => router.push("/projects"))
       .finally(() => setLoading(false));
+  }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    fetchSubscriberCount(id as string).then(setSubscriberCount).catch(() => null);
   }, [id]);
 
   const handleCopyWallet = async () => {
@@ -92,6 +98,7 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
       });
       setSubState('success');
       setSubEmail("");
+      setSubscriberCount(c => (c !== null ? c + 1 : null));
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
       setSubError(msg || "Could not subscribe. Try again.");
@@ -345,9 +352,14 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
             <p className="text-xs text-[#5a7a5a] mb-3 font-body">
               Receive an email when this project posts new updates.
             </p>
+            {subscriberCount !== null && (
+              <p className="text-xs text-[#8aaa8a] font-body mb-3">
+                📬 {subscriberCount.toLocaleString()} {subscriberCount === 1 ? "subscriber" : "subscribers"}
+              </p>
+            )}
             {subState === 'success' ? (
-              <p className="text-sm text-green-700 font-body text-center py-2">
-                ✓ You're subscribed!
+              <p className="text-sm text-green-700 font-body text-center py-2 font-semibold">
+                ✓ Thank you for subscribing!
               </p>
             ) : (
               <form onSubmit={handleSubscribe} className="space-y-2">


### PR DESCRIPTION
## Summary

This PR resolves four open issues by adding key UX improvements across the dashboard, home page, and project detail pages.

---

### ✅ Issue #72 — Add a Get testnet XLM one-click button for new users

- Added `getFriendBotFunding(publicKey)` to `frontend/lib/stellar.ts`, which calls the Stellar Friendbot API and waits for account creation before returning the refreshed balance
- Exported the `NETWORK` constant from `stellar.ts` so the UI can guard mainnet usage
- In `frontend/pages/dashboard.tsx`: detect unfunded testnet accounts when `getXLMBalance` throws, show a **💧 Fund My Testnet Wallet** amber card with a loading/success state, auto-refresh balance after funding, and hide the card entirely on mainnet

Closes #72

---

### ✅ Issue #70 — Add a total global CO2 offset ticker to the home page

- Created `backend/src/routes/stats.js` — new `GET /api/stats/global` endpoint that aggregates total donation count, total XLM raised, and total CO2 offset kg from the database
- Registered the route in `backend/src/server.js` as `/api/stats`
- Added `fetchGlobalStats()` and `GlobalStats` type to `frontend/lib/api.ts`
- In `frontend/pages/index.tsx`: fetch global stats on mount, render a dark gradient `CO2OffsetTicker` card with a 🍃 leaf icon, large bold number formatted with `formatCO2()`, and count-up animation via the existing `useCountUp` hook (triggers on viewport entry)

Closes #70

---

### ✅ Issue #69 — Add a project update subscription email form

- In `backend/src/routes/subscriptions.js`: changed `INSERT ... ON CONFLICT DO NOTHING` to `RETURNING id` and return **409 Conflict** with `"Already subscribed with this email."` when the row was not inserted
- In `frontend/pages/projects/[id].tsx`: added `fetchSubscriberCount` import, fetch subscriber count on project load, display `📬 N subscribers` above the subscription form, and updated confirmation message to **"✓ Thank you for subscribing!"**; subscriber count increments optimistically on success

Closes #69

---

### ✅ Issue #78 — Add a featured project spotlight to the home page

- In `backend/src/routes/projects.js`: added `GET /api/projects/featured` route (placed before `/:id` to avoid route conflicts) that queries the active project with the highest `donor_count`, with a 24-hour in-memory cache
- Added `fetchFeaturedProject()` to `frontend/lib/api.ts`
- In `frontend/pages/index.tsx`: fetch featured project on mount and render a `FeaturedProjectCard` component between the stats grid / CO2 ticker and the Features section; card shows project name, description, category badge, location, donor count, CO2 offset, a progress bar, and a prominent **🌍 Donate Now** CTA button

Closes #78

---

### Files Changed

| File | Change |
|---|---|
| `backend/src/routes/stats.js` | New — `GET /api/stats/global` |
| `backend/src/routes/projects.js` | Added `GET /api/projects/featured` with 24h cache |
| `backend/src/routes/subscriptions.js` | Return 409 on duplicate subscription |
| `backend/src/server.js` | Register `/api/stats` route |
| `frontend/lib/stellar.ts` | Export `NETWORK`; add `getFriendBotFunding()` |
| `frontend/lib/api.ts` | Add `fetchGlobalStats()`, `fetchFeaturedProject()`, `GlobalStats` type |
| `frontend/pages/dashboard.tsx` | Friendbot funding card (testnet only) |
| `frontend/pages/index.tsx` | CO2 ticker + featured project spotlight |
| `frontend/pages/projects/[id].tsx` | Subscriber count display + improved confirmation |

---

### Testing on Testnet

1. Connect an unfunded Freighter wallet on testnet → Funding card appears on dashboard
2. Click **Fund My Testnet Wallet** → balance refreshes to ~10,000 XLM; card hides
3. Home page CO2 ticker animates in on scroll; data comes from `/api/stats/global`
4. Featured project card shows on home page, **Donate Now** navigates to project
5. Subscribe to a project with an email → "Thank you for subscribing!" shown; subscriber count increments
6. Submit the same email again → error message "Already subscribed with this email."