### PR TITLE
Add architecture decision records

### DIFF
--- a/docs/adr/ADR-001-why-stellar-soroban-over-evm.md
+++ b/docs/adr/ADR-001-why-stellar-soroban-over-evm.md
@@ -1,0 +1,76 @@
+# ADR-001: Why Stellar/Soroban Over EVM
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+Stellar GreenPay needs a blockchain layer for transparent climate donations. Donors should be able to send small XLM-denominated donations directly to verified project wallets, while the platform records donation totals, donor impact, badges, and CO2 offset metrics in a way that can be audited outside the backend.
+
+The project needed to choose whether to build this on Stellar/Soroban, an EVM chain, or an off-chain-only backend.
+
+## Decision Drivers
+
+- Donations should remain practical for small amounts, so transaction fees must be low and predictable.
+- The payment path should be simple: donor wallet to project wallet, with minimal platform involvement.
+- On-chain impact records should be auditable without making the backend the source of truth.
+- The contract layer should integrate with the existing Stellar payment flow and Freighter wallet UX.
+- The platform should avoid forcing donors through cross-chain bridging or chain-specific gas-token complexity for the core flow.
+- The implementation should support future features such as donation badges, verified project registration, matching, and governance.
+
+## Considered Options
+
+- Stellar payments plus Soroban contracts
+- EVM smart contracts
+- Off-chain-only backend records
+
+## Decision Outcome
+
+Chosen option: Stellar payments plus Soroban contracts.
+
+Stellar is a better fit for GreenPay's payment-first donation model because donations can be sent directly to project wallets while Soroban records project, donor, and impact state on-chain. This keeps funds out of platform custody, keeps small donations viable, and makes donation-derived impact data independently verifiable.
+
+## Positive Consequences
+
+- Direct Stellar payments remain the core donation path.
+- Soroban can track donation totals, donor stats, badges, and project verification without holding funds.
+- Freighter provides a clear browser-wallet integration for signing Stellar transactions.
+- Lower and more predictable fees make small climate donations more practical.
+- The backend can focus on metadata, feeds, and aggregation instead of being the authority for donation truth.
+
+## Negative Consequences
+
+- Soroban has a smaller ecosystem than EVM and fewer reusable contract libraries.
+- Some donors may already be more familiar with EVM wallets than Stellar wallets.
+- Cross-chain donors may need a bridge or separate Stellar funding flow before donating.
+- Tooling and operational knowledge must stay aligned with Soroban-specific SDKs, Horizon, and RPC services.
+
+## Pros and Cons of the Options
+
+### Stellar payments plus Soroban contracts
+
+- Good, because it matches GreenPay's direct-to-project payment model.
+- Good, because Soroban records impact data without requiring custodial donation contracts.
+- Good, because Freighter and Horizon support a straightforward browser payment flow.
+- Bad, because ecosystem maturity and wallet familiarity are narrower than EVM.
+
+### EVM smart contracts
+
+- Good, because EVM has mature tooling, many wallets, and a large developer ecosystem.
+- Good, because Solidity contract patterns are well documented.
+- Bad, because gas costs and L2 fragmentation add friction for small recurring donations.
+- Bad, because an EVM-first flow would not naturally match GreenPay's existing Stellar wallet, Horizon, and Soroban code paths.
+
+### Off-chain-only backend records
+
+- Good, because it would be simpler to build and operate initially.
+- Good, because it would avoid smart contract deployment and upgrade concerns.
+- Bad, because donors would need to trust backend records for impact totals.
+- Bad, because fake or disputed donation records would be harder for the public to audit independently.
+
+## More Information
+
+- [Architecture overview](../architecture.md)
+- [GreenPay Soroban contract README](../../contracts/greenpay-contract/README.md)
+- [GreenPay Soroban contract security notes](../../contracts/greenpay-contract/SECURITY.md)

--- a/docs/adr/ADR-002-why-direct-to-wallet-payments-over-platform-custody.md
+++ b/docs/adr/ADR-002-why-direct-to-wallet-payments-over-platform-custody.md
@@ -1,0 +1,77 @@
+# ADR-002: Why Direct-to-Wallet Payments Over Platform Custody
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+GreenPay connects donors with verified climate projects. The platform needed to decide whether donations should go directly from donor wallets to project wallets, or whether GreenPay should receive, hold, and later disburse funds as a custodial intermediary.
+
+This decision affects donor trust, operational risk, regulatory exposure, incident impact, and the architecture of the Soroban contract.
+
+## Decision Drivers
+
+- Donors should know that their donation reaches the project wallet directly.
+- GreenPay should minimize custody, private-key, and treasury-management risk.
+- The platform should avoid becoming the critical path for fund disbursement.
+- Donation transparency should be available through Stellar transactions and Soroban impact records.
+- Project wallets should be visible and auditable.
+- The product promise is zero platform fees for the core donation flow.
+
+## Considered Options
+
+- Direct-to-wallet payments
+- Platform-custodied donations
+- Hybrid custody with periodic project payouts
+
+## Decision Outcome
+
+Chosen option: Direct-to-wallet payments.
+
+Donations are sent from the donor wallet directly to the verified project wallet. GreenPay records donation metadata in the backend and donation-derived impact state in Soroban, but does not custody the donated funds.
+
+## Positive Consequences
+
+- GreenPay does not hold donor funds for the donation flow.
+- A compromised platform backend cannot directly drain donated funds.
+- Donors and projects can verify payment destination and transaction history on Stellar.
+- The Soroban contract can remain focused on recording and aggregating impact state instead of managing balances.
+- Operational burden is lower because GreenPay does not need payout scheduling, treasury reconciliation, or custody controls for donations.
+
+## Negative Consequences
+
+- GreenPay cannot reverse, pause, or recover a donation after the donor signs and submits it.
+- Project wallet accuracy becomes critical before a project is listed or registered on-chain.
+- Refunds and disputes must happen outside the core platform flow.
+- Some matching, escrow, or conditional-release features require separate flows rather than changing the core donation path.
+
+## Pros and Cons of the Options
+
+### Direct-to-wallet payments
+
+- Good, because it minimizes trust placed in GreenPay as an intermediary.
+- Good, because it aligns with public Stellar payment records.
+- Good, because Soroban can record impact without holding balances.
+- Bad, because incorrect project wallet configuration has immediate payment consequences.
+
+### Platform-custodied donations
+
+- Good, because GreenPay could batch payouts, support refunds, and enforce extra controls before disbursement.
+- Good, because the product could expose simpler accounting from one platform treasury.
+- Bad, because custody creates a high-value attack target.
+- Bad, because it increases operational, legal, and compliance complexity.
+- Bad, because it weakens the product promise that donations go straight to projects.
+
+### Hybrid custody with periodic project payouts
+
+- Good, because it could combine some payout controls with later project settlement.
+- Good, because matching and campaign mechanics may be easier to coordinate centrally.
+- Bad, because users still need to trust GreenPay to hold and release funds.
+- Bad, because payout delays and treasury operations become core system responsibilities.
+
+## More Information
+
+- [Architecture overview](../architecture.md)
+- [Donation flow in the frontend](../../frontend/components/DonateForm.tsx)
+- [GreenPay Soroban contract](../../contracts/greenpay-contract/src/lib.rs)

--- a/docs/adr/ADR-003-authentication-approach-wallet-as-identity.md
+++ b/docs/adr/ADR-003-authentication-approach-wallet-as-identity.md
@@ -1,0 +1,76 @@
+# ADR-003: Authentication Approach: Wallet as Identity
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+GreenPay needs to identify donors, project owners, and admins in a way that fits blockchain donations. The platform needed to decide whether to introduce traditional accounts with passwords or OAuth, rely on wallet public keys as identity, or support several wallet providers from the first release.
+
+The current product is centered on Stellar transactions signed in Freighter, public donor profiles, project-owner wallet checks, and on-chain records keyed by Stellar addresses.
+
+## Decision Drivers
+
+- Donors should not need a separate GreenPay password account before donating.
+- Private keys must never be handled by the frontend or backend.
+- Donation identity should match the Stellar address that signs the transaction.
+- Public profiles, leaderboards, badges, and project-owner checks should use a stable identifier.
+- The first browser flow should remain simple and testable.
+- The platform should leave room for additional Stellar wallets later without changing the identity model.
+
+## Considered Options
+
+- Wallet-as-identity with Freighter as the first supported wallet
+- Traditional username/password or OAuth accounts
+- Multi-wallet support from the first release
+
+## Decision Outcome
+
+Chosen option: Wallet-as-identity with Freighter as the first supported wallet.
+
+GreenPay treats the connected Stellar public key as the primary user identifier. Freighter signs transactions locally, and the app uses the resulting public key for donor profiles, dashboard state, project-owner checks, and transaction authorization flows.
+
+## Positive Consequences
+
+- Users can donate without creating a separate platform account.
+- Private keys remain inside the wallet extension.
+- The public key used for identity is the same address visible in Stellar transactions and Soroban state.
+- Donor profiles, leaderboards, and badges can be associated with a durable on-chain identifier.
+- The first wallet integration stays focused on one Stellar wallet API instead of several provider-specific APIs.
+
+## Negative Consequences
+
+- Users without Freighter need to install it before using the main browser donation flow.
+- Account recovery is wallet recovery; GreenPay cannot reset a lost wallet.
+- Supporting mobile wallets or other Stellar wallets later will require provider adapters.
+- Backend routes that mutate wallet-owned resources must consistently verify wallet ownership or require signed authorization, not just accept a submitted public key.
+
+## Pros and Cons of the Options
+
+### Wallet-as-identity with Freighter as the first supported wallet
+
+- Good, because it aligns identity with signed Stellar transactions.
+- Good, because it avoids password storage and account-recovery operations.
+- Good, because Freighter is already integrated into the frontend donation flow.
+- Bad, because Freighter-only support narrows the initial browser wallet audience.
+
+### Traditional username/password or OAuth accounts
+
+- Good, because many users understand conventional sign-in flows.
+- Good, because account recovery and notification preferences are easier to model.
+- Bad, because account identity can diverge from the wallet that actually donated.
+- Bad, because passwords and OAuth sessions add security and privacy responsibilities that are not needed for the core donation flow.
+
+### Multi-wallet support from the first release
+
+- Good, because it would make the product accessible to more Stellar wallet users immediately.
+- Good, because it would reduce dependency on one wallet provider.
+- Bad, because wallet APIs differ and would add early complexity to signing, network selection, error handling, and tests.
+- Bad, because it would slow delivery of the core donation and impact-tracking flows.
+
+## More Information
+
+- [Wallet integration helper](../../frontend/lib/wallet.ts)
+- [Wallet connect component](../../frontend/components/WalletConnect.tsx)
+- [Architecture security notes](../architecture.md#security)


### PR DESCRIPTION
## Summary
- Adds `docs/adr/` with three MADR-style architecture decision records
- Documents why GreenPay uses Stellar/Soroban over EVM
- Documents direct-to-wallet payments over platform custody
- Documents wallet-as-identity authentication with Freighter as the initial wallet

## Validation
- `git diff --check`

closes #224 