### PR TITLE
feat(api): add /api/v1 versioning with legacy redirect

### DIFF
--- a/backend/src/routes/csrf.test.js
+++ b/backend/src/routes/csrf.test.js
@@ -6,8 +6,8 @@ const app = require("../server");
 describe("CSRF protection", () => {
   const agent = request.agent(app);
 
-  it("returns a CSRF token from GET /api/csrf-token", async () => {
-    const res = await agent.get("/api/csrf-token").expect(200);
+  it("returns a CSRF token from GET /api/v1/csrf-token", async () => {
+    const res = await agent.get("/api/v1/csrf-token").expect(200);
     expect(res.body).toEqual(expect.objectContaining({ success: true }));
     expect(typeof res.body.csrfToken).toBe("string");
     expect(res.body.csrfToken.length).toBeGreaterThan(0);
@@ -15,7 +15,7 @@ describe("CSRF protection", () => {
 
   it("rejects mutating requests without an X-CSRF-Token header", async () => {
     const res = await agent
-      .post("/api/ratings")
+      .post("/api/v1/ratings")
       .send({ projectId: "project-1", donorAddress: "GA123456789012345678901234567890123456789012345678901234", rating: 5 })
       .expect(403);
 
@@ -23,11 +23,11 @@ describe("CSRF protection", () => {
   });
 
   it("allows mutating requests when a valid X-CSRF-Token header is provided", async () => {
-    const tokenResponse = await agent.get("/api/csrf-token").expect(200);
+    const tokenResponse = await agent.get("/api/v1/csrf-token").expect(200);
     const token = tokenResponse.body.csrfToken;
 
     const res = await agent
-      .post("/api/ratings")
+      .post("/api/v1/ratings")
       .set("X-CSRF-Token", token)
       .send({ projectId: "project-1", donorAddress: "GA123456789012345678901234567890123456789012345678901234", rating: 5 });
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,7 +4,6 @@
 "use strict";
 
 const express   = require("express");
-const cors      = require("cors");
 const cookieParser = require("cookie-parser");
 const csurf     = require("csurf");
 const helmet    = require("helmet");
@@ -46,13 +45,6 @@ app.use(csurf({
   ignoreMethods: ["GET", "HEAD", "OPTIONS"],
 }));
 
-const origins = (process.env.ALLOWED_ORIGINS || "http://localhost:3000").split(",").map(o => o.trim());
-app.use(cors({
-  origin: (origin, cb) => (!origin || origins.includes(origin)) ? cb(null, true) : cb(new Error("CORS blocked")),
-  credentials: true,
-  methods: ["GET", "POST", "PATCH", "OPTIONS"],
-  allowedHeaders: ["Content-Type", "X-CSRF-Token"],
-}));
 const origins = getAllowedOrigins();
 app.use(...createCorsMiddleware(origins));
 
@@ -66,22 +58,42 @@ const io = new Server(server, {
 app.set("io", io);
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 150, standardHeaders: true, legacyHeaders: false }));
 
-app.get("/api/csrf-token", (req, res) => {
+// ── API versioning ───────────────────────────────────────────────────────────
+// All routes are served under the `/api/v1` prefix. Legacy unversioned `/api/*`
+// requests are redirected to their `/api/v1/*` equivalent with a `Deprecation`
+// header so existing clients keep working. See docs/api.md for the policy.
+const API_V1 = "/api/v1";
+
+app.get(`${API_V1}/csrf-token`, (req, res) => {
   res.json({ success: true, csrfToken: req.csrfToken() });
 });
 
-app.use("/health",        require("./routes/health"));
-app.use("/api/projects",  require("./routes/projects"));
-app.use("/api/donations", require("./routes/donations"));
-app.use("/api/profiles",  require("./routes/profiles"));
-app.use("/api/leaderboard", require("./routes/leaderboard"));
-app.use("/api/updates",        require("./routes/updates"));
-app.use("/api/subscriptions",  require("./routes/subscriptions"));
-app.use("/api/jobs",           require("./routes/jobs"));
-app.use("/api/stats",          require("./routes/stats"));
-app.use("/api/impact",         require("./routes/impact"));
-app.use("/api/ratings",        require("./routes/ratings"));
-app.use("/api/notifications",  require("./routes/notifications"));
+app.use("/health",                  require("./routes/health"));
+app.use(`${API_V1}/projects`,       require("./routes/projects"));
+app.use(`${API_V1}/donations`,      require("./routes/donations"));
+app.use(`${API_V1}/profiles`,       require("./routes/profiles"));
+app.use(`${API_V1}/leaderboard`,    require("./routes/leaderboard"));
+app.use(`${API_V1}/updates`,        require("./routes/updates"));
+app.use(`${API_V1}/subscriptions`,  require("./routes/subscriptions"));
+app.use(`${API_V1}/jobs`,           require("./routes/jobs"));
+app.use(`${API_V1}/stats`,          require("./routes/stats"));
+app.use(`${API_V1}/impact`,         require("./routes/impact"));
+app.use(`${API_V1}/ratings`,        require("./routes/ratings"));
+app.use(`${API_V1}/notifications`,  require("./routes/notifications"));
+
+// Legacy unversioned routes → redirect to /api/v1 with a deprecation notice.
+app.use("/api", (req, res, next) => {
+  // Already-versioned and Swagger UI requests are handled elsewhere.
+  if (req.path === "/v1" || req.path.startsWith("/v1/") ||
+      req.path === "/docs" || req.path.startsWith("/docs/")) {
+    return next();
+  }
+  res.set("Deprecation", "true");
+  res.set("Link", `<${API_V1}>; rel="successor-version"`);
+  // 308 preserves the request method and body for non-GET clients.
+  // req.url is relative to the "/api" mount and retains the query string.
+  return res.redirect(308, `${API_V1}${req.url}`);
+});
 
 app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
 app.use((err, req, res, next) => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,28 @@ All responses: `{ "success": true, "data": {...} }` or `{ "error": "..." }`
 
 ---
 
+## Versioning
+
+All API routes are served under a version prefix: **`/api/v1`**. The version
+prefix lets us ship breaking changes in a future `/api/v2` without disrupting
+existing clients.
+
+**Policy**
+
+- Resource routes live under `/api/v1/<resource>` (e.g. `/api/v1/projects`).
+- `/health` is unversioned (infrastructure/liveness check).
+- New non-breaking fields may be added to a version without a bump. Breaking
+  changes (removing/renaming fields, changing semantics) introduce a new
+  version (`/api/v2`) and the previous version is supported until deprecated.
+- **Legacy redirect:** unversioned `/api/v1/*` requests are answered with a
+  `308 Permanent Redirect` to their `/api/v1/*` equivalent and carry a
+  `Deprecation: true` header plus a
+  `Link: </api/v1>; rel="successor-version"` header. The `308` status
+  preserves the HTTP method and body, so existing `POST`/`PATCH` clients keep
+  working. New clients should call `/api/v1` directly.
+
+---
+
 ## Health
 `GET /health` — Server status check.
 
@@ -15,8 +37,8 @@ All responses: `{ "success": true, "data": {...} }` or `{ "error": "..." }`
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/projects` | List projects (`?category=&status=active&limit=50`) |
-| GET | `/api/projects/:id` | Get single project |
+| GET | `/api/v1/projects` | List projects (`?category=&status=active&limit=50`) |
+| GET | `/api/v1/projects/:id` | Get single project |
 
 ### Project object
 ```json
@@ -44,11 +66,11 @@ All responses: `{ "success": true, "data": {...} }` or `{ "error": "..." }`
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/donations` | Record a donation after on-chain tx |
-| GET | `/api/donations/project/:id` | Donations for a project (`?limit=20`) |
-| GET | `/api/donations/donor/:publicKey` | A donor's full history |
+| POST | `/api/v1/donations` | Record a donation after on-chain tx |
+| GET | `/api/v1/donations/project/:id` | Donations for a project (`?limit=20`) |
+| GET | `/api/v1/donations/donor/:publicKey` | A donor's full history |
 
-### POST /api/donations
+### POST /api/v1/donations
 ```json
 {
   "projectId": "uuid",
@@ -67,8 +89,8 @@ Donations are **deduplicated by transactionHash** — safe to retry.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/profiles/:publicKey` | Get donor profile + badges |
-| POST | `/api/profiles` | Create or update profile |
+| GET | `/api/v1/profiles/:publicKey` | Get donor profile + badges |
+| POST | `/api/v1/profiles` | Create or update profile |
 
 ---
 
@@ -76,7 +98,7 @@ Donations are **deduplicated by transactionHash** — safe to retry.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/leaderboard` | Top donors by total XLM (`?limit=20`) |
+| GET | `/api/v1/leaderboard` | Top donors by total XLM (`?limit=20`) |
 
 ### Leaderboard entry
 ```json
@@ -96,7 +118,7 @@ Donations are **deduplicated by transactionHash** — safe to retry.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/updates/:projectId` | Updates posted by a project |
+| GET | `/api/v1/updates/:projectId` | Updates posted by a project |
 
 ---
 

--- a/frontend/components/ProjectRating.tsx
+++ b/frontend/components/ProjectRating.tsx
@@ -27,7 +27,7 @@ export default function ProjectRating({ projectId, projectName, donorAddress, on
     setSubmitting(true);
     setError(null);
     try {
-      const res = await csrfFetch(`${process.env.NEXT_PUBLIC_API_URL || "/api"}/ratings`, {
+      const res = await csrfFetch(`${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/ratings`, {
         method: "POST",
         body: JSON.stringify({ projectId, donorAddress, rating, review }),
       });

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -20,6 +20,16 @@ const api = axios.create({
   withCredentials: true,
 });
 
+// All API routes are served under the versioned `/api/v1` prefix (issue #204).
+// Rewrite `/api/*` request paths to `/api/v1/*` from a single place so every
+// helper below stays on the unversioned path string.
+api.interceptors.request.use((config) => {
+  if (config.url && config.url.startsWith("/api/") && !config.url.startsWith("/api/v1/")) {
+    config.url = config.url.replace(/^\/api\//, "/api/v1/");
+  }
+  return config;
+});
+
 let csrfToken: string | null = null;
 
 async function refreshCsrfToken() {

--- a/frontend/pages/admin/[projectId].tsx
+++ b/frontend/pages/admin/[projectId].tsx
@@ -66,7 +66,7 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
     Promise.all([
       fetchProject(projectId),
       fetchProjectDonations(projectId, 200).then((r) => r.donations),
-      fetch(`${process.env.NEXT_PUBLIC_API_URL || "/api"}/projects/${projectId}/milestones`).then(r => r.json()),
+      fetch(`${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/projects/${projectId}/milestones`).then(r => r.json()),
       fetchProjectMatches(projectId).catch(() => []),
     ])
       .then(([p, d, m, mt]) => {
@@ -151,7 +151,7 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
     if (!project || !newMilestoneTitle.trim()) return;
     setMilestoneActionState("loading");
     try {
-      const res = await csrfFetch(`${process.env.NEXT_PUBLIC_API_URL || "/api"}/projects/${project.id}/milestones`, {
+      const res = await csrfFetch(`${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/projects/${project.id}/milestones`, {
         method: "POST",
         body: JSON.stringify({ title: newMilestoneTitle.trim(), percentage: newMilestonePercentage }),
       });
@@ -185,7 +185,7 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
       const result = await submitTransaction(signedXDR);
       
       // 3. Update backend
-      const res = await csrfFetch(`${process.env.NEXT_PUBLIC_API_URL || "/api"}/projects/${project?.id}/milestones/${milestone.id}/reach`, {
+      const res = await csrfFetch(`${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/projects/${project?.id}/milestones/${milestone.id}/reach`, {
         method: "POST",
         body: JSON.stringify({ transactionHash: result.hash }),
       });

--- a/frontend/pages/api-docs.tsx
+++ b/frontend/pages/api-docs.tsx
@@ -19,7 +19,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Projects",
     method: "GET",
-    path: "/api/projects",
+    path: "/api/v1/projects",
     description: "Fetch all projects with optional filtering",
     example: {
       response: {
@@ -39,7 +39,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Projects",
     method: "GET",
-    path: "/api/projects/:id",
+    path: "/api/v1/projects/:id",
     description: "Fetch a single project by ID",
     example: {
       response: {
@@ -59,7 +59,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Projects",
     method: "POST",
-    path: "/api/projects/:id/matching",
+    path: "/api/v1/projects/:id/matching",
     description: "Create a donation matching offer",
     example: {
       request: {
@@ -85,7 +85,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Projects",
     method: "GET",
-    path: "/api/projects/:id/matching",
+    path: "/api/v1/projects/:id/matching",
     description: "Fetch active matching offers for a project",
     example: {
       response: {
@@ -106,7 +106,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Donations",
     method: "POST",
-    path: "/api/donations",
+    path: "/api/v1/donations",
     description: "Record a donation after blockchain confirmation",
     example: {
       request: {
@@ -132,7 +132,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Donations",
     method: "GET",
-    path: "/api/donations/project/:id/messages",
+    path: "/api/v1/donations/project/:id/messages",
     description: "Fetch donation messages for a project",
     example: {
       response: {
@@ -150,7 +150,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Leaderboard",
     method: "GET",
-    path: "/api/leaderboard",
+    path: "/api/v1/leaderboard",
     description: "Fetch top donors by XLM donated (supports period filtering)",
     example: {
       response: {
@@ -169,7 +169,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Profiles",
     method: "GET",
-    path: "/api/profiles/:publicKey",
+    path: "/api/v1/profiles/:publicKey",
     description: "Fetch a donor profile",
     example: {
       response: {
@@ -187,7 +187,7 @@ const endpoints: ApiEndpoint[] = [
   {
     resource: "Profiles",
     method: "POST",
-    path: "/api/profiles",
+    path: "/api/v1/profiles",
     description: "Create or update a donor profile",
     example: {
       request: {
@@ -353,7 +353,7 @@ export default function ApiDocsPage() {
         </h2>
         <div className="bg-forest-50 p-4 rounded border border-forest-200 overflow-auto">
           <pre className="text-sm text-forest-700 font-mono">{`// Fetch all projects
-const response = await fetch('http://localhost:4000/api/projects');
+const response = await fetch('http://localhost:4000/api/v1/projects');
 const { success, data } = await response.json();
 
 if (success) {
@@ -361,7 +361,7 @@ if (success) {
 }
 
 // Record a donation
-const donationRes = await fetch('http://localhost:4000/api/donations', {
+const donationRes = await fetch('http://localhost:4000/api/v1/donations', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -53,7 +53,7 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         setSavedProjects(allProjects.filter(proj => wishlist.includes(proj.id)));
         
         // Fetch pending rating
-        return fetch(`${process.env.NEXT_PUBLIC_API_URL || "/api"}/ratings/pending?donorAddress=${publicKey}`);
+        return fetch(`${process.env.NEXT_PUBLIC_API_URL || ""}/api/v1/ratings/pending?donorAddress=${publicKey}`);
       })
       .then(r => r?.json())
       .then(res => {

--- a/frontend/pages/donate/[id].tsx
+++ b/frontend/pages/donate/[id].tsx
@@ -462,7 +462,7 @@ export const getServerSideProps: GetServerSideProps<DonatePageProps> = async (ct
     process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 
   try {
-    const res = await fetch(`${apiBase}/api/projects/${id}`);
+    const res = await fetch(`${apiBase}/api/v1/projects/${id}`);
     if (!res.ok) {
       return { props: { project: null, presetAmount } };
     }


### PR DESCRIPTION
Closes #204

## What
Introduces API versioning under the `/api/v1` prefix so future breaking changes can ship as `/api/v2` without disrupting clients.

## Changes
- **Backend (`server.js`)**: All resource routes now mount under `/api/v1/*` (`/health` stays unversioned). Added a legacy `/api/*` → `/api/v1/*` redirect that responds `308` (preserves method + body) with `Deprecation: true` and `Link: </api/v1>; rel="successor-version"`. `/api/v1/csrf-token` is the versioned token endpoint; Swagger UI at `/api/docs` is untouched.
- **Fix**: removed a duplicate `const origins` declaration (bad-merge leftover) that was a hard `SyntaxError` preventing server startup.
- **Frontend**: `lib/api.ts` rewrites `/api/*` → `/api/v1/*` in one request interceptor; direct fetch/csrfFetch calls in `ProjectRating`, `dashboard`, `admin/[projectId]`, `donate/[id]` and the `api-docs` page now use `/api/v1`.
- **Docs**: Added a Versioning section to `docs/api.md` and versioned all endpoint paths.
- **Tests**: `csrf.test.js` updated to versioned endpoints.

## Acceptance criteria
- [x] All routes prefixed with `/api/v1/`
- [x] `/api/*` redirects to `/api/v1/*` with `Deprecation: true`
- [x] Frontend API calls use the versioned prefix
- [x] Versioning policy documented in `docs/api.md`

Local `npm install` fails in this sandbox (registry can't reach `expo-server-sdk-node`), so jest wasn't run locally — `node -c` passes; CI runs the full suite.
