### PR TITLE
test(e2e): make Playwright suite pass end-to-end (9 tests, 10s)

### DIFF
--- a/frontend/e2e/greenpay.spec.ts
+++ b/frontend/e2e/greenpay.spec.ts
@@ -1,29 +1,30 @@
 /**
- * e2e/greenpay.spec.ts — End-to-end tests for Stellar GreenPay key user journeys.
+ * e2e/greenpay.spec.ts — End-to-end tests for the GreenPay user journeys.
  *
- * Covers:
- * - Home page loads correctly
- * - Projects list and empty state
- * - Navigation to project details
- * - DonateForm validation and preset amounts (with mocked wallet)
- * - Leaderboard and dashboard (with and without wallet)
+ * Each spec mocks every backend (`/api/**`) and Stellar (`horizon-testnet`)
+ * endpoint the page touches, plus injects a fake `window.freighter` so the
+ * connected-wallet branches render without a real extension.
  */
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 
-// ── Mock Data ────────────────────────────────────────────────────────────────
+// ── Mock data ───────────────────────────────────────────────────────────────
 
 const MOCK_PROJECT_ID = "8d9ac19b-52eb-42f7-80d9-19a88ba59e43";
+const MOCK_WALLET     = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+const MOCK_PUBLIC_KEY = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGLEWZE5BGYTG2XTGQBC3VP";
+
 const MOCK_PROJECT = {
   id: MOCK_PROJECT_ID,
   name: "Amazon Reforestation Initiative",
   description: "Planting 1 million native trees in the Brazilian Amazon.",
   category: "Reforestation",
   location: "Brazil, South America",
-  walletAddress: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  walletAddress: MOCK_WALLET,
   goalXLM: "50000",
   raisedXLM: "18420",
   donorCount: 147,
   co2OffsetKg: 245000,
+  co2_per_xlm: 100,
   status: "active",
   verified: true,
   onChainVerified: true,
@@ -35,7 +36,7 @@ const MOCK_PROJECT = {
 const MOCK_LEADERBOARD = [
   {
     rank: 1,
-    publicKey: "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGLEWZE5BGYTG2XTGQBC3VP",
+    publicKey: MOCK_PUBLIC_KEY,
     displayName: "EcoChampion",
     totalDonatedXLM: "2500",
     projectsSupported: 5,
@@ -43,131 +44,153 @@ const MOCK_LEADERBOARD = [
   },
 ];
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+const ok    = (data: unknown) => ({ json: { success: true, data } });
+const okMsg = (msg: string)   => ({ json: { success: true, message: msg } });
+
+// ── Mocking helpers ─────────────────────────────────────────────────────────
 
 /**
- * Mock the Freighter wallet globally via window.freighter.
+ * Intercept every `/api/**` call the GreenPay frontend can make and reply
+ * with deterministic mock data. Unspecified routes fall through to a
+ * blanket `{success: true, data: []}` so the page never sees a network
+ * error from a forgotten endpoint.
  */
-async function mockFreighter(page: Page, publicKey = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGLEWZE5BGYTG2XTGQBC3VP") {
+async function mockApi(page: Page) {
+  // Playwright resolves routes in reverse insertion order — register the
+  // catch-all FIRST so the more-specific handlers below win.
+  await page.route("**/api/**", (r: Route) => r.fulfill(ok([])));
+  await page.route("**/horizon-testnet.stellar.org/**", (r) =>
+    r.fulfill({ json: { _embedded: { records: [] }, balances: [{ asset_type: "native", balance: "500.0000000" }] } }),
+  );
+
+  // Stats / categories / impact / leaderboard.
+  await page.route("**/api/impact/**",          (r) => r.fulfill(ok({})));
+  await page.route("**/api/stats/categories",   (r) => r.fulfill(ok([{ category: "Reforestation", count: 1 }])));
+  await page.route("**/api/stats/global",       (r) => r.fulfill(ok({ totalDonations: 1, totalXLMRaised: "100", totalCO2OffsetKg: 1000 })));
+  await page.route("**/api/leaderboard**",      (r) => r.fulfill(ok(MOCK_LEADERBOARD)));
+
+  // Profile, donations, subscriptions, updates.
+  await page.route("**/api/profiles/**",        (r) => r.fulfill(ok({ publicKey: MOCK_PUBLIC_KEY, totalDonatedXLM: "0", projectsSupported: 0, badges: [] })));
+  await page.route("**/api/donations",          (r) => r.fulfill(ok({ id: "d1" })));
+  await page.route("**/api/donations/**",       (r) => r.fulfill(ok([])));
+  await page.route("**/api/subscriptions",      (r) => r.fulfill(okMsg("subscribed")));
+  await page.route("**/api/subscriptions/**",   (r) => r.fulfill({ json: { success: true, count: 0 } }));
+  await page.route("**/api/updates/**",         (r) => r.fulfill(ok([])));
+
+  // Projects (broadest first within this group, then more specific).
+  await page.route("**/api/projects?**",                        (r) => r.fulfill(ok([MOCK_PROJECT])));
+  await page.route("**/api/projects",                           (r) => r.fulfill(ok([MOCK_PROJECT])));
+  await page.route("**/api/projects/featured",                  (r) => r.fulfill(ok(MOCK_PROJECT)));
+  await page.route(`**/api/projects/${MOCK_PROJECT_ID}/**`,     (r) => r.fulfill(ok([])));
+  await page.route(`**/api/projects/${MOCK_PROJECT_ID}`,        (r) => r.fulfill(ok(MOCK_PROJECT)));
+}
+
+/**
+ * Inject a connected-wallet state into the app. The runtime cooperates
+ * via a small test seam in `_app.tsx` that prefers
+ * `window.__test_publicKey__` over the real Freighter handshake — the
+ * `@stellar/freighter-api` v2 library otherwise routes most calls
+ * through `window.postMessage` to the extension, which is brittle and
+ * race-prone to mock. Setting this global short-circuits the entire
+ * handshake while leaving production behavior untouched.
+ */
+async function mockFreighter(page: Page, publicKey = MOCK_PUBLIC_KEY) {
   await page.addInitScript((pk) => {
-    (window as any).freighter = {
-      isConnected: () => Promise.resolve(true),
-      isAllowed: () => Promise.resolve(true),
-      requestAccess: () => Promise.resolve(pk),
-      getPublicKey: () => Promise.resolve(pk),
-      signTransaction: (xdr: string) => Promise.resolve(xdr),
+    (window as unknown as Record<string, unknown>).__test_publicKey__ = pk;
+    // Keep window.freighter present so any code that does an
+    // `isFreighterInstalled` check still sees a wallet.
+    (window as unknown as Record<string, unknown>).freighter = {
+      isConnected: () => Promise.resolve({ isConnected: true }),
     };
   }, publicKey);
 }
 
-/**
- * Intercept backend API calls with deterministic mock responses.
- */
-async function mockApi(page: Page) {
-  await page.route(`**/api/projects/${MOCK_PROJECT_ID}`, (route) =>
-    route.fulfill({ json: { success: true, data: MOCK_PROJECT } })
-  );
-  await page.route("**/api/projects**", (route) =>
-    route.fulfill({ json: { success: true, data: [MOCK_PROJECT] } })
-  );
-  await page.route("**/api/leaderboard**", (route) =>
-    route.fulfill({ json: { success: true, data: MOCK_LEADERBOARD } })
-  );
-  await page.route("**/api/donations/**", (route) =>
-    route.fulfill({ json: { success: true, data: [] } })
-  );
-  await page.route("**/api/profiles/**", (route) =>
-    route.fulfill({ json: { success: true, data: { publicKey: "G...", totalDonatedXLM: "0", badges: [] } } })
-  );
-  
-  // Mock Horizon balance check
-  await page.route("**/horizon-testnet.stellar.org/accounts/**", (route) =>
-    route.fulfill({
-      json: { balances: [{ asset_type: "native", balance: "500.0000000" }] },
-    })
-  );
-}
+// ── Tests ───────────────────────────────────────────────────────────────────
 
-// ── Tests ────────────────────────────────────────────────────────────────────
-
-test.describe("Home Page", () => {
-  test("loads with hero section, badge tiers, and category grid", async ({ page }) => {
+test.describe("Home page", () => {
+  test("loads with hero, badge tiers, and category grid", async ({ page }) => {
     await mockApi(page);
     await page.goto("/");
 
-    await expect(page.getByRole("heading", { name: /fund the planet/i })).toBeVisible();
-    
-    // Badge tiers
+    // Hero — match the visible h1 text rather than the role+name lookup,
+    // since the heading wraps a `<br/>` and gradient `<span>`.
+    await expect(page.getByText("Fund the planet.").first()).toBeVisible();
+
+    // All four on-chain badge tiers should be visible somewhere on the page.
     for (const badge of ["Seedling", "Tree", "Forest", "Earth Guardian"]) {
       await expect(page.getByText(badge).first()).toBeVisible();
     }
 
-    // Categories
-    await expect(page.getByRole("link", { name: /reforestation/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /solar energy/i })).toBeVisible();
+    // Category grid — links into /projects?category=...  (Reforestation
+    // can also appear in the data-driven category-stats chart, so use
+    // .first() to silence strict-mode multi-match violations.)
+    await expect(page.getByRole("link", { name: /reforestation/i }).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /solar energy/i }).first()).toBeVisible();
   });
 });
 
-test.describe("Projects Page", () => {
-  test("loads and shows project cards", async ({ page }) => {
+test.describe("Projects page", () => {
+  test("shows project cards", async ({ page }) => {
     await mockApi(page);
     await page.goto("/projects");
-    await expect(page.getByText("Amazon Reforestation Initiative")).toBeVisible();
+    await expect(page.getByText(MOCK_PROJECT.name)).toBeVisible();
   });
 
-  test("shows empty state when no projects found", async ({ page }) => {
-    await page.route("**/api/projects**", (route) =>
-      route.fulfill({ json: { success: true, data: [] } })
-    );
+  test("shows empty state when API returns no projects", async ({ page }) => {
+    await mockApi(page);
+    // Override the projects list mock — registered AFTER mockApi so the
+    // reverse-insertion-order tiebreaker picks this one.
+    await page.route("**/api/projects",    (r) => r.fulfill(ok([])));
+    await page.route("**/api/projects?**", (r) => r.fulfill(ok([])));
     await page.goto("/projects");
     await expect(page.getByText(/no projects found/i)).toBeVisible();
   });
 
-  test("clicking a project card navigates to detail page", async ({ page }) => {
+  test("clicking a project card navigates to its detail page", async ({ page }) => {
     await mockApi(page);
     await page.goto("/projects");
-    await page.getByText("Amazon Reforestation Initiative").click();
+    await page.getByText(MOCK_PROJECT.name).click();
     await expect(page).toHaveURL(new RegExp(`/projects/${MOCK_PROJECT_ID}`));
   });
 });
 
-test.describe("Project Detail & DonateForm", () => {
-  test("shows WalletConnect prompt when no wallet is connected", async ({ page }) => {
+test.describe("Project detail & DonateForm", () => {
+  test("shows the WalletConnect prompt when no wallet is connected", async ({ page }) => {
     await mockApi(page);
     await page.goto(`/projects/${MOCK_PROJECT_ID}`);
     await expect(page.getByText(/connect your wallet to donate/i)).toBeVisible();
   });
 
-  test.describe("With Connected Wallet", () => {
+  test.describe("with a connected (mocked) Freighter wallet", () => {
     test.beforeEach(async ({ page }) => {
       await mockFreighter(page);
       await mockApi(page);
       await page.goto(`/projects/${MOCK_PROJECT_ID}`);
     });
 
-    test("preset amount buttons pre-fill the amount input correctly", async ({ page }) => {
-      await expect(page.getByRole("heading", { name: /make a donation/i })).toBeVisible();
+    test("preset amount buttons pre-fill the custom-amount input", async ({ page }) => {
+      // Scope selectors to the donation form so we don't collide with the
+      // CO₂-impact calculator preview that also renders "25 XLM" buttons.
+      const form = page.locator(".card", { hasText: /make a donation/i });
+      await expect(form.getByRole("heading", { name: /make a donation/i })).toBeVisible();
+      const amountInput = form.getByPlaceholder(/or enter custom amount/i);
 
-      const amountInput = page.getByPlaceholder(/or enter custom amount/i);
-      
-      await page.getByRole("button", { name: /^25 XLM$/i }).click();
+      await form.getByRole("button", { name: /^25 XLM$/i }).click();
       await expect(amountInput).toHaveValue("25");
 
-      await page.getByRole("button", { name: /^100 XLM$/i }).click();
+      await form.getByRole("button", { name: /^100 XLM$/i }).click();
       await expect(amountInput).toHaveValue("100");
     });
 
-    test("submit button is disabled when no amount is entered", async ({ page }) => {
-      await expect(page.getByRole("heading", { name: /make a donation/i })).toBeVisible();
-      
-      const donateButton = page.getByRole("button", { name: /donate/i });
-      const amountInput = page.getByPlaceholder(/or enter custom amount/i);
+    test("submit button is disabled until a valid amount is entered", async ({ page }) => {
+      const form = page.locator(".card", { hasText: /make a donation/i });
+      await expect(form.getByRole("heading", { name: /make a donation/i })).toBeVisible();
+      const donateButton = form.getByRole("button", { name: /Donate/ });
+      const amountInput  = form.getByPlaceholder(/or enter custom amount/i);
 
       await expect(donateButton).toBeDisabled();
-
       await amountInput.fill("10");
       await expect(donateButton).toBeEnabled();
-
       await amountInput.fill("");
       await expect(donateButton).toBeDisabled();
     });
@@ -175,7 +198,7 @@ test.describe("Project Detail & DonateForm", () => {
 });
 
 test.describe("Leaderboard", () => {
-  test("loads and shows badge tier legend", async ({ page }) => {
+  test("loads and shows the badge tier legend", async ({ page }) => {
     await mockApi(page);
     await page.goto("/leaderboard");
     await expect(page.getByText("Impact Badge Tiers")).toBeVisible();
@@ -183,11 +206,13 @@ test.describe("Leaderboard", () => {
   });
 });
 
-test.describe("Dashboard", () => {
+test.describe("Dashboard (My Impact)", () => {
   test("shows WalletConnect when no wallet is connected", async ({ page }) => {
     await mockApi(page);
     await page.goto("/dashboard");
-    await expect(page.getByRole("heading", { name: /my impact/i })).toBeVisible();
-    await expect(page.getByText(/connect your wallet/i)).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^my impact$/i })).toBeVisible();
+    // The WalletConnect card renders a level-3 heading — assert on it
+    // specifically to avoid the strict-mode ambiguity with the prompt copy.
+    await expect(page.getByRole("heading", { name: /connect your wallet/i })).toBeVisible();
   });
 });

--- a/frontend/e2e/helpers/mockFreighter.ts
+++ b/frontend/e2e/helpers/mockFreighter.ts
@@ -1,34 +1,30 @@
 import type { Page } from "@playwright/test";
 
 /**
- * Injects a mock Freighter wallet into the page context.
+ * Inject a connected-wallet state into the GreenPay frontend.
  *
- * NOTE: wallet.ts uses statically bundled @stellar/freighter-api imports,
- * so this mock patches window.freighter (the extension injection point) and
- * stores the mock pk for any code that reads it. For tests that need a
- * fully connected wallet state, combine this with a page.route() mock for
- * the Horizon account endpoint.
+ * The runtime cooperates via a small test seam in `pages/_app.tsx` that
+ * prefers `window.__test_publicKey__` over the real Freighter handshake.
+ * The `@stellar/freighter-api` v2 library otherwise routes most calls
+ * (`requestAccess`, `getPublicKey`, `signTransaction`, …) through
+ * `window.postMessage` to the extension, which is brittle and race-prone
+ * to mock from a Playwright init script. Setting this global
+ * short-circuits the entire handshake while leaving production behavior
+ * untouched (the global is never set in production builds).
+ *
+ * Combine with `page.route(...)` mocks for `/api/**` and Horizon if the
+ * page under test reads balances or fetches data.
  */
 export async function mockFreighter(
   page: Page,
   publicKey = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGLEWZE5BGYTG2XTGQBC3VP",
 ) {
   await page.addInitScript((pk) => {
-    // Patch window.freighter — the surface the extension injects
+    (window as unknown as Record<string, unknown>).__test_publicKey__ = pk;
+    // Keep window.freighter present so any code that does an
+    // `isFreighterInstalled` check still sees a wallet.
     (window as unknown as Record<string, unknown>).freighter = {
-      isConnected: () => Promise.resolve(true),
-      getPublicKey: () => Promise.resolve(pk),
-      signTransaction: (xdr: string) => Promise.resolve({ signedTxXdr: xdr }),
-      getNetwork: () => Promise.resolve("TESTNET"),
-      getNetworkDetails: () =>
-        Promise.resolve({
-          network: "TESTNET",
-          networkUrl: "https://horizon-testnet.stellar.org",
-          networkPassphrase: "Test SDF Network ; September 2015",
-        }),
+      isConnected: () => Promise.resolve({ isConnected: true }),
     };
-
-    // Store the mock public key for test assertions
-    (window as unknown as Record<string, unknown>).__mock_public_key__ = pk;
   }, publicKey);
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -11,6 +11,16 @@ export default function App({ Component, pageProps }: AppProps) {
   const [publicKey, setPublicKey] = useState<string | null>(null);
 
   useEffect(() => {
+    // Test seam: e2e tests inject a public key via window.addInitScript
+    // so the wallet-gated UI renders without driving the real Freighter
+    // postMessage handshake. Untouched in production.
+    const testPk = (typeof window !== "undefined"
+      ? (window as unknown as { __test_publicKey__?: unknown }).__test_publicKey__
+      : undefined);
+    if (typeof testPk === "string" && testPk.length > 0) {
+      setPublicKey(testPk);
+      return;
+    }
     getConnectedPublicKey().then(pk => { if (pk) setPublicKey(pk); });
   }, []);
 

--- a/frontend/pages/admin/[projectId].tsx
+++ b/frontend/pages/admin/[projectId].tsx
@@ -302,7 +302,7 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
               <p className="text-sm text-[#5a7a5a] font-body">No milestones defined yet.</p>
             ) : (
               milestones.map((m) => {
-                const reached = project.raisedXLM >= (parseFloat(project.goalXLM) * m.percentage / 100);
+                const reached = parseFloat(project.raisedXLM) >= (parseFloat(project.goalXLM) * m.percentage / 100);
                 return (
                   <div key={m.id} className={`p-4 rounded-xl border ${m.reachedAt ? 'bg-emerald-50 border-emerald-100' : 'bg-white border-forest-100'}`}>
                     <div className="flex items-center justify-between mb-2">
@@ -338,7 +338,7 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
                     <div className="w-full bg-forest-100 h-1.5 rounded-full overflow-hidden">
                       <div 
                         className={`h-full transition-all duration-1000 ${m.reachedAt ? 'bg-emerald-500' : reached ? 'bg-amber-400' : 'bg-forest-300'}`}
-                        style={{ width: `${Math.min(100, (project.raisedXLM / (parseFloat(project.goalXLM) * m.percentage / 100)) * 100)}%` }}
+                        style={{ width: `${Math.min(100, (parseFloat(project.raisedXLM) / (parseFloat(project.goalXLM) * m.percentage / 100)) * 100)}%` }}
                       />
                     </div>
                   </div>

--- a/frontend/pages/api-docs.tsx
+++ b/frontend/pages/api-docs.tsx
@@ -230,10 +230,10 @@ function EndpointCard({ endpoint }: { endpoint: ApiEndpoint }) {
       });
 
       const path = endpoint.path.replace(":id", "featured").replace(":projectId", "1");
-      const res = await api[endpoint.method.toLowerCase() as keyof typeof api](
-        path,
-        endpoint.example?.request,
-      );
+      const method = endpoint.method.toLowerCase() as "get" | "post" | "put" | "delete" | "patch";
+      const res = method === "get" || method === "delete"
+        ? await api[method](path)
+        : await api[method](path, endpoint.example?.request);
       setResponse(res.data);
     } catch (err: any) {
       setError(err.message || "Failed to fetch");

--- a/frontend/pages/projects/[id].tsx
+++ b/frontend/pages/projects/[id].tsx
@@ -10,8 +10,9 @@ import ToastNotification, { type ToastItem } from "@/components/ToastNotificatio
 import WalletConnect from "@/components/WalletConnect";
 import CircularProgress from "@/components/CircularProgress";
 import MonthlyGivingSetup from "@/components/MonthlyGivingSetup";
+import DescriptionAccordion from "@/components/DescriptionAccordion";
 import { fetchProject, fetchProjectUpdates, subscribeToProject, fetchSubscriberCount, createProjectCampaign, fetchProjectMatches } from "@/lib/api";
-import { formatXLM, formatCO2, progressPercent, timeAgo, statusClass, statusLabel, CATEGORY_ICONS, copyToClipboard } from "@/utils/format";
+import { formatXLM, formatCO2, progressPercent, timeAgo, statusClass, statusLabel, CATEGORY_ICONS, copyToClipboard, shortenAddress } from "@/utils/format";
 import { accountUrl, fetchProjectDiscussion, type ProjectDiscussionMessage } from "@/lib/stellar";
 import { markMonthlySubscriptionPaid } from "@/lib/monthlyGiving";
 import type {
@@ -61,6 +62,7 @@ export default function ProjectDetail({
   const [discussion, setDiscussion] = useState<ProjectDiscussionMessage[]>([]);
   const [discussionLoading, setDiscussionLoading] = useState(false);
   const [matches, setMatches] = useState<any[]>([]);
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const { toggleWishlist, isInWishlist } = useWishlist();
   const prefillAmount =
@@ -77,13 +79,11 @@ export default function ProjectDetail({
     Promise.all([
       fetchProject(id as string),
       fetchProjectUpdates(id as string),
-      fetchProjectDonationMessages(id as string, 10),
       fetchProjectMatches(id as string),
     ])
-      .then(([p, u, messages, m]) => {
+      .then(([p, u, m]) => {
         setProject(p);
         setUpdates(u);
-        setMessageWall(messages);
         setMatches(m);
       })
       .catch(() => router.push("/projects"))
@@ -1365,9 +1365,6 @@ export default function ProjectDetail({
                   }
                 }
                 setRefreshKey((k) => k + 1);
-                fetchProjectDonationMessages(project.id, 10)
-                  .then(setMessageWall)
-                  .catch(() => {});
                 setTimeout(
                   () => fetchProject(project.id).then(setProject),
                   2000,


### PR DESCRIPTION
Get the existing Playwright spec actually green and run it on the real Next.js production build (`npm run start`). The scaffold was in place (playwright.config.ts, e2e/greenpay.spec.ts, helpers/mockFreighter.ts, test:e2e script, ci.yml e2e job) but the suite did not pass.

- Rewrite e2e/greenpay.spec.ts with comprehensive `/api/**` mocks that match each endpoint's actual response shape (GlobalStats, CategoryStats, ClimateProject, etc.), a Horizon catch-all, and selectors that survive the duplicated buttons/links the page renders (CO2 calc preview vs. donation form, category-stats chart vs. static category grid).
- Replace the postMessage-based Freighter mock with a tiny test seam: pages/_app.tsx now reads window.__test_publicKey__ before falling back to the real Freighter handshake. The seam is a no-op in production (the global is never set) and lets the wallet-gated DonateForm render for the preset-amount and submit-disabled tests.
- Update helpers/mockFreighter.ts to match the new seam.
- Fix several pre-existing TypeScript build errors that blocked `npm run build` (and therefore the Playwright webServer): pages/admin/[projectId].tsx (string vs number arithmetic on raisedXLM), pages/api-docs.tsx (axios method dispatch), and pages/projects/[id].tsx (missing import/state hook for ToastItem, missing DescriptionAccordion import, missing shortenAddress import, dangling refs to setMessageWall/fetchProjectDonationMessages).

Result: `npm run test:e2e` runs 9 tests covering home, projects list + empty state + click-through, project detail wallet prompt, DonateForm preset/disabled, leaderboard, and dashboard wallet prompt. All pass in ~10 seconds, well under the 90-second budget.

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)

Closes #125
