### PR TITLE
feat: add Kubernetes manifests for production deployment

### DIFF
--- a/helm/greenpay/Chart.yaml
+++ b/helm/greenpay/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: greenpay
+description: Helm chart for Stellar-GreenPay production deployment
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/greenpay/templates/backend.yaml
+++ b/helm/greenpay/templates/backend.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: {{ .Values.backend.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.backend.port }}
+          envFrom:
+            - configMapRef:
+                name: greenpay-config
+            - secretRef:
+                name: greenpay-secrets
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.backend.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-svc
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: {{ .Values.backend.port }}
+      targetPort: {{ .Values.backend.port }}

--- a/helm/greenpay/templates/configmap.yaml
+++ b/helm/greenpay/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: greenpay-config
+  namespace: {{ .Values.namespace }}
+data:
+  NODE_ENV: "production"
+  PORT: {{ .Values.backend.port | quote }}
+  STELLAR_NETWORK: {{ .Values.config.stellarNetwork }}
+  HORIZON_URL: {{ .Values.config.horizonUrl }}
+  ALLOWED_ORIGINS: "https://{{ .Values.ingress.host }}"
+  APP_URL: "http://frontend-svc:{{ .Values.frontend.port }}"
+  EMAIL_FROM: {{ .Values.config.emailFrom | quote }}
+  CONTRACT_ID: {{ .Values.config.contractId | quote }}
+  NEXT_PUBLIC_STELLAR_NETWORK: {{ .Values.config.stellarNetwork }}
+  NEXT_PUBLIC_HORIZON_URL: {{ .Values.config.horizonUrl }}
+  NEXT_PUBLIC_SOROBAN_RPC_URL: {{ .Values.config.sorobanRpcUrl }}
+  NEXT_PUBLIC_API_URL: "http://backend-svc:{{ .Values.backend.port }}"
+  NEXT_PUBLIC_CONTRACT_ID: {{ .Values.config.contractId | quote }}
+  NEXT_PUBLIC_USDC_ISSUER: {{ .Values.config.usdcIssuer | quote }}

--- a/helm/greenpay/templates/frontend.yaml
+++ b/helm/greenpay/templates/frontend.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: {{ .Values.frontend.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.frontend.port }}
+          envFrom:
+            - configMapRef:
+                name: greenpay-config
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.frontend.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-svc
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: {{ .Values.frontend.port }}
+      targetPort: {{ .Values.frontend.port }}

--- a/helm/greenpay/templates/ingress.yaml
+++ b/helm/greenpay/templates/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: greenpay-ingress
+  namespace: {{ .Values.namespace }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend-svc
+                port:
+                  number: {{ .Values.backend.port }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-svc
+                port:
+                  number: {{ .Values.frontend.port }}

--- a/helm/greenpay/templates/namespace.yaml
+++ b/helm/greenpay/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}

--- a/helm/greenpay/templates/postgres.yaml
+++ b/helm/greenpay/templates/postgres.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: {{ .Values.namespace }}
+spec:
+  serviceName: postgres-svc
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: greenpay-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: greenpay-secrets
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: greenpay-secrets
+                  key: POSTGRES_DB
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres", "-d", "greenpay"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-svc
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: postgres
+  clusterIP: None
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/helm/greenpay/templates/secret.yaml
+++ b/helm/greenpay/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: greenpay-secrets
+  namespace: {{ .Values.namespace }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.secrets.postgresUser | quote }}
+  POSTGRES_PASSWORD: {{ .Values.secrets.postgresPassword | quote }}
+  POSTGRES_DB: {{ .Values.secrets.postgresDb | quote }}
+  DATABASE_URL: "postgres://{{ .Values.secrets.postgresUser }}:{{ .Values.secrets.postgresPassword }}@postgres-svc:5432/{{ .Values.secrets.postgresDb }}"
+  RESEND_API_KEY: {{ .Values.secrets.resendApiKey | quote }}
+  ADMIN_API_KEY: {{ .Values.secrets.adminApiKey | quote }}

--- a/helm/greenpay/values.yaml
+++ b/helm/greenpay/values.yaml
@@ -1,0 +1,34 @@
+namespace: greenpay
+
+backend:
+  image: greenpay/backend:latest
+  replicas: 2
+  port: 4000
+
+frontend:
+  image: greenpay/frontend:latest
+  replicas: 2
+  port: 3000
+
+postgres:
+  image: postgres:16-alpine
+  storage: 5Gi
+
+config:
+  stellarNetwork: testnet
+  horizonUrl: https://horizon-testnet.stellar.org
+  sorobanRpcUrl: https://soroban-testnet.stellar.org
+  contractId: ""
+  usdcIssuer: ""
+  emailFrom: "GreenPay <updates@yourdomain.com>"
+
+secrets:
+  postgresUser: postgres
+  postgresPassword: changeme
+  postgresDb: greenpay
+  resendApiKey: ""
+  adminApiKey: ""
+
+ingress:
+  host: greenpay.local
+  className: nginx

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: greenpay
+  labels:
+    app: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: greenpay/backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4000
+          envFrom:
+            - configMapRef:
+                name: greenpay-config
+            - secretRef:
+                name: greenpay-secrets
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-svc
+  namespace: greenpay
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 4000
+      targetPort: 4000

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: greenpay-config
+  namespace: greenpay
+data:
+  # Shared
+  NODE_ENV: "production"
+  # Backend
+  PORT: "4000"
+  STELLAR_NETWORK: "testnet"
+  HORIZON_URL: "https://horizon-testnet.stellar.org"
+  ALLOWED_ORIGINS: "https://greenpay.app,http://localhost:3000"
+  APP_URL: "http://frontend-svc:3000"
+  EMAIL_FROM: "GreenPay <updates@yourdomain.com>"
+  CONTRACT_ID: ""
+  # Frontend
+  NEXT_PUBLIC_STELLAR_NETWORK: "testnet"
+  NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org"
+  NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+  NEXT_PUBLIC_API_URL: "http://backend-svc:4000"
+  NEXT_PUBLIC_CONTRACT_ID: ""
+  NEXT_PUBLIC_USDC_ISSUER: ""

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: greenpay
+  labels:
+    app: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: greenpay/frontend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: greenpay-config
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-svc
+  namespace: greenpay
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: greenpay-ingress
+  namespace: greenpay
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: greenpay.local
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend-svc
+                port:
+                  number: 4000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-svc
+                port:
+                  number: 3000

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: greenpay
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - postgres.yaml
+  - backend.yaml
+  - frontend.yaml
+  - ingress.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: greenpay

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: greenpay
+  labels:
+    app: postgres
+spec:
+  serviceName: postgres-svc
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: greenpay-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: greenpay-secrets
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: greenpay-secrets
+                  key: POSTGRES_DB
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres", "-d", "greenpay"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-svc
+  namespace: greenpay
+spec:
+  selector:
+    app: postgres
+  clusterIP: None  # Headless service for StatefulSet
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: greenpay-secrets
+  namespace: greenpay
+type: Opaque
+# Values are base64-encoded placeholders. Replace before applying.
+# echo -n 'value' | base64
+stringData:
+  POSTGRES_USER: "postgres"
+  POSTGRES_PASSWORD: "changeme"
+  POSTGRES_DB: "greenpay"
+  DATABASE_URL: "postgres://postgres:changeme@postgres-svc:5432/greenpay"
+  RESEND_API_KEY: ""
+  ADMIN_API_KEY: ""


### PR DESCRIPTION
## Summary

Implements [#213](https://github.com/Emmy123222/Stellar-GreenPay/issues/213) — adds full Kubernetes production deployment support.

## Changes

### `k8s/` (plain manifests — `kubectl apply -k k8s/`)
| File | Purpose |
|------|---------|
| `namespace.yaml` | `greenpay` namespace |
| `configmap.yaml` | Non-secret env vars (Stellar network, URLs, app config) |
| `secret.yaml` | DB credentials, RESEND_API_KEY, ADMIN_API_KEY (placeholders) |
| `postgres.yaml` | StatefulSet with 5Gi PVC + headless Service |
| `backend.yaml` | Deployment (2 replicas) + ClusterIP Service on port 4000 |
| `frontend.yaml` | Deployment (2 replicas) + ClusterIP Service on port 3000 |
| `ingress.yaml` | nginx Ingress: `/api` → backend, `/` → frontend |
| `kustomization.yaml` | Enables `kubectl apply -k k8s/` |

### `helm/greenpay/` (bonus Helm chart)
Full parameterised Helm chart with `values.yaml` for all configurable settings.

## How to deploy (minikube)

```bash
# Plain kustomize
kubectl apply -k k8s/

# Or Helm
helm install greenpay ./helm/greenpay
```

## Acceptance Criteria
- [x] `kubectl apply -k k8s/` deploys a functional cluster
- [x] ConfigMap holds non-secret vars; Secret holds credentials
- [x] PostgreSQL StatefulSet with PersistentVolumeClaim
- [x] Helm chart bonus included

Closes #213