### PR TITLE
feat: add campaigns, live ticker, comparison, and monthly giving

### DIFF
--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -69,3 +69,13 @@ CREATE TABLE IF NOT EXISTS jobs (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS project_campaigns (
+  id UUID PRIMARY KEY,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  goal_xlm NUMERIC(20, 7) NOT NULL,
+  deadline TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -4,6 +4,7 @@
 "use strict";
 const express = require("express");
 const router = express.Router();
+const { v4: uuid } = require("uuid");
 const pool = require("../db/pool");
 const { mapProjectRow } = require("../services/store");
 const { getOnChainProject, CONTRACT_ID, server, NETWORK_PASSPHRASE } = require("../services/stellar");
@@ -29,6 +30,54 @@ const VALID_CATEGORIES = [
  */
 let featuredCache = null;
 let featuredCacheExpiry = 0;
+
+function mapCampaignRow(row) {
+  const now = Date.now();
+  const goalXLM = Number.parseFloat(row.goal_xlm?.toString() || "0");
+  const raisedXLM = Number.parseFloat(row.raised_xlm?.toString() || "0");
+  const deadlineMs = new Date(row.deadline).getTime();
+  const completed = raisedXLM >= goalXLM || now >= deadlineMs;
+  const progressPercent = goalXLM > 0 ? Math.min(Math.round((raisedXLM / goalXLM) * 100), 100) : 0;
+
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    title: row.title,
+    description: row.description || "",
+    goalXLM: row.goal_xlm?.toString() || "0",
+    raisedXLM: raisedXLM.toFixed(7),
+    deadline: new Date(row.deadline).toISOString(),
+    progressPercent,
+    completed,
+    active: !completed,
+    createdAt: new Date(row.created_at).toISOString(),
+  };
+}
+
+async function fetchCampaignsForProject(projectId) {
+  const result = await pool.query(
+    `SELECT c.*,
+            COALESCE(
+              SUM(
+                CASE
+                  WHEN d.currency = 'XLM' THEN d.amount_xlm
+                  ELSE 0
+                END
+              ),
+              0
+            ) AS raised_xlm
+     FROM project_campaigns c
+     LEFT JOIN donations d
+       ON d.project_id = c.project_id
+      AND d.created_at >= c.created_at
+      AND d.created_at <= c.deadline
+     WHERE c.project_id = $1
+     GROUP BY c.id
+     ORDER BY c.created_at DESC`,
+    [projectId],
+  );
+  return result.rows.map(mapCampaignRow);
+}
 
 router.get("/featured", async (req, res, next) => {
   try {
@@ -119,6 +168,61 @@ router.get("/:id/verify", async (req, res) => {
   }
 });
 
+router.post("/:id/campaigns", async (req, res, next) => {
+  try {
+    const { title, goalXLM, deadline, description } = req.body || {};
+    const trimmedTitle = typeof title === "string" ? title.trim() : "";
+    const trimmedDescription = typeof description === "string" ? description.trim() : "";
+    const goal = Number.parseFloat(goalXLM);
+    const deadlineDate = new Date(deadline);
+
+    if (trimmedTitle.length < 3 || trimmedTitle.length > 120) {
+      return res.status(400).json({ error: "title must be between 3 and 120 characters" });
+    }
+    if (!Number.isFinite(goal) || goal <= 0) {
+      return res.status(400).json({ error: "goalXLM must be a positive number" });
+    }
+    if (!deadline || Number.isNaN(deadlineDate.getTime())) {
+      return res.status(400).json({ error: "deadline must be a valid ISO date string" });
+    }
+    if (deadlineDate.getTime() <= Date.now()) {
+      return res.status(400).json({ error: "deadline must be in the future" });
+    }
+    if (trimmedDescription.length > 500) {
+      return res.status(400).json({ error: "description must be 500 characters or fewer" });
+    }
+
+    const projectResult = await pool.query("SELECT id FROM projects WHERE id = $1", [req.params.id]);
+    if (!projectResult.rows[0]) {
+      return res.status(404).json({ error: "Project not found" });
+    }
+
+    const result = await pool.query(
+      `INSERT INTO project_campaigns (id, project_id, title, description, goal_xlm, deadline, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW())
+       RETURNING *, 0::numeric AS raised_xlm`,
+      [uuid(), req.params.id, trimmedTitle, trimmedDescription || null, goal.toFixed(7), deadlineDate.toISOString()],
+    );
+
+    res.status(201).json({ success: true, data: mapCampaignRow(result.rows[0]) });
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.get("/:id/campaigns", async (req, res, next) => {
+  try {
+    const projectResult = await pool.query("SELECT id FROM projects WHERE id = $1", [req.params.id]);
+    if (!projectResult.rows[0]) {
+      return res.status(404).json({ error: "Project not found" });
+    }
+    const campaigns = await fetchCampaignsForProject(req.params.id);
+    res.json({ success: true, data: campaigns });
+  } catch (e) {
+    next(e);
+  }
+});
+
 /**
  * POST /api/projects/admin/register
  * Builds a Soroban transaction to register a project on-chain.
@@ -177,9 +281,17 @@ router.post("/admin/confirm", async (req, res) => {
 
 router.get("/:id", async (req, res, next) => {
   try {
-    const result = await pool.query("SELECT * FROM projects WHERE id = $1", [req.params.id]);
-    if (!result.rows[0]) return res.status(404).json({ error: "Project not found" });
-    res.json({ success: true, data: mapProjectRow(result.rows[0]) });
+    const projectResult = await pool.query("SELECT * FROM projects WHERE id = $1", [req.params.id]);
+    if (!projectResult.rows[0]) return res.status(404).json({ error: "Project not found" });
+    const campaigns = await fetchCampaignsForProject(req.params.id);
+    res.json({
+      success: true,
+      data: {
+        ...mapProjectRow(projectResult.rows[0]),
+        campaigns,
+        activeCampaign: campaigns.find((campaign) => campaign.active) || null,
+      },
+    });
   } catch (e) {
     next(e);
   }

--- a/frontend/components/DonateForm.tsx
+++ b/frontend/components/DonateForm.tsx
@@ -12,6 +12,7 @@ import type { ClimateProject } from "@/utils/types";
 interface DonateFormProps {
   project: ClimateProject;
   publicKey: string;
+  initialAmount?: string;
   onSuccess?: () => void;
 }
 
@@ -20,7 +21,7 @@ type Step = "idle" | "building" | "signing" | "submitting" | "recording" | "succ
 const PRESETS_XLM = ["10", "25", "50", "100", "250"];
 const PRESETS_USDC = ["5", "10", "25", "50", "100"];
 
-export default function DonateForm({ project, publicKey, onSuccess }: DonateFormProps) {
+export default function DonateForm({ project, publicKey, initialAmount, onSuccess }: DonateFormProps) {
   const [amount, setAmount]   = useState("");
   const [message, setMessage] = useState("");
   const [currency, setCurrency] = useState<"XLM" | "USDC">("XLM");
@@ -31,6 +32,11 @@ export default function DonateForm({ project, publicKey, onSuccess }: DonateForm
   const [usdcBalance, setUsdcBalance] = useState<string | null>(null);
   const [trustlineMissing, setTrustlineMissing] = useState<boolean>(false);
   const [donorBadge, setDonorBadge] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!initialAmount) return;
+    setAmount(initialAmount);
+  }, [initialAmount]);
 
   useEffect(() => {
     let mounted = true;

--- a/frontend/components/MonthlyGivingSetup.tsx
+++ b/frontend/components/MonthlyGivingSetup.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from "react";
+import { createMonthlySubscription, loadMonthlySubscriptions } from "@/lib/monthlyGiving";
+import { formatXLM, timeAgo } from "@/utils/format";
+import type { MonthlySubscription } from "@/utils/types";
+
+interface MonthlyGivingSetupProps {
+  projectId: string;
+  projectName: string;
+  onClose: () => void;
+  onCreated?: (subscriptionId: string) => void;
+}
+
+const DURATION_OPTIONS = [
+  { label: "3 months", value: "3" },
+  { label: "6 months", value: "6" },
+  { label: "12 months", value: "12" },
+  { label: "Indefinite", value: "indefinite" },
+];
+
+export default function MonthlyGivingSetup({
+  projectId,
+  projectName,
+  onClose,
+  onCreated,
+}: MonthlyGivingSetupProps) {
+  const [amountXLM, setAmountXLM] = useState("25");
+  const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
+  const [duration, setDuration] = useState("3");
+  const [subscriptions, setSubscriptions] = useState<MonthlySubscription[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const all = loadMonthlySubscriptions();
+    setSubscriptions(all.filter((sub) => sub.projectId === projectId));
+  }, [projectId]);
+
+  const canCreate = useMemo(() => {
+    const amount = Number.parseFloat(amountXLM);
+    if (!Number.isFinite(amount) || amount < 1) return false;
+    if (!startDate) return false;
+    return true;
+  }, [amountXLM, startDate]);
+
+  const handleCreate = () => {
+    if (!canCreate) {
+      setError("Enter a valid amount and start date.");
+      return;
+    }
+    setError(null);
+    const durationMonths = duration === "indefinite" ? null : Number.parseInt(duration, 10);
+    const created = createMonthlySubscription({
+      projectId,
+      projectName,
+      amountXLM: Number.parseFloat(amountXLM).toFixed(7),
+      startDate: new Date(startDate).toISOString(),
+      durationMonths,
+    });
+    onCreated?.(created.id);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/30 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="w-full max-w-xl card bg-white max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-display text-xl font-semibold text-forest-900">Monthly Giving Setup</h3>
+          <button onClick={onClose} className="btn-secondary text-xs py-1.5 px-3">Close</button>
+        </div>
+
+        <p className="text-sm text-[#5a7a5a] font-body mb-5">
+          Schedule recurring monthly donations for <strong>{projectName}</strong>.
+        </p>
+
+        <div className="grid sm:grid-cols-2 gap-4">
+          <div>
+            <label className="label">Amount (XLM)</label>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={amountXLM}
+              onChange={(e) => setAmountXLM(e.target.value)}
+              className="input-field"
+            />
+          </div>
+          <div>
+            <label className="label">Start Date</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="input-field"
+            />
+          </div>
+          <div className="sm:col-span-2">
+            <label className="label">Duration</label>
+            <div className="flex flex-wrap gap-2">
+              {DURATION_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setDuration(option.value)}
+                  className={`px-3 py-2 rounded-lg text-sm border font-body ${
+                    duration === option.value
+                      ? "bg-forest-500 text-white border-forest-500"
+                      : "bg-forest-50 text-forest-700 border-forest-200"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {error && <p className="mt-3 text-sm text-red-600 font-body">{error}</p>}
+
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={!canCreate}
+          className="btn-primary w-full mt-5 disabled:opacity-60"
+        >
+          Save Monthly Giving
+        </button>
+
+        <div className="mt-8 border-t border-forest-100 pt-5">
+          <h4 className="font-display text-lg font-semibold text-forest-900 mb-3">Subscription History</h4>
+          {subscriptions.length === 0 ? (
+            <p className="text-sm text-[#5a7a5a] font-body">No subscriptions created for this project yet.</p>
+          ) : (
+            <div className="space-y-3">
+              {subscriptions.map((sub) => (
+                <div key={sub.id} className="p-3 rounded-lg border border-forest-200 bg-forest-50">
+                  <p className="text-sm font-semibold text-forest-900 font-body">
+                    {formatXLM(sub.amountXLM)} monthly · {sub.status}
+                  </p>
+                  <p className="text-xs text-[#8aaa8a] font-body mt-1">
+                    Next due: {new Date(sub.nextDueDate).toLocaleDateString()}
+                  </p>
+                  {sub.history.length > 0 ? (
+                    <div className="mt-2 space-y-1">
+                      {sub.history.slice(0, 5).map((entry) => (
+                        <p key={entry.paidAt} className="text-xs text-[#5a7a5a] font-body">
+                          Paid {formatXLM(entry.amountXLM)} · {timeAgo(entry.paidAt)}
+                        </p>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-xs text-[#5a7a5a] font-body">No paid months yet.</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/ProjectCard.tsx
+++ b/frontend/components/ProjectCard.tsx
@@ -109,6 +109,7 @@ export default function ProjectCard({ project }: { project: ClimateProject }) {
             Donate →
           </span>
         </div>
+        </div>
       </Link>
 
       {/* Wishlist Toggle */}

--- a/frontend/components/ProjectComparison.tsx
+++ b/frontend/components/ProjectComparison.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { Fragment, useMemo, useState } from "react";
+import { formatCO2, formatXLM, progressPercent } from "@/utils/format";
+import type { ClimateProject } from "@/utils/types";
+
+interface ProjectComparisonProps {
+  projects: ClimateProject[];
+  onClose: () => void;
+}
+
+const ROWS = [
+  { key: "co2", label: "CO2 per XLM" },
+  { key: "progress", label: "Progress %" },
+  { key: "donorCount", label: "Donor count" },
+  { key: "goal", label: "Goal" },
+  { key: "raised", label: "Raised" },
+  { key: "status", label: "Status" },
+  { key: "verified", label: "Verified" },
+] as const;
+
+export default function ProjectComparison({ projects, onClose }: ProjectComparisonProps) {
+  const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+  const shareUrl = useMemo(() => {
+    if (typeof window === "undefined") return "";
+    const url = new URL(window.location.href);
+    url.searchParams.set("compare", projects.map((project) => project.id).join(","));
+    return url.toString();
+  }, [projects]);
+
+  const handleCopyLink = async () => {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    setCopyState("copied");
+    window.setTimeout(() => setCopyState("idle"), 2000);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/30 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="w-full max-w-6xl card bg-white max-h-[90vh] overflow-auto">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="font-display text-xl font-semibold text-forest-900">Project Comparison</h2>
+          <div className="flex items-center gap-2">
+            <button onClick={handleCopyLink} className="btn-secondary text-xs py-1.5 px-3">
+              {copyState === "copied" ? "Copied URL" : "Share URL"}
+            </button>
+            <button onClick={onClose} className="btn-secondary text-xs py-1.5 px-3">Close</button>
+          </div>
+        </div>
+
+        <div className="grid gap-4" style={{ gridTemplateColumns: `150px repeat(${projects.length}, minmax(180px, 1fr))` }}>
+          <div className="font-body text-xs uppercase tracking-widest text-[#8aaa8a]">Metric</div>
+          {projects.map((project) => (
+            <div key={`${project.id}-header`} className="p-3 rounded-lg bg-forest-50 border border-forest-200">
+              <p className="font-display text-sm font-semibold text-forest-900">{project.name}</p>
+              <p className="text-xs text-[#5a7a5a] mt-1 font-body">{project.category}</p>
+            </div>
+          ))}
+
+          {ROWS.map((row) => (
+            <Fragment key={row.key}>
+              <div className="font-body text-sm text-[#5a7a5a] py-2 border-t border-forest-100">
+                {row.label}
+              </div>
+              {projects.map((project) => {
+                const pct = progressPercent(project.raisedXLM, project.goalXLM);
+                const co2PerXLM = Number.parseFloat(project.goalXLM) > 0
+                  ? project.co2OffsetKg / Number.parseFloat(project.goalXLM)
+                  : 0;
+                let value = "";
+                if (row.key === "co2") value = `${co2PerXLM.toFixed(2)} kg`;
+                if (row.key === "progress") value = `${pct}%`;
+                if (row.key === "donorCount") value = project.donorCount.toLocaleString();
+                if (row.key === "goal") value = formatXLM(project.goalXLM);
+                if (row.key === "raised") value = formatXLM(project.raisedXLM);
+                if (row.key === "status") value = project.status;
+                if (row.key === "verified") value = project.verified ? "Yes" : "No";
+
+                return (
+                  <div key={`${project.id}-${row.key}`} className="py-2 border-t border-forest-100">
+                    <p className="font-body text-sm text-forest-900">{value}</p>
+                    {row.key === "raised" && (
+                      <p className="font-body text-xs text-[#8aaa8a] mt-1">{formatCO2(project.co2OffsetKg)} offset</p>
+                    )}
+                  </div>
+                );
+              })}
+            </Fragment>
+          ))}
+
+          <div className="pt-3 border-t border-forest-100" />
+          {projects.map((project) => (
+            <div key={`${project.id}-actions`} className="pt-3 border-t border-forest-100">
+              <Link
+                href={`/projects/${project.id}`}
+                className="btn-primary text-sm py-2 px-4 inline-flex items-center justify-center w-full"
+              >
+                Donate
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   ProjectUpdate,
   LeaderboardEntry,
   EscrowJob,
+  ProjectCampaign,
 } from "@/utils/types";
 
 const api = axios.create({
@@ -36,6 +37,22 @@ export async function fetchProjects(params?: {
 export async function fetchProject(id: string) {
   const { data } = await api.get<{ success: boolean; data: ClimateProject }>(
     `/api/projects/${id}`,
+  );
+  return data.data;
+}
+
+export async function createProjectCampaign(
+  projectId: string,
+  payload: {
+    title: string;
+    goalXLM: string;
+    deadline: string;
+    description?: string;
+  },
+) {
+  const { data } = await api.post<{ success: boolean; data: ProjectCampaign }>(
+    `/api/projects/${projectId}/campaigns`,
+    payload,
   );
   return data.data;
 }

--- a/frontend/lib/monthlyGiving.ts
+++ b/frontend/lib/monthlyGiving.ts
@@ -1,0 +1,86 @@
+import type { MonthlySubscription } from "@/utils/types";
+
+export const MONTHLY_GIVING_STORAGE_KEY = "greenpay_monthly_subscriptions";
+
+function addMonths(isoDate: string, months: number) {
+  const date = new Date(isoDate);
+  const day = date.getUTCDate();
+  date.setUTCDate(1);
+  date.setUTCMonth(date.getUTCMonth() + months);
+  const maxDay = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0)).getUTCDate();
+  date.setUTCDate(Math.min(day, maxDay));
+  return date.toISOString();
+}
+
+export function loadMonthlySubscriptions(): MonthlySubscription[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(MONTHLY_GIVING_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveMonthlySubscriptions(subscriptions: MonthlySubscription[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(MONTHLY_GIVING_STORAGE_KEY, JSON.stringify(subscriptions));
+}
+
+export function createMonthlySubscription(input: {
+  projectId: string;
+  projectName: string;
+  amountXLM: string;
+  startDate: string;
+  durationMonths: number | null;
+}) {
+  const nowIso = new Date().toISOString();
+  const subscription: MonthlySubscription = {
+    id: `sub_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`,
+    projectId: input.projectId,
+    projectName: input.projectName,
+    amountXLM: input.amountXLM,
+    startDate: input.startDate,
+    durationMonths: input.durationMonths,
+    nextDueDate: input.startDate,
+    remainingMonths: input.durationMonths,
+    status: "active",
+    createdAt: nowIso,
+    history: [],
+  };
+
+  const all = loadMonthlySubscriptions();
+  saveMonthlySubscriptions([subscription, ...all]);
+  return subscription;
+}
+
+export function markMonthlySubscriptionPaid(subscriptionId: string, amountXLM: string) {
+  const all = loadMonthlySubscriptions();
+  const updated = all.map((sub) => {
+    if (sub.id !== subscriptionId || sub.status !== "active") return sub;
+
+    const nextRemaining =
+      sub.remainingMonths === null ? null : Math.max(sub.remainingMonths - 1, 0);
+    const completed = nextRemaining === 0;
+    const nextStatus: MonthlySubscription["status"] = completed ? "completed" : "active";
+
+    return {
+      ...sub,
+      history: [{ paidAt: new Date().toISOString(), amountXLM }, ...sub.history],
+      remainingMonths: nextRemaining,
+      status: nextStatus,
+      nextDueDate: completed ? sub.nextDueDate : addMonths(sub.nextDueDate, 1),
+    };
+  });
+  saveMonthlySubscriptions(updated);
+}
+
+export function getDueMonthlySubscriptions() {
+  const now = new Date();
+  return loadMonthlySubscriptions().filter((sub) => {
+    if (sub.status !== "active") return false;
+    return new Date(sub.nextDueDate).getTime() <= now.getTime();
+  });
+}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -360,6 +360,67 @@ export function streamProjectPayments(
   return closeStream;
 }
 
+/**
+ * Stream global XLM donations and map destination accounts to known projects.
+ * Returns a cleanup function to close the Horizon SSE stream.
+ */
+export function streamGlobalProjectDonations(
+  projects: Array<{ id: string; name: string; walletAddress: string }>,
+  onDonation: (donation: {
+    id: string;
+    projectId: string;
+    projectName: string;
+    amountXLM: string;
+    from: string;
+    createdAt: string;
+    transactionHash: string;
+  }) => void,
+  cursor?: string,
+): () => void {
+  const projectByWallet = new Map(
+    projects.map((project) => [project.walletAddress.toUpperCase(), project]),
+  );
+
+  const closeStream = server
+    .payments()
+    .cursor(cursor || "now")
+    .stream({
+      onmessage: (record: any) => {
+        if (record.type !== "payment" && record.type !== "create_account") return;
+        const destination = String(
+          record.to || record.account || record.destination || "",
+        ).toUpperCase();
+        if (!destination || !projectByWallet.has(destination)) return;
+
+        const project = projectByWallet.get(destination);
+        if (!project) return;
+
+        const isNativeXLM =
+          record.asset_type === "native" || !record.asset_type || record.asset_code === "XLM";
+        if (!isNativeXLM) return;
+
+        const amountRaw = record.amount || record.starting_balance || "0";
+        const amount = Number.parseFloat(amountRaw);
+        if (!Number.isFinite(amount) || amount <= 0) return;
+
+        onDonation({
+          id: String(record.id),
+          projectId: project.id,
+          projectName: project.name,
+          amountXLM: amount.toFixed(7),
+          from: record.from || record.funder || record.source_account || "Unknown",
+          createdAt: record.created_at || new Date().toISOString(),
+          transactionHash: record.transaction_hash || "",
+        });
+      },
+      onerror: (err: any) => {
+        console.error("Global Horizon stream error:", err);
+      },
+    });
+
+  return closeStream;
+}
+
 async function simulateCall(contract: Contract, method: string, args: any[] = []) {
   // We use a dummy account for simulation
   const dummyAccount = new Account("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF", "-1");

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -7,10 +7,11 @@ import WalletConnect from "@/components/WalletConnect";
 import EditProfileForm from "@/components/EditProfileForm";
 import ProjectCard from "@/components/ProjectCard";
 import { fetchProfile, fetchDonorHistory, fetchProjects } from "@/lib/api";
+import { getDueMonthlySubscriptions } from "@/lib/monthlyGiving";
 import { getXLMBalance, getFriendBotFunding, NETWORK } from "@/lib/stellar";
 import { formatXLM, formatCO2, timeAgo, shortenAddress, badgeEmoji, badgeLabel, calculateStreak } from "@/utils/format";
 import { explorerUrl } from "@/lib/stellar";
-import type { DonorProfile, Donation, ClimateProject } from "@/utils/types";
+import type { DonorProfile, Donation, ClimateProject, MonthlySubscription } from "@/utils/types";
 import { useWishlist } from "@/hooks/useWishlist";
 
 interface DashboardProps { publicKey: string | null; onConnect: (pk: string) => void; }
@@ -25,6 +26,7 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   const [isUnfunded, setIsUnfunded] = useState(false);
   const [friendbotState, setFriendbotState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [friendbotError, setFrienbotError] = useState<string | null>(null);
+  const [dueSubscriptions, setDueSubscriptions] = useState<MonthlySubscription[]>([]);
   const { wishlist } = useWishlist();
 
   useEffect(() => {
@@ -47,6 +49,11 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
       .catch(console.error)
       .finally(() => setLoading(false));
   }, [publicKey, wishlist]);
+
+  useEffect(() => {
+    if (!publicKey) return;
+    setDueSubscriptions(getDueMonthlySubscriptions());
+  }, [publicKey]);
 
   const streak = calculateStreak(donations);
   
@@ -102,6 +109,27 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         </div>
         <Link href="/projects" className="btn-primary text-sm py-2.5 px-5 flex-shrink-0">🌱 Donate Now</Link>
       </div>
+
+      {dueSubscriptions.length > 0 && (
+        <div className="card mb-6 border-amber-200 bg-amber-50">
+          <h2 className="font-display text-lg font-semibold text-amber-900 mb-2">Monthly Giving Due Today</h2>
+          <div className="space-y-2">
+            {dueSubscriptions.map((subscription) => (
+              <div key={subscription.id} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-lg border border-amber-200 bg-white px-3 py-2">
+                <p className="text-sm text-amber-900 font-body">
+                  {subscription.projectName}: {formatXLM(subscription.amountXLM)}
+                </p>
+                <Link
+                  href={`/projects/${subscription.projectId}?amount=${encodeURIComponent(subscription.amountXLM)}&monthlySubId=${encodeURIComponent(subscription.id)}`}
+                  className="btn-primary text-xs py-1.5 px-3 inline-flex items-center justify-center"
+                >
+                  Pay Now
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Testnet Friendbot funding card — testnet only, shown when account is unfunded */}
       {NETWORK === "testnet" && isUnfunded && (

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -5,12 +5,21 @@ import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 import WalletConnect from "@/components/WalletConnect";
 import { useCountUp } from "@/hooks/useCountUp";
-import { fetchGlobalStats, fetchFeaturedProject } from "@/lib/api";
+import { fetchGlobalStats, fetchFeaturedProject, fetchProjects } from "@/lib/api";
+import { streamGlobalProjectDonations } from "@/lib/stellar";
 import { formatCO2, formatXLM, progressPercent } from "@/utils/format";
 import type { GlobalStats } from "@/lib/api";
 import type { ClimateProject } from "@/utils/types";
 
 interface HomeProps { publicKey: string | null; onConnect: (pk: string) => void; }
+
+interface LiveDonationTickerItem {
+  id: string;
+  projectId: string;
+  projectName: string;
+  amountXLM: string;
+  createdAt: string;
+}
 
 const FEATURES = [
   { icon: "🔗", title: "Direct to Project", desc: "Your XLM goes straight to the project wallet — no platform takes a cut." },
@@ -39,11 +48,60 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
   const [showConnect, setShowConnect] = useState(false);
   const [globalStats, setGlobalStats] = useState<GlobalStats | null>(null);
   const [featuredProject, setFeaturedProject] = useState<ClimateProject | null>(null);
+  const [liveDonations, setLiveDonations] = useState<LiveDonationTickerItem[]>([]);
+  const [tickerIndex, setTickerIndex] = useState(0);
 
   useEffect(() => {
+    let closeStream: (() => void) | null = null;
+    let isMounted = true;
+
     fetchGlobalStats().then(setGlobalStats).catch(() => null);
     fetchFeaturedProject().then(setFeaturedProject).catch(() => null);
+
+    fetchProjects({ limit: 100 })
+      .then((projects) => {
+        if (!isMounted || projects.length === 0) return;
+        closeStream = streamGlobalProjectDonations(
+          projects.map((project) => ({
+            id: project.id,
+            name: project.name,
+            walletAddress: project.walletAddress,
+          })),
+          (donation) => {
+            setLiveDonations((prev) => [
+              {
+                id: donation.id,
+                projectId: donation.projectId,
+                projectName: donation.projectName,
+                amountXLM: donation.amountXLM,
+                createdAt: donation.createdAt,
+              },
+              ...prev.filter((item) => item.id !== donation.id),
+            ].slice(0, 10));
+          },
+        );
+      })
+      .catch(() => null);
+
+    return () => {
+      isMounted = false;
+      if (closeStream) closeStream();
+    };
   }, []);
+
+  useEffect(() => {
+    if (liveDonations.length <= 1) return;
+    const timer = window.setInterval(() => {
+      setTickerIndex((current) => (current + 1) % liveDonations.length);
+    }, 3500);
+    return () => window.clearInterval(timer);
+  }, [liveDonations.length]);
+
+  useEffect(() => {
+    if (tickerIndex >= liveDonations.length) {
+      setTickerIndex(0);
+    }
+  }, [liveDonations.length, tickerIndex]);
 
   return (
     <div className="relative overflow-hidden">
@@ -179,6 +237,39 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
           </div>
         </div>
       )}
+
+      <LiveDonationTicker
+        donations={liveDonations}
+        activeIndex={tickerIndex}
+      />
+    </div>
+  );
+}
+
+function LiveDonationTicker({
+  donations,
+  activeIndex,
+}: {
+  donations: LiveDonationTickerItem[];
+  activeIndex: number;
+}) {
+  if (donations.length === 0) return null;
+  const item = donations[activeIndex];
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-forest-800 bg-forest-900/95 backdrop-blur px-4 py-2">
+      <div className="max-w-6xl mx-auto flex items-center gap-3 text-sm text-white font-body">
+        <span className="inline-flex items-center gap-2 text-[11px] uppercase tracking-widest text-forest-300 font-bold">
+          <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
+          Live donations
+        </span>
+        <p key={item.id} className="animate-slide-up">
+          just donated <strong>{formatXLM(item.amountXLM)}</strong> to{" "}
+          <Link href={`/projects/${item.projectId}`} className="text-emerald-300 hover:text-emerald-200">
+            {item.projectName}
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/pages/projects/[id].tsx
+++ b/frontend/pages/projects/[id].tsx
@@ -7,10 +7,12 @@ import Link from "next/link";
 import DonateForm from "@/components/DonateForm";
 import DonationFeed from "@/components/DonationFeed";
 import WalletConnect from "@/components/WalletConnect";
-import { fetchProject, fetchProjectUpdates, subscribeToProject, fetchSubscriberCount } from "@/lib/api";
+import MonthlyGivingSetup from "@/components/MonthlyGivingSetup";
+import { fetchProject, fetchProjectUpdates, subscribeToProject, fetchSubscriberCount, createProjectCampaign } from "@/lib/api";
 import { formatXLM, formatCO2, progressPercent, timeAgo, statusClass, statusLabel, CATEGORY_ICONS, copyToClipboard } from "@/utils/format";
 import { accountUrl } from "@/lib/stellar";
-import type { ClimateProject, ProjectUpdate } from "@/utils/types";
+import { markMonthlySubscriptionPaid } from "@/lib/monthlyGiving";
+import type { ClimateProject, ProjectCampaign, ProjectUpdate } from "@/utils/types";
 import { useWishlist } from "@/hooks/useWishlist";
 
 interface ProjectDetailProps { publicKey: string | null; onConnect: (pk: string) => void; }
@@ -29,8 +31,20 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
   const [subState, setSubState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [subError, setSubError] = useState<string | null>(null);
   const [subscriberCount, setSubscriberCount] = useState<number | null>(null);
+  const [showMonthlySetup, setShowMonthlySetup] = useState(false);
+  const [countdownNow, setCountdownNow] = useState(Date.now());
+  const [campaignForm, setCampaignForm] = useState({
+    title: "",
+    goalXLM: "",
+    deadline: "",
+    description: "",
+  });
+  const [campaignState, setCampaignState] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
+  const [campaignError, setCampaignError] = useState<string | null>(null);
 
   const { toggleWishlist, isInWishlist } = useWishlist();
+  const prefillAmount = typeof router.query.amount === "string" ? router.query.amount : undefined;
+  const monthlySubId = typeof router.query.monthlySubId === "string" ? router.query.monthlySubId : null;
 
   useEffect(() => {
     if (!id) return;
@@ -44,6 +58,11 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
     if (!id) return;
     fetchSubscriberCount(id as string).then(setSubscriberCount).catch(() => null);
   }, [id]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setCountdownNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   const handleCopyWallet = async () => {
     if (!project) return;
@@ -106,6 +125,25 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
     }
   };
 
+  const handleCreateCampaign = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!project) return;
+    setCampaignState('saving');
+    setCampaignError(null);
+    try {
+      await createProjectCampaign(project.id, campaignForm);
+      const updatedProject = await fetchProject(project.id);
+      setProject(updatedProject);
+      setCampaignForm({ title: "", goalXLM: "", deadline: "", description: "" });
+      setCampaignState('success');
+      window.setTimeout(() => setCampaignState('idle'), 2000);
+    } catch (err: unknown) {
+      const message = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setCampaignError(message || "Could not create campaign.");
+      setCampaignState('error');
+    }
+  };
+
   if (loading || !project) return (    <div className="max-w-5xl mx-auto px-4 sm:px-6 py-10 animate-pulse">
       <div className="h-8 bg-forest-200 rounded w-2/3 mb-4" />
       <div className="card space-y-4">
@@ -116,6 +154,11 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
 
   const pct = progressPercent(project.raisedXLM, project.goalXLM);
   const isComplete = pct >= 100;
+  const campaigns = project.campaigns || [];
+  const activeCampaign = project.activeCampaign || campaigns.find((campaign) => campaign.active) || null;
+  const completedCampaigns = campaigns.filter((campaign) => campaign.completed);
+
+  const countdownText = activeCampaign ? formatCountdown(activeCampaign.deadline, countdownNow) : null;
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 py-10 animate-fade-in">
@@ -138,6 +181,32 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
       <Link href="/projects" className="inline-flex items-center gap-1 text-sm text-[#5a7a5a] hover:text-forest-700 transition-colors mb-6 font-body">
         ← Back to Projects
       </Link>
+
+      {activeCampaign && (
+        <div className="card mb-6 border-amber-200 bg-gradient-to-r from-amber-50 to-orange-50">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-widest font-bold text-amber-700 font-body mb-1">Active Campaign</p>
+              <h2 className="font-display text-xl font-semibold text-amber-900">{activeCampaign.title}</h2>
+              {activeCampaign.description && (
+                <p className="text-sm text-amber-800 font-body mt-1">{activeCampaign.description}</p>
+              )}
+            </div>
+            <p className="text-xs px-3 py-1 rounded-full bg-amber-100 border border-amber-200 text-amber-800 font-body">
+              Ends in {countdownText}
+            </p>
+          </div>
+          <div className="mt-4">
+            <div className="flex justify-between text-xs mb-1 font-body text-amber-800">
+              <span>{formatXLM(activeCampaign.raisedXLM)} raised</span>
+              <span>{activeCampaign.progressPercent}% of {formatXLM(activeCampaign.goalXLM)}</span>
+            </div>
+            <div className="progress-bar h-2.5">
+              <div className="progress-fill" style={{ width: `${Math.min(activeCampaign.progressPercent, 100)}%` }} />
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="grid lg:grid-cols-3 gap-6">
 
@@ -286,6 +355,80 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
             )}
           </div>
 
+          {completedCampaigns.length > 0 && (
+            <div className="card">
+              <h2 className="font-display text-lg font-semibold text-forest-900 mb-4">Campaign History</h2>
+              <div className="space-y-3">
+                {completedCampaigns.map((campaign: ProjectCampaign) => (
+                  <div key={campaign.id} className="rounded-xl border border-forest-200 bg-forest-50 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+                      <p className="font-semibold text-forest-900 font-body">{campaign.title}</p>
+                      <span className="text-xs px-2 py-1 rounded-full bg-forest-100 border border-forest-200 text-forest-700 font-body">
+                        Completed
+                      </span>
+                    </div>
+                    <p className="text-xs text-[#5a7a5a] font-body mb-2">
+                      Ended {new Date(campaign.deadline).toLocaleDateString()}
+                    </p>
+                    <div className="flex justify-between text-xs mb-1 font-body">
+                      <span>{formatXLM(campaign.raisedXLM)} raised</span>
+                      <span>{campaign.progressPercent}% of {formatXLM(campaign.goalXLM)}</span>
+                    </div>
+                    <div className="progress-bar h-2">
+                      <div className="progress-fill progress-fill-complete" style={{ width: `${Math.min(campaign.progressPercent, 100)}%` }} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="card bg-forest-50 border-forest-200">
+            <h2 className="font-display text-lg font-semibold text-forest-900 mb-2">Campaign Creator</h2>
+            <p className="text-xs text-[#5a7a5a] font-body mb-4">
+              Project admins can launch a time-limited campaign with a custom goal and deadline.
+            </p>
+            <form onSubmit={handleCreateCampaign} className="space-y-3">
+              <input
+                type="text"
+                required
+                placeholder="Campaign title"
+                value={campaignForm.title}
+                onChange={(e) => setCampaignForm((prev) => ({ ...prev, title: e.target.value }))}
+                className="input-field"
+              />
+              <div className="grid sm:grid-cols-2 gap-3">
+                <input
+                  type="number"
+                  required
+                  min="1"
+                  step="1"
+                  placeholder="Goal (XLM)"
+                  value={campaignForm.goalXLM}
+                  onChange={(e) => setCampaignForm((prev) => ({ ...prev, goalXLM: e.target.value }))}
+                  className="input-field"
+                />
+                <input
+                  type="datetime-local"
+                  required
+                  value={campaignForm.deadline}
+                  onChange={(e) => setCampaignForm((prev) => ({ ...prev, deadline: e.target.value }))}
+                  className="input-field"
+                />
+              </div>
+              <textarea
+                placeholder="Description (optional)"
+                value={campaignForm.description}
+                onChange={(e) => setCampaignForm((prev) => ({ ...prev, description: e.target.value }))}
+                className="input-field min-h-24"
+              />
+              {campaignError && <p className="text-xs text-red-600 font-body">{campaignError}</p>}
+              <button type="submit" disabled={campaignState === 'saving'} className="btn-primary text-sm py-2 px-4">
+                {campaignState === 'saving' ? "Saving..." : campaignState === 'success' ? "Campaign Created" : "Create Campaign"}
+              </button>
+            </form>
+          </div>
+
           {/* Project updates */}
           {updates.length > 0 && (
             <div className="card">
@@ -313,11 +456,26 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
 
         {/* ── Sidebar ─────────────────────────────────────────────────── */}
         <div className="space-y-4">
+          <button
+            type="button"
+            onClick={() => setShowMonthlySetup(true)}
+            className="btn-secondary w-full text-sm py-2.5 px-4"
+          >
+            Give Monthly
+          </button>
+
           {publicKey ? (
             <DonateForm
               project={project}
               publicKey={publicKey}
+              initialAmount={prefillAmount}
               onSuccess={() => {
+                if (monthlySubId && prefillAmount) {
+                  const parsedPrefillAmount = Number.parseFloat(prefillAmount);
+                  if (Number.isFinite(parsedPrefillAmount) && parsedPrefillAmount > 0) {
+                    markMonthlySubscriptionPaid(monthlySubId, parsedPrefillAmount.toFixed(7));
+                  }
+                }
                 setRefreshKey(k => k + 1);
                 setTimeout(() => fetchProject(project.id).then(setProject), 2000);
               }}
@@ -386,6 +544,28 @@ export default function ProjectDetail({ publicKey, onConnect }: ProjectDetailPro
           </div>
         </div>
       </div>
+
+      {showMonthlySetup && (
+        <MonthlyGivingSetup
+          projectId={project.id}
+          projectName={project.name}
+          onClose={() => setShowMonthlySetup(false)}
+        />
+      )}
     </div>
   );
+}
+
+function formatCountdown(deadline: string, nowMs: number) {
+  const deltaMs = new Date(deadline).getTime() - nowMs;
+  if (deltaMs <= 0) return "0h 0m 0s";
+
+  const totalSeconds = Math.floor(deltaMs / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  return `${hours}h ${minutes}m ${seconds}s`;
 }

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -1,9 +1,10 @@
 /**
  * pages/projects/index.tsx — Browse all climate projects
  */
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/router";
 import ProjectCard, { ProjectCardSkeleton } from "@/components/ProjectCard";
+import ProjectComparison from "@/components/ProjectComparison";
 import { fetchProjects } from "@/lib/api";
 import { PROJECT_CATEGORIES, CATEGORY_ICONS } from "@/utils/format";
 import type { ClimateProject } from "@/utils/types";
@@ -14,6 +15,8 @@ export default function ProjectsPage() {
   const router = useRouter();
   const [projects, setProjects] = useState<ClimateProject[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([]);
+  const [showComparison, setShowComparison] = useState(false);
   
   const searchRef = useRef<HTMLDivElement>(null);
   
@@ -36,6 +39,12 @@ export default function ProjectsPage() {
   const status = (router.query.status as string) || "active";
   const verified = (router.query.verified as string) === "true";
   const searchQuery = (router.query.search as string) || "";
+  const compareQuery = (router.query.compare as string) || "";
+
+  const selectedProjects = useMemo(
+    () => projects.filter((project) => selectedProjectIds.includes(project.id)),
+    [projects, selectedProjectIds],
+  );
 
   // Initialize search from URL query parameter
   useEffect(() => {
@@ -74,6 +83,19 @@ export default function ProjectsPage() {
     return () => clearTimeout(timer);
   }, [category, status, verified, search]);
 
+  useEffect(() => {
+    if (!compareQuery || projects.length === 0) return;
+    const ids = compareQuery
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => projects.some((project) => project.id === id))
+      .slice(0, 3);
+    if (ids.length >= 2) {
+      setSelectedProjectIds(ids);
+      setShowComparison(true);
+    }
+  }, [compareQuery, projects]);
+
   const setFilter = (key: string, val: string) => {
     router.push(
       {
@@ -109,6 +131,18 @@ export default function ProjectsPage() {
   const handleSelectProject = (project: ClimateProject) => {
     setIsAutocompleteOpen(false);
     router.push(`/projects/${project.id}`);
+  };
+
+  const toggleSelection = (projectId: string) => {
+    setSelectedProjectIds((current) => {
+      if (current.includes(projectId)) {
+        return current.filter((id) => id !== projectId);
+      }
+      if (current.length >= 3) {
+        return current;
+      }
+      return [...current, projectId];
+    });
   };
 
   return (
@@ -269,6 +303,21 @@ export default function ProjectsPage() {
 
         {/* Grid */}
         <div className="flex-1">
+          {selectedProjectIds.length >= 2 && (
+            <div className="mb-4 flex items-center justify-between rounded-xl border border-forest-200 bg-forest-50 px-4 py-3">
+              <p className="text-sm text-forest-800 font-body">
+                {selectedProjectIds.length} selected for comparison
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowComparison(true)}
+                className="btn-primary text-sm py-2 px-4"
+              >
+                Compare selected
+              </button>
+            </div>
+          )}
+
           {loading ? (
             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {Array.from({ length: 6 }).map((_, i) => (
@@ -290,12 +339,40 @@ export default function ProjectsPage() {
           ) : (
             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {projects.map((p) => (
-                <ProjectCard key={p.id} project={p} />
+                <div key={p.id} className="relative">
+                  <label
+                    className={`absolute left-3 top-3 z-30 flex items-center gap-2 rounded-md border px-2 py-1 text-xs font-body shadow-sm ${
+                      selectedProjectIds.includes(p.id)
+                        ? "bg-forest-700 text-white border-forest-700"
+                        : "bg-white text-forest-700 border-forest-200"
+                    }`}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedProjectIds.includes(p.id)}
+                      onChange={() => toggleSelection(p.id)}
+                      disabled={selectedProjectIds.length >= 3 && !selectedProjectIds.includes(p.id)}
+                    />
+                    Compare
+                  </label>
+                  <ProjectCard project={p} />
+                </div>
               ))}
             </div>
           )}
         </div>
       </div>
+
+      {showComparison && selectedProjects.length >= 2 && (
+        <ProjectComparison
+          projects={selectedProjects}
+          onClose={() => setShowComparison(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -34,6 +34,22 @@ export interface ClimateProject {
   tags: string[];
   createdAt: string;
   updatedAt: string;
+  campaigns?: ProjectCampaign[];
+  activeCampaign?: ProjectCampaign | null;
+}
+
+export interface ProjectCampaign {
+  id: string;
+  projectId: string;
+  title: string;
+  description: string;
+  goalXLM: string;
+  raisedXLM: string;
+  deadline: string;
+  progressPercent: number;
+  completed: boolean;
+  active: boolean;
+  createdAt: string;
 }
 
 export interface Donation {
@@ -127,4 +143,23 @@ export interface EscrowJob {
   releaseTransactionHash?: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface MonthlyDonationHistoryItem {
+  paidAt: string;
+  amountXLM: string;
+}
+
+export interface MonthlySubscription {
+  id: string;
+  projectId: string;
+  projectName: string;
+  amountXLM: string;
+  startDate: string;
+  durationMonths: number | null;
+  nextDueDate: string;
+  remainingMonths: number | null;
+  status: "active" | "completed";
+  createdAt: string;
+  history: MonthlyDonationHistoryItem[];
 }


### PR DESCRIPTION
## Description
Implemented four related product features in one cohesive release: project fundraising campaigns, real-time global donation ticker, project comparison mode, and monthly giving subscriptions with reminder flow.

Closes #91
Closes #89
Closes #88
Closes #90

## Changes proposed

### What were you told to do?
Implement four open issues in one PR:
- Add campaign creation and campaign display/history on project pages.
- Add a real-time global donation ticker on the home page using Horizon streaming.
- Add a project comparison workflow for selecting up to three projects and comparing side-by-side.
- Add monthly giving setup, local persistence, dashboard due reminders, and Pay Now prefill behavior.

### What did I do?
#### Campaign system (#91)
- Added `project_campaigns` backend table.
- Added `POST /api/projects/:id/campaigns` endpoint with validation for title, goal, deadline, and description.
- Added `GET /api/projects/:id/campaigns` endpoint.
- Extended `GET /api/projects/:id` to return campaign list and active campaign.
- Computed campaign progress based on donations within campaign window (created_at to deadline).
- Added project-page active campaign banner with countdown and campaign progress bar.
- Added completed campaign history section.
- Added in-page campaign creation form for project admins.

#### Live global donation ticker (#89)
- Added `streamGlobalProjectDonations(...)` helper in `frontend/lib/stellar.ts` to stream and filter XLM payments to known project wallets.
- Updated home page to fetch projects, subscribe to stream, keep latest 10 donations, and cycle ticker entries.
- Implemented cleanup on unmount to close the Horizon stream.

#### Project comparison tool (#88)
- Added `ProjectComparison` modal component for side-by-side comparison.
- Added card-level compare checkboxes on projects list with max 3 selection limit.
- Added “Compare selected” CTA shown when 2+ projects are selected.
- Added comparison rows for CO2/XLM, progress, donor count, goal, raised, status, verified.
- Added per-project Donate button in comparison view.
- Added shareable comparison URL support via `compare` query param.

#### Monthly giving subscriptions (#90)
- Added `MonthlyGivingSetup` modal component.
- Added localStorage-backed monthly giving utility module (`frontend/lib/monthlyGiving.ts`) for create/load/due/mark-paid flows.
- Added “Give Monthly” button on project detail page.
- Added dashboard “Monthly Giving Due Today” Pay Now banners.
- Added Pay Now deep-link prefill (`amount` + `monthlySubId`) to project donation form.
- Added subscription payment history tracking and next-due progression when monthly payment succeeds.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Frontend type-check passed: `npm run type-check` (frontend)
- Backend unit tests passed: `npm test` (backend) — 17/17 tests passing.
- Notes on lint tooling in this repo:
  - `npm run lint` (frontend) prompts for first-time Next.js ESLint setup (no existing config committed).
  - `npm run lint` (backend) fails because no ESLint config file exists in backend.
