### PR TITLE
ci: upload backend coverage artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
       - run: npm run lint
+      - run: npm test -- --coverage
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-coverage-lcov
+          path: backend/coverage/lcov.info
+          retention-days: 7
 
   contracts:
     name: Soroban Contract (Rust)


### PR DESCRIPTION
Closes #146

## Changes
- Run backend Jest with --coverage in CI
- Upload ackend/coverage/lcov.info as a 7-day artifact on every backend run

## Testing
- Not run, per request