### PR TITLE
[DevOps] Add dependabot configuration for all package ecosystems (Issue #215)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "npm"
+    directory: "/mobile"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "mobile"
+
+  - package-ecosystem: "npm"
+    directory: "/extension"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "extension"
+
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "contracts"
+
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## Summary
Add Dependabot configuration to automate dependency updates across all package ecosystems in the monorepo.

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Smart contract change

## Related Issue
Closes #215

## Changes
Adds \.github/dependabot.yml\ with weekly update schedules for:

| Ecosystem | Directories |
|-----------|-------------|
| npm | \/backend\, \/frontend\, \/mobile\, \/extension\ |
| cargo | \/contracts\ |
| docker | \/backend\, \/frontend\ |

Each ecosystem has its own label set for easy filtering. A maximum of 10 open PRs per ecosystem prevents overwhelming the queue.

## Testing
- [x] Configuration follows the Dependabot v2 schema (validated against GitHub docs)
- [ ] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [ ] Docs updated if needed