### PR TITLE
ci: add secret scanning workflow

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,29 @@
+name: Secret Scanning
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan for hardcoded secrets
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_VERSION: 8.30.1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,32 @@
+title = "Stellar GreenPay secret scanning"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Generated distributable archives are not source files to scan."
+paths = [
+  '''^extension/greenpay-extension\.zip$''',
+]
+
+[[allowlists]]
+description = "Environment templates contain placeholder-only values for contributors."
+condition = "AND"
+paths = [
+  '''(^|/)\.env\.example$''',
+]
+regexes = [
+  '''(?i)(yourdomain\.com|YOUR_PUBLIC_ADDRESS|YOUR_|PLACEHOLDER|example(?:\.com)?|localhost|testnet|postgres:postgres)''',
+  '''^$''',
+]
+
+[[allowlists]]
+description = "Automated tests and mocks use deterministic dummy identifiers."
+condition = "AND"
+paths = [
+  '''(^|/)(__tests__|__mocks__|e2e|test_snapshots)(/|$)''',
+  '''\.(test|spec)\.(js|ts|tsx)$''',
+]
+regexes = [
+  '''(?i)(mock|dummy|fixture|example|test|aaaaaaaa|bbbbbbbb|cccccccc)''',
+]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). All skill levels welcome!
 
 Please note that this project is governed by a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold its terms.
 
+### Secret Scanning
+
+Every push and every pull request to `main` runs Gitleaks with the repo-local `.gitleaks.toml` config. Any detected secret fails CI, so keep real credentials out of source control; use `.env` files locally and GitHub encrypted secrets for CI/deployment values. The allowlist only covers generated archives, env templates, and deterministic test fixtures.
+
 ## 🗺 Roadmap
 
 See [ROADMAP.md](ROADMAP.md) for planned features.


### PR DESCRIPTION
## Summary
- Adds a Gitleaks workflow for pushes to `main`/`develop`, pull requests to `main`, and manual runs.
- Adds a repo-local `.gitleaks.toml` that extends the default Gitleaks rules and only allowlists generated archives, environment templates, and deterministic test fixtures.
- Documents the secret-scanning workflow and expected secret handling in the README.

Closes #218

## Testing
- Workflow YAML parsed locally with Ruby YAML
- Gitleaks TOML parsed locally with Python tomllib