### PR TITLE
ci: run soroban contract tests from workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,11 @@ jobs:
       - run: npm run lint
 
   contracts:
-    name: Soroban Contract (Rust)
+    name: Soroban Contracts (Rust)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        contract: [greenpay-contract, escrow-contract]
     defaults:
       run:
-        working-directory: contracts/${{ matrix.contract }}
+        working-directory: contracts
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -96,8 +93,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ matrix.contract }}-${{ hashFiles('contracts/**/Cargo.lock') }}
-      - run: cargo check --target wasm32-unknown-unknown
-      - run: cargo test
-      - run: cargo build --target wasm32-unknown-unknown --release
+            contracts/target
+          key: ${{ runner.os }}-cargo-contracts-${{ hashFiles('contracts/**/Cargo.lock') }}
+      - run: cargo check --workspace
+      - run: cargo test --workspace
+      - run: cargo build --workspace --target wasm32-unknown-unknown --release


### PR DESCRIPTION
Closes #145

Changes:
- Run contract checks from the contracts workspace root
- Use cargo check --workspace
- Use cargo test --workspace
- Use cargo build --workspace --target wasm32-unknown-unknown --release
- Simplify contract CI by removing per-contract matrix execution
