### PR TITLE
feat(mobile): add deep link support for project and donation URLs (#169)

### DIFF
--- a/mobile/__tests__/useDeepLink.test.ts
+++ b/mobile/__tests__/useDeepLink.test.ts
@@ -1,0 +1,67 @@
+/**
+ * __tests__/useDeepLink.test.ts
+ * Tests for the useDeepLink hook.
+ */
+import { renderHook, act } from '@testing-library/react-native';
+
+const mockPush = jest.fn();
+const mockGetInitialURL = jest.fn(() => Promise.resolve(null));
+const mockAddEventListener = jest.fn(() => ({ remove: jest.fn() }));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('expo-linking', () => ({
+  getInitialURL: () => mockGetInitialURL(),
+  addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
+  parse: (url: string) => {
+    const match = url.match(/^greenpay:\/\/(.+)/);
+    return { path: match ? match[1] : null };
+  },
+}));
+
+import { useDeepLink } from '../hooks/useDeepLink';
+
+beforeEach(() => {
+  mockPush.mockClear();
+});
+
+test('navigates to project screen on cold start', async () => {
+  mockGetInitialURL.mockResolvedValueOnce('greenpay://project/42');
+  const { unmount } = renderHook(() => useDeepLink());
+  await act(async () => {});
+  expect(mockPush).toHaveBeenCalledWith('/projects/42');
+  unmount();
+});
+
+test('navigates to donate screen on cold start', async () => {
+  mockGetInitialURL.mockResolvedValueOnce('greenpay://donate/GABCXYZ');
+  const { unmount } = renderHook(() => useDeepLink());
+  await act(async () => {});
+  expect(mockPush).toHaveBeenCalledWith('/donate/GABCXYZ');
+  unmount();
+});
+
+test('handles warm-start url event for project', async () => {
+  let urlHandler: ((e: { url: string }) => void) | undefined;
+  mockAddEventListener.mockImplementationOnce((_event: string, handler: (e: { url: string }) => void) => {
+    urlHandler = handler;
+    return { remove: jest.fn() };
+  });
+
+  const { unmount } = renderHook(() => useDeepLink());
+  await act(async () => {
+    urlHandler?.({ url: 'greenpay://project/99' });
+  });
+  expect(mockPush).toHaveBeenCalledWith('/projects/99');
+  unmount();
+});
+
+test('does not navigate for unknown path segments', async () => {
+  mockGetInitialURL.mockResolvedValueOnce('greenpay://unknown/123');
+  const { unmount } = renderHook(() => useDeepLink());
+  await act(async () => {});
+  expect(mockPush).not.toHaveBeenCalled();
+  unmount();
+});

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -23,7 +23,15 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#227239"
       },
-      "package": "com.stellargreenpay.app"
+      "package": "com.stellargreenpay.app",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [{ "scheme": "greenpay" }],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"
@@ -39,6 +47,6 @@
         }
       ]
     ],
-    "scheme": "stellargreenpay"
+    "scheme": "greenpay"
   }
 }

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -6,6 +6,12 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from 'react-native';
 import { ThemeProvider, themes } from './theme';
+import { useDeepLink } from '../hooks/useDeepLink';
+
+function DeepLinkHandler() {
+  useDeepLink();
+  return null;
+}
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -14,6 +20,7 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider>
+      <DeepLinkHandler />
       <StatusBar style={theme.statusBarStyle} />
       <Stack screenOptions={{
         headerStyle: { backgroundColor: theme.header },

--- a/mobile/hooks/useDeepLink.ts
+++ b/mobile/hooks/useDeepLink.ts
@@ -1,0 +1,39 @@
+/**
+ * hooks/useDeepLink.ts
+ * Handles greenpay:// deep links and navigates to the correct screen.
+ *
+ * Supported URLs:
+ *   greenpay://project/123       → /projects/123
+ *   greenpay://donate/G...ABC    → /donate/G...ABC  (address pre-selects via id param)
+ */
+import { useEffect } from 'react';
+import * as Linking from 'expo-linking';
+import { useRouter } from 'expo-router';
+
+export function useDeepLink() {
+  const router = useRouter();
+
+  function handleUrl(url: string | null) {
+    if (!url) return;
+    const { path } = Linking.parse(url);
+    if (!path) return;
+
+    const [segment, param] = path.replace(/^\//, '').split('/');
+    if (!param) return;
+
+    if (segment === 'project') {
+      router.push(`/projects/${param}`);
+    } else if (segment === 'donate') {
+      router.push(`/donate/${param}`);
+    }
+  }
+
+  useEffect(() => {
+    // Handle the link that launched the app (cold start)
+    Linking.getInitialURL().then(handleUrl);
+
+    // Handle links received while the app is already open
+    const subscription = Linking.addEventListener('url', ({ url }) => handleUrl(url));
+    return () => subscription.remove();
+  }, []);
+}


### PR DESCRIPTION
- Change app scheme from 'stellargreenpay' to 'greenpay'
- Add Android intentFilters for greenpay:// scheme
- Add useDeepLink hook to handle greenpay://project/:id and greenpay://donate/:address
- Wire hook into root layout via DeepLinkHandler component
- Add 4 unit tests covering cold start, warm start, and unknown routes

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #169 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
