### PR TITLE
Harden backend CORS policy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,7 @@ PORT=4000
 NODE_ENV=development
 STELLAR_NETWORK=testnet
 HORIZON_URL=https://horizon-testnet.stellar.org
-ALLOWED_ORIGINS=http://localhost:3000
+ALLOWED_ORIGINS=https://greenpay.app,https://www.greenpay.app,https://stellar-greenpay.app,https://www.stellar-greenpay.app,http://localhost:3000,http://127.0.0.1:3000
 CONTRACT_ID=
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/greenpay
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,8 @@
       "devDependencies": {
         "eslint": "^8.57.0",
         "jest": "^30.3.0",
-        "nodemon": "^3.1.2"
+        "nodemon": "^3.1.2",
+        "supertest": "^7.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -80,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1381,6 +1381,19 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1417,6 +1430,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1943,7 +1966,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2058,6 +2080,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -2416,7 +2445,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2722,6 +2750,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2770,6 +2808,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2906,6 +2951,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/doctrine": {
@@ -3117,7 +3173,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3443,6 +3498,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3640,6 +3702,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -5761,7 +5841,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -6765,6 +6844,65 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/src/middleware/corsPolicy.js
+++ b/backend/src/middleware/corsPolicy.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const cors = require("cors");
+
+const DEFAULT_ALLOWED_ORIGINS = Object.freeze([
+  "https://greenpay.app",
+  "https://www.greenpay.app",
+  "https://stellar-greenpay.app",
+  "https://www.stellar-greenpay.app",
+  "http://localhost:3000",
+  "http://127.0.0.1:3000",
+]);
+
+function parseOrigins(value) {
+  return String(value || "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function getAllowedOrigins(value = process.env.ALLOWED_ORIGINS) {
+  const configuredOrigins = parseOrigins(value);
+  const origins = configuredOrigins.length > 0
+    ? configuredOrigins
+    : DEFAULT_ALLOWED_ORIGINS;
+
+  return [...new Set(origins)];
+}
+
+function rejectDisallowedOrigins(allowedOrigins = getAllowedOrigins()) {
+  const allowed = new Set(allowedOrigins);
+
+  return (req, res, next) => {
+    const { origin } = req.headers;
+
+    if (!origin || allowed.has(origin)) {
+      return next();
+    }
+
+    return res.status(403).json({ error: "Origin not allowed" });
+  };
+}
+
+function createCorsOptions(allowedOrigins = getAllowedOrigins()) {
+  const allowed = new Set(allowedOrigins);
+
+  return {
+    origin(origin, callback) {
+      if (!origin) {
+        return callback(null, false);
+      }
+
+      return callback(null, allowed.has(origin));
+    },
+    credentials: false,
+    methods: ["GET", "POST", "PATCH"],
+  };
+}
+
+function createCorsMiddleware(allowedOrigins = getAllowedOrigins()) {
+  return [
+    rejectDisallowedOrigins(allowedOrigins),
+    cors(createCorsOptions(allowedOrigins)),
+  ];
+}
+
+module.exports = {
+  DEFAULT_ALLOWED_ORIGINS,
+  createCorsMiddleware,
+  createCorsOptions,
+  getAllowedOrigins,
+  rejectDisallowedOrigins,
+};

--- a/backend/src/middleware/corsPolicy.test.js
+++ b/backend/src/middleware/corsPolicy.test.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const express = require("express");
+const request = require("supertest");
+const { createCorsMiddleware, getAllowedOrigins } = require("./corsPolicy");
+
+function buildApp(allowedOrigins = ["https://greenpay.app", "http://localhost:3000"]) {
+  const app = express();
+  app.use(...createCorsMiddleware(allowedOrigins));
+  app.get("/health", (_req, res) => res.status(200).json({ ok: true }));
+  return app;
+}
+
+describe("CORS policy", () => {
+  test("rejects a random origin with 403 and no CORS headers", async () => {
+    const res = await request(buildApp())
+      .get("/health")
+      .set("Origin", "https://evil.com");
+
+    expect(res.status).toBe(403);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+    expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+
+  test("rejects a random preflight origin with 403 and no CORS headers", async () => {
+    const res = await request(buildApp())
+      .options("/health")
+      .set("Origin", "https://evil.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).toBe(403);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+    expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+
+  test("allows a configured production origin without credentials", async () => {
+    const res = await request(buildApp())
+      .get("/health")
+      .set("Origin", "https://greenpay.app");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe("https://greenpay.app");
+    expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+
+  test("uses only configured origins when ALLOWED_ORIGINS is provided", () => {
+    expect(getAllowedOrigins("https://app.example.com, http://localhost:3000")).toEqual([
+      "https://app.example.com",
+      "http://localhost:3000",
+    ]);
+  });
+
+  test("defaults to production and local development origins", () => {
+    expect(getAllowedOrigins("")).toEqual(
+      expect.arrayContaining([
+        "https://greenpay.app",
+        "https://www.greenpay.app",
+        "https://stellar-greenpay.app",
+        "https://www.stellar-greenpay.app",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+      ]),
+    );
+  });
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,7 +4,6 @@
 "use strict";
 
 const express   = require("express");
-const cors      = require("cors");
 const helmet    = require("helmet");
 const morgan    = require("morgan");
 const rateLimit = require("express-rate-limit");
@@ -14,6 +13,7 @@ const { startTurretsServer } = require("./services/turrets");
 const http = require("http");
 const { Server } = require("socket.io");
 const { startIndexer } = require("./services/indexerService");
+const { createCorsMiddleware, getAllowedOrigins } = require("./middleware/corsPolicy");
 
 const app  = express();
 const PORT = process.env.PORT || 4000;
@@ -23,16 +23,14 @@ app.use(helmet());
 app.use(morgan("dev"));
 app.use(express.json({ limit: "20kb" }));
 
-const origins = (process.env.ALLOWED_ORIGINS || "http://localhost:3000").split(",").map(o => o.trim());
-app.use(cors({
-  origin: (origin, cb) => (!origin || origins.includes(origin)) ? cb(null, true) : cb(new Error("CORS blocked")),
-  methods: ["GET", "POST", "PATCH"],
-}));
+const origins = getAllowedOrigins();
+app.use(...createCorsMiddleware(origins));
 
 const io = new Server(server, {
   cors: {
     origin: origins,
-    methods: ["GET", "POST"]
+    methods: ["GET", "POST"],
+    credentials: false,
   }
 });
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 150, standardHeaders: true, legacyHeaders: false }));
@@ -51,6 +49,7 @@ app.use("/api/ratings",        require("./routes/ratings"));
 
 app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
 app.use((err, req, res, next) => {
+  void next;
   console.error("[Error]", err.message);
   res.status(err.status || 500).json({ error: err.message || "Internal server error" });
 });


### PR DESCRIPTION
## Summary
- Adds an explicit backend CORS allowlist for production and local development origins
- Rejects disallowed origins with `403` before CORS headers are applied
- Disables credentialed CORS responses for public API and Socket.IO CORS config
- Adds regression coverage for `https://evil.com` requests and preflights

## Validation
- `npm ci`
- `npm run test -- --runTestsByPath src/middleware/corsPolicy.test.js`
- `npx eslint src/server.js src/middleware/corsPolicy.js src/middleware/corsPolicy.test.js`



closes #234 