### PR TITLE
devops: add docker hot reload override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,14 @@ cd backend && npm run dev   # → http://localhost:4000
 cd frontend && npm run dev  # → http://localhost:3000
 ```
 
+Or run both services with Docker hot reload:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+The Docker override watches backend changes through `backend/src` with Nodemon and runs the frontend Next.js dev server with polling enabled, so source edits are picked up without rebuilding images.
+
 ### 🎯 Make Your First Testnet Donation
 
 1. Open `http://localhost:3000` in your browser.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ cd backend && npm run dev
 # → http://localhost:4000
 ```
 
+### Docker Hot-Reload Development
+
+Use the development override when you want frontend and backend source edits to refresh inside Docker without rebuilding:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+The override mounts `backend/src` directly into the API container and runs Nodemon in legacy watch mode for Docker Desktop file-event reliability. It mounts the frontend workspace into the Next.js container, keeps container-owned `node_modules`/`.next` directories, and enables polling for Next/Webpack watchers.
+
 ---
 
 ## 🔑 Environment Variables

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "main": "src/server.js",
   "scripts": {
     "dev": "nodemon src/server.js",
+    "dev:docker": "nodemon --legacy-watch --watch src src/server.js",
     "start": "node src/server.js",
     "lint": "eslint src/**/*.js",
     "test": "jest --runInBand"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  frontend:
+    command: npm run dev:docker
+    environment:
+      - WATCHPACK_POLLING=true
+      - CHOKIDAR_USEPOLLING=true
+      - NEXT_TELEMETRY_DISABLED=1
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+
+  backend:
+    command: npm run dev:docker
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - CHOKIDAR_INTERVAL=500
+    volumes:
+      - ./backend/src:/app/src
+      - ./backend/package.json:/app/package.json:ro
+      - ./backend/package-lock.json:/app/package-lock.json:ro
+      - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,10 +27,6 @@ services:
       - NEXT_PUBLIC_STELLAR_NETWORK=testnet
       - NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
       - NEXT_PUBLIC_API_URL=http://localhost:4000
-    volumes:
-      - ./frontend:/app
-      - /app/node_modules
-      - /app/.next
     depends_on:
       - backend
     command: npm run dev
@@ -48,9 +44,6 @@ services:
       - HORIZON_URL=https://horizon-testnet.stellar.org
       - ALLOWED_ORIGINS=http://localhost:3000
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/greenpay
-    volumes:
-      - ./backend:/app
-      - /app/node_modules
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:docker": "next dev --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Summary
- Adds `docker-compose.dev.yml` for explicit frontend/backend hot reload.
- Runs backend with Nodemon legacy watch and frontend with Next dev bound to Docker.
- Documents the Docker hot-reload command in README and CONTRIBUTING.

Closes #216

## Testing
- `ruby -e 'require "yaml"; YAML.load_file("docker-compose.yml"); YAML.load_file("docker-compose.dev.yml"); puts "compose yaml ok"'`
- Docker compose config was not run locally because Docker is not installed in this environment.