### PR TITLE
fix: resolve issues #199, #173, #161, #171

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,26 @@
+name: Mobile Preview Build
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: EAS Preview Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: mobile/package-lock.json
+      - run: npm ci
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: eas build --platform all --profile preview --non-interactive

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,6 @@ JWT_SECRET=
 # Admin login credentials (used by POST /api/admin/login)
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=
+
+# Anthropic Claude API — required for AI project summaries
+ANTHROPIC_API_KEY=

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
+    "pg-boss": "^10.1.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -10,7 +10,7 @@ const pool = require("../db/pool");
 const { logAdminAction } = require("../services/audit");
 const { mapProjectRow, mapProjectMilestoneRow } = require("../services/store");
 const { getOnChainProject, CONTRACT_ID, server, NETWORK_PASSPHRASE } = require("../services/stellar");
-const { generateProjectSummary } = require("../services/claude");
+const { enqueueAISummary } = require("../services/summaryQueue");
 const { Contract, TransactionBuilder } = require("@stellar/stellar-sdk");
 
 const VALID_STATUSES = ["active", "completed", "paused"];
@@ -492,57 +492,23 @@ router.post("/:id/generate-summary", async (req, res, next) => {
       return res.status(403).json({ error: "Only the project owner can generate a summary" });
     }
 
-    let summaryResult;
-    try {
-      summaryResult = await generateProjectSummary({
-        name: project.name,
-        category: project.category,
-        description: project.description,
-      });
-    } catch (err) {
-      if (err.code === "MISSING_API_KEY") {
-        return res.status(503).json({ error: "AI summary feature is not configured on this server" });
-      }
-      const status = err.status && Number.isInteger(err.status) ? err.status : 502;
-      return res.status(status).json({ error: err.message || "Failed to generate summary" });
-    }
-
-    const sourceHash = crypto
-      .createHash("sha256")
-      .update(project.description || "")
-      .digest("hex");
-
-    const updated = await pool.query(
-      `UPDATE projects
-          SET ai_summary              = $1,
-              ai_summary_generated_at = NOW(),
-              ai_summary_model        = $2,
-              ai_summary_source_hash  = $3,
-              updated_at              = NOW()
-        WHERE id = $4
-        RETURNING ai_summary, ai_summary_generated_at, ai_summary_model, ai_summary_source_hash`,
-      [summaryResult.summary, summaryResult.model, sourceHash, req.params.id],
-    );
+    await enqueueAISummary(req.params.id, {
+      name: project.name,
+      category: project.category,
+      description: project.description,
+      adminAddress,
+    });
 
     logAdminAction({
       actor: adminAddress,
-      action: "project.summary.generate",
+      action: "project.summary.enqueued",
       targetType: "project",
       targetId: req.params.id,
-      metadata: { model: summaryResult.model },
+      metadata: {},
       ipAddress: req.ip,
     });
 
-    const row = updated.rows[0];
-    res.json({
-      success: true,
-      data: {
-        aiSummary:            row.ai_summary,
-        aiSummaryGeneratedAt: new Date(row.ai_summary_generated_at).toISOString(),
-        aiSummaryModel:       row.ai_summary_model,
-        aiSummarySourceHash:  row.ai_summary_source_hash,
-      },
-    });
+    res.status(202).json({ success: true, data: { status: "queued" } });
   } catch (e) {
     next(e);
   }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -80,7 +80,10 @@ app.use((err, req, res, next) => {
 
 async function startServer() {
   await runMigrations();
-  
+
+  const { start: startSummaryQueue } = require("./services/summaryQueue");
+  await startSummaryQueue(io);
+
   // Start the indexer service
   startIndexer(io).catch(err => console.error("[Indexer Error]", err.message));
 

--- a/backend/src/services/summaryQueue.js
+++ b/backend/src/services/summaryQueue.js
@@ -1,0 +1,108 @@
+/**
+ * src/services/summaryQueue.js
+ *
+ * pg-boss job queue for async AI summary generation.
+ * Keeps the HTTP request lifecycle decoupled from the Claude API call.
+ */
+"use strict";
+
+const crypto = require("crypto");
+const PgBoss = require("pg-boss");
+const pool = require("../db/pool");
+const { generateProjectSummary } = require("./claude");
+const { logAdminAction } = require("./audit");
+
+const QUEUE = "ai-summary";
+
+let boss = null;
+
+/**
+ * Start the pg-boss scheduler and register the AI-summary worker.
+ * Must be called after database migrations and before the HTTP server starts
+ * accepting requests.
+ *
+ * @param {import('socket.io').Server} io  Socket.IO server instance
+ */
+async function start(io) {
+  const connectionString =
+    process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/greenpay";
+
+  boss = new PgBoss(connectionString);
+
+  boss.on("error", (err) => console.error("[summaryQueue] pg-boss error:", err.message));
+
+  await boss.start();
+
+  await boss.work(QUEUE, { teamSize: 2, teamConcurrency: 1 }, async (job) => {
+    const { projectId, name, category, description, adminAddress } = job.data;
+
+    let summaryResult;
+    try {
+      summaryResult = await generateProjectSummary({ name, category, description });
+    } catch (err) {
+      if (err.code === "MISSING_API_KEY") {
+        // Permanent misconfiguration — log and give up without retrying.
+        console.error("[summaryQueue] ANTHROPIC_API_KEY not set; skipping job", projectId);
+        return;
+      }
+      throw err; // pg-boss will retry according to retryLimit
+    }
+
+    const sourceHash = crypto
+      .createHash("sha256")
+      .update(description || "")
+      .digest("hex");
+
+    const updated = await pool.query(
+      `UPDATE projects
+          SET ai_summary              = $1,
+              ai_summary_generated_at = NOW(),
+              ai_summary_model        = $2,
+              ai_summary_source_hash  = $3,
+              updated_at              = NOW()
+        WHERE id = $4
+        RETURNING ai_summary, ai_summary_generated_at, ai_summary_model`,
+      [summaryResult.summary, summaryResult.model, sourceHash, projectId],
+    );
+
+    const row = updated.rows[0];
+    if (!row) return; // project was deleted while job was queued
+
+    if (io) {
+      io.emit("ai_summary_ready", {
+        projectId,
+        aiSummary:            row.ai_summary,
+        aiSummaryGeneratedAt: new Date(row.ai_summary_generated_at).toISOString(),
+        aiSummaryModel:       row.ai_summary_model,
+      });
+    }
+
+    logAdminAction({
+      actor: adminAddress || "system",
+      action: "project.summary.generated",
+      targetType: "project",
+      targetId: projectId,
+      metadata: { model: summaryResult.model },
+      ipAddress: null,
+    });
+  });
+
+  console.log("[summaryQueue] pg-boss started, worker registered on queue:", QUEUE);
+}
+
+/**
+ * Enqueue an AI summary generation job.
+ *
+ * @param {string} projectId
+ * @param {{ name: string, category: string, description: string, adminAddress?: string }} projectData
+ * @returns {Promise<string>} job ID
+ */
+async function enqueueAISummary(projectId, projectData) {
+  if (!boss) {
+    throw new Error("summaryQueue not started — call start(io) first");
+  }
+  const jobId = await boss.send(QUEUE, { projectId, ...projectData }, { retryLimit: 3, retryDelay: 10 });
+  return jobId;
+}
+
+module.exports = { start, enqueueAISummary };

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -66,11 +66,13 @@ interface ProjectResult {
   id: string;
   name: string;
   category: string;
+  walletAddress?: string;
 }
 
 let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let activeDropdownIndex = -1;
 let dropdownItems: HTMLLIElement[] = [];
+let selectedProjectId: string | null = null;
 
 function debounce(fn: () => void, ms: number) {
   if (searchDebounceTimer !== null) clearTimeout(searchDebounceTimer);
@@ -101,7 +103,15 @@ function renderDropdown(projects: ProjectResult[], dropdown: HTMLUListElement) {
     `;
     li.addEventListener('mousedown', (e) => {
       e.preventDefault();
-      window.open(`https://stellar-greenpay.app/projects/${p.id}`, '_blank');
+      const destInput = document.getElementById('destination') as HTMLInputElement | null;
+      const searchInput = document.getElementById('project-search') as HTMLInputElement | null;
+      if (p.walletAddress && destInput) {
+        destInput.value = p.walletAddress;
+        selectedProjectId = p.id;
+      }
+      if (searchInput) {
+        searchInput.value = p.name;
+      }
       dropdown.classList.add('hidden');
     });
     dropdown.appendChild(li);
@@ -137,6 +147,7 @@ function initProjectSearch() {
 
   input.addEventListener('input', () => {
     const q = input.value.trim();
+    selectedProjectId = null; // user is typing a new search, clear prior selection
     if (q.length < 2) {
       dropdown.classList.add('hidden');
       return;
@@ -171,6 +182,44 @@ function initProjectSearch() {
   input.addEventListener('blur', () => {
     setTimeout(() => dropdown.classList.add('hidden'), 150);
   });
+}
+
+// --- Record donation on backend with exponential-backoff retry ---
+
+async function recordDonation(params: {
+  projectId: string;
+  donorAddress: string;
+  amountXLM: string;
+  currency: string;
+  transactionHash: string;
+  message?: string;
+}): Promise<void> {
+  // 4 attempts with increasing delays: immediate, 500 ms, 1 000 ms, 2 000 ms
+  const delays = [0, 500, 1000, 2000];
+  let lastError: Error | null = null;
+
+  for (let i = 0; i < delays.length; i++) {
+    if (i > 0) await new Promise<void>((r) => setTimeout(r, delays[i]));
+    try {
+      const res = await fetch(`${API_BASE}/api/donations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+      });
+      if (res.ok) return;
+      // 4xx = client error (bad data); retrying won't help
+      if (res.status >= 400 && res.status < 500) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err: any) {
+      // Re-throw immediately on client errors
+      if (err.message?.startsWith('HTTP 4')) throw err;
+      lastError = err;
+    }
+  }
+
+  throw lastError ?? new Error('Failed to record donation after retries');
 }
 
 // --- UI wiring ---
@@ -225,7 +274,29 @@ document.addEventListener('DOMContentLoaded', () => {
       setStatus('Submitting to Horizon testnet…');
       const txHash = await submitTransaction(signedXdr);
 
-      setStatus(`Donation successful! TX: ${txHash.slice(0, 12)}…`);
+      // Capture and reset before the async recording call to prevent double-submit
+      const capturedProjectId = selectedProjectId;
+      selectedProjectId = null;
+
+      if (capturedProjectId) {
+        setStatus('Recording donation…');
+        try {
+          await recordDonation({
+            projectId: capturedProjectId,
+            donorAddress: sourceAddress,
+            amountXLM: amount,
+            currency: 'XLM',
+            transactionHash: txHash,
+            message: memo || undefined,
+          });
+          setStatus(`Donation successful! TX: ${txHash.slice(0, 12)}… (recorded)`);
+        } catch {
+          // The Stellar tx succeeded — don't fail the UX because recording failed
+          setStatus(`Donation successful! TX: ${txHash.slice(0, 12)}… (record failed, tx succeeded)`);
+        }
+      } else {
+        setStatus(`Donation successful! TX: ${txHash.slice(0, 12)}…`);
+      }
     } catch (err: any) {
       const detail =
         err?.response?.data?.extras?.result_codes?.transaction ??

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -36,6 +36,17 @@ npm run android
 npm start
 ```
 
+## Expo Go Preview
+
+Preview builds are generated automatically on every push to `main` via EAS Build.
+
+[![Open in Expo Go](https://img.shields.io/badge/Expo%20Go-Scan%20QR-000?logo=expo)](https://expo.dev/@OWNER/stellar-greenpay)
+
+> Replace `OWNER` with your Expo account username. Add `EXPO_TOKEN` as a GitHub Actions repository secret (Settings → Secrets and variables → Actions) before the first build.
+
+- **Android**: APK (direct install, no Play Store needed)
+- **iOS**: Simulator build (`.app` bundle, not a signed IPA)
+
 ## Shared API Client
 
 The mobile app shares the API client logic with the web frontend. The API functions are located in `lib/api.ts` and are imported from the shared package.

--- a/mobile/app/impact.tsx
+++ b/mobile/app/impact.tsx
@@ -1,10 +1,12 @@
 /**
  * app/impact.tsx
- * My Impact screen - donor stats and history
+ * My Impact screen - donor stats, history, and shareable certificate
  */
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
-import { useEffect, useState } from 'react';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
+import { captureRef } from 'react-native-view-shot';
+import * as Sharing from 'expo-sharing';
 import { useTheme } from './theme';
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:4000';
@@ -26,12 +28,19 @@ interface DonorProfile {
   badges: any[];
 }
 
+interface ImpactStats {
+  co2OffsetKg: number;
+  projectsSupported: number;
+}
+
 export default function ImpactScreen() {
   const { colors } = useTheme();
   const [profile, setProfile] = useState<DonorProfile | null>(null);
   const [donations, setDonations] = useState<Donation[]>([]);
+  const [impactStats, setImpactStats] = useState<ImpactStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [publicKey, setPublicKey] = useState('');
+  const certificateRef = useRef<any>(null);
 
   useEffect(() => {
     const demoKey = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
@@ -41,12 +50,14 @@ export default function ImpactScreen() {
 
   const loadImpactData = async (pk: string) => {
     try {
-      const [profileRes, donationsRes] = await Promise.all([
+      const [profileRes, donationsRes, impactRes] = await Promise.all([
         axios.get(`${API_URL}/api/profiles/${pk}`).catch(() => ({ data: { data: null } })),
         axios.get(`${API_URL}/api/donations/donor/${pk}`).catch(() => ({ data: { data: [] } })),
+        axios.get(`${API_URL}/api/impact/donor/${pk}`).catch(() => ({ data: { data: null } })),
       ]);
       setProfile(profileRes.data.data);
       setDonations(donationsRes.data.data);
+      setImpactStats(impactRes.data.data);
     } catch (error) {
       console.error('Error loading impact data:', error);
     } finally {
@@ -54,52 +65,66 @@ export default function ImpactScreen() {
     }
   };
 
+  const handleShare = async () => {
+    try {
+      const uri = await captureRef(certificateRef, { format: 'png', quality: 1.0 });
+      // Prefix with file:// for Android compatibility
+      const fileUri = uri.startsWith('file://') ? uri : `file://${uri}`;
+      await Sharing.shareAsync(fileUri, {
+        mimeType: 'image/png',
+        dialogTitle: 'Share your impact certificate',
+      });
+    } catch (err) {
+      console.error('Share failed:', err);
+    }
+  };
+
   if (loading) {
     return (
-      <View style={[styles.container, { backgroundColor: colors.background }]}> 
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
         <Text style={[styles.loadingText, { color: colors.secondaryText }]}>Loading your impact...</Text>
       </View>
     );
   }
 
   return (
-    <ScrollView style={[styles.container, { backgroundColor: colors.background }]}> 
-      <View style={[styles.header, { backgroundColor: colors.primary }]}> 
+    <ScrollView style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { backgroundColor: colors.primary }]}>
         <Text style={[styles.title, { color: colors.headerText }]}>My Impact</Text>
         <Text style={[styles.subtitle, { color: colors.headerText }]}>{publicKey.slice(0, 8)}...{publicKey.slice(-4)}</Text>
       </View>
 
       <View style={styles.statsGrid}>
-        <View style={[styles.statCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}> 
+        <View style={[styles.statCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}>
           <Text style={[styles.statIcon, { color: colors.accent }]}>💚</Text>
-          <Text style={[styles.statValue, { color: colors.accent }]}> 
+          <Text style={[styles.statValue, { color: colors.accent }]}>
             {profile ? parseFloat(profile.totalDonatedXLM).toFixed(2) : '0'}
           </Text>
           <Text style={[styles.statLabel, { color: colors.muted }]}>XLM Donated</Text>
         </View>
-        <View style={[styles.statCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}> 
+        <View style={[styles.statCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}>
           <Text style={[styles.statIcon, { color: colors.accent }]}>🌍</Text>
-          <Text style={[styles.statValue, { color: colors.accent }]}> 
+          <Text style={[styles.statValue, { color: colors.accent }]}>
             {profile ? profile.projectsSupported : 0}
           </Text>
           <Text style={[styles.statLabel, { color: colors.muted }]}>Projects</Text>
         </View>
-        <View style={[styles.statCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}> 
+        <View style={[styles.statCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}>
           <Text style={[styles.statIcon, { color: colors.accent }]}>🏆</Text>
-          <Text style={[styles.statValue, { color: colors.accent }]}> 
+          <Text style={[styles.statValue, { color: colors.accent }]}>
             {profile ? profile.badges.length : 0}
           </Text>
           <Text style={[styles.statLabel, { color: colors.muted }]}>Badges</Text>
         </View>
       </View>
 
-      <View style={[styles.historyCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}> 
+      <View style={[styles.historyCard, { backgroundColor: colors.surface, shadowColor: colors.cardShadow, borderColor: colors.cardBorder }]}>
         <Text style={[styles.sectionTitle, { color: colors.primaryText }]}>Donation History</Text>
         {donations.length === 0 ? (
           <Text style={[styles.emptyText, { color: colors.secondaryText }]}>No donations yet</Text>
         ) : (
           donations.map(donation => (
-            <View key={donation.id} style={[styles.donationRow, { borderBottomColor: colors.border }]}> 
+            <View key={donation.id} style={[styles.donationRow, { borderBottomColor: colors.border }]}>
               <View style={styles.donationInfo}>
                 <Text style={[styles.donationProject, { color: colors.primaryText }]}>Project {donation.projectId.slice(0, 8)}</Text>
                 {donation.message && (
@@ -107,12 +132,12 @@ export default function ImpactScreen() {
                 )}
               </View>
               <View style={styles.donationAmount}>
-                <Text style={[styles.amount, { color: colors.accent }]}> 
+                <Text style={[styles.amount, { color: colors.accent }]}>
                   {donation.currency === 'USDC'
                     ? `$${parseFloat(donation.amount).toFixed(2)} USDC`
                     : `${parseFloat(donation.amount).toFixed(2)} XLM`}
                 </Text>
-                <Text style={[styles.date, { color: colors.muted }]}> 
+                <Text style={[styles.date, { color: colors.muted }]}>
                   {new Date(donation.createdAt).toLocaleDateString()}
                 </Text>
               </View>
@@ -120,6 +145,33 @@ export default function ImpactScreen() {
           ))
         )}
       </View>
+
+      {/* Impact Certificate — captured as PNG for sharing */}
+      <View
+        ref={certificateRef}
+        collapsable={false}
+        style={styles.certificateCard}
+      >
+        <Text style={styles.certBrand}>Stellar GreenPay</Text>
+        <Text style={styles.certTitle}>Climate Impact Certificate</Text>
+        <Text style={styles.certRow}>
+          {publicKey.slice(0, 8)}...{publicKey.slice(-4)}
+        </Text>
+        <Text style={styles.certRow}>
+          CO₂ Offset: {impactStats?.co2OffsetKg ?? 0} kg
+        </Text>
+        <Text style={styles.certRow}>
+          Total Donated: {profile ? parseFloat(profile.totalDonatedXLM).toFixed(2) : '0'} XLM
+        </Text>
+      </View>
+
+      <TouchableOpacity
+        onPress={handleShare}
+        disabled={loading}
+        style={styles.shareButton}
+      >
+        <Text style={styles.shareButtonText}>Share Certificate</Text>
+      </TouchableOpacity>
     </ScrollView>
   );
 }
@@ -219,5 +271,40 @@ const styles = StyleSheet.create({
   date: {
     fontSize: 10,
     marginTop: 2,
+  },
+  certificateCard: {
+    margin: 16,
+    padding: 24,
+    borderRadius: 12,
+    backgroundColor: '#227239',
+  },
+  certBrand: {
+    color: '#ffffff',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  certTitle: {
+    color: '#d4edda',
+    fontSize: 14,
+    marginBottom: 16,
+  },
+  certRow: {
+    color: '#ffffff',
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  shareButton: {
+    margin: 16,
+    marginTop: 0,
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: '#227239',
+    alignItems: 'center',
+  },
+  shareButtonText: {
+    color: '#ffffff',
+    fontWeight: 'bold',
+    fontSize: 16,
   },
 });

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,0 +1,15 @@
+{
+  "cli": {
+    "version": ">= 10.0.0"
+  },
+  "build": {
+    "preview": {
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": true
+      }
+    }
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -14,6 +14,8 @@
     "@react-native-async-storage/async-storage": "^1.23.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "axios": "^1.7.0",
+    "expo-sharing": "~12.0.0",
+    "react-native-view-shot": "^3.8.0",
     "expo": "~51.0.0",
     "expo-linking": "~6.3.0",
     "expo-local-authentication": "~14.0.0",


### PR DESCRIPTION
 Summary
  
  Resolves four open issues across the backend, browser extension, and mobile app.

  ---
  [Backend #199] Async AI summary generation via pg-boss job queue

  Problem: POST /api/projects/:id/generate-summary called the Claude API synchronously, blocking the HTTP request
  until Anthropic responded.

  Solution: Added pg-boss (PostgreSQL-backed queue — no new infrastructure needed) as the async layer.

  - New backend/src/services/summaryQueue.js: initialises pg-boss with DATABASE_URL, registers a worker that
  calls Claude, writes the result to the ai_summary column, then emits an ai_summary_ready Socket.IO event.
  - The endpoint now validates ownership, enqueues the job, and returns 202 { status: "queued" } in well under
  500 ms.
  - Worker retries up to 3 times on transient errors; swallows MISSING_API_KEY permanently so a misconfigured
  server doesn't fill the retry queue.
  - Added ANTHROPIC_API_KEY= to .env.example (was missing).

  ---
  [Extension #173] POST /api/donations from popup after successful donation

  Problem: The extension submitted a Stellar transaction but never called the backend to record it.

  Solution: Three additions to extension/src/popup.ts:

  1. When the user selects a project from the search dropdown, its id is stored and its walletAddress is
  pre-filled into the destination field (instead of opening a new tab).
  2. A recordDonation() function POSTs to /api/donations with up to 4 attempts and exponential backoff (immediate
  → 500 ms → 1 000 ms → 2 000 ms). Client-side 4xx errors are not retried.
  3. The Stellar transaction success is never gated on whether recording succeeds — the user sees a clear status
  either way.

  ---
  [Mobile #161] Impact certificate share on iOS and Android

  Problem: The impact screen showed donor stats but had no shareable certificate.

  Solution:

  - Added react-native-view-shot and expo-sharing to mobile/package.json.
  - Extended loadImpactData to also call GET /api/impact/donor/:pk for co2OffsetKg.
  - Added a CertificateCard view (collapsable={false} required for Android capture) containing donor address, CO₂
  offset, total XLM, and platform branding.
  - handleShare() captures the view via captureRef, prepends file:// for Android compatibility, and opens the
  native share sheet as a PNG.
  - "Share Certificate" button is disabled while data is loading.

  ---
  [Mobile #171] Expo preview build via EAS + GitHub Actions

  Problem: No EAS build config, no CI pipeline for the mobile app, no QR code in the README.

  Solution:

  - New mobile/eas.json: preview profile with Android APK (buildType: apk) and iOS simulator (simulator: true).
  Note: distribution: "internal" is intentionally omitted for iOS — ios.simulator: true governs that output.
  - New .github/workflows/mobile.yml: triggers on push to main, uses expo/expo-github-action@v8, and runs eas 
  build --platform all --profile preview --non-interactive. Requires EXPO_TOKEN to be set as a GitHub Actions
  secret.
  - Updated mobile/README.md with an Expo Go preview section and QR badge.

  ---
  Closes

  Closes #199
  Closes #173
  Closes #161
  Closes #171
