### PR TITLE
feat: add E2E and integration tests for leaderboard, projects, and donations

### DIFF
--- a/backend/src/routes/donations.api.test.js
+++ b/backend/src/routes/donations.api.test.js
@@ -1,0 +1,254 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+jest.mock("../middleware/rateLimiter", () => ({
+  createRateLimiter: () => (req, res, next) => next(),
+}));
+
+jest.mock("../services/redis", () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+const pool = require("../db/pool");
+const express = require("express");
+const request = require("supertest");
+const donationsRouter = require("./donations");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  const io = { to: () => ({ emit: jest.fn() }) };
+  app.set("io", io);
+
+  app.use("/api/donations", donationsRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message || "Internal server error" });
+  });
+  return app;
+}
+
+function makePublicKey(char = "A") {
+  return `G${char.repeat(55)}`;
+}
+
+function makeTxHash() {
+  return "a".repeat(64);
+}
+
+function createMockClient(...responses) {
+  const client = {
+    query: jest.fn(),
+    release: jest.fn(),
+  };
+  responses.forEach((response) => {
+    if (response instanceof Error) {
+      client.query.mockRejectedValueOnce(response);
+    } else {
+      client.query.mockResolvedValueOnce(response);
+    }
+  });
+  pool.connect.mockResolvedValue(client);
+  return client;
+}
+
+const MOCK_PROJECT = { id: "proj-1", name: "Test Project" };
+const MOCK_DONATION_ROW = {
+  id: "don-1",
+  project_id: "proj-1",
+  donor_address: makePublicKey(),
+  amount_xlm: 100,
+  amount: 100,
+  currency: "XLM",
+  message: "Great project!",
+  transaction_hash: makeTxHash(),
+  created_at: new Date().toISOString(),
+};
+
+describe("POST /api/donations", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("records a valid donation", async () => {
+    createMockClient(
+      { rows: [MOCK_PROJECT] },
+      { rows: [] },
+      { rows: [MOCK_DONATION_ROW] },
+      { rows: [] },
+      { rows: [] },
+      undefined,
+      { rows: [{ ...MOCK_DONATION_ROW, total_donated_xlm: 100 }] },
+      { rows: [] },
+    );
+
+    const res = await request(app)
+      .post("/api/donations")
+      .send({
+        projectId: "proj-1",
+        donorAddress: makePublicKey(),
+        amountXLM: 100,
+        currency: "XLM",
+        message: "Great project!",
+        transactionHash: makeTxHash(),
+      })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  test("rejects invalid donor address", async () => {
+    const res = await request(app)
+      .post("/api/donations")
+      .send({
+        projectId: "proj-1",
+        donorAddress: "invalid",
+        amountXLM: 100,
+        transactionHash: makeTxHash(),
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Invalid Stellar public key");
+  });
+
+  test("rejects invalid transaction hash", async () => {
+    const res = await request(app)
+      .post("/api/donations")
+      .send({
+        projectId: "proj-1",
+        donorAddress: makePublicKey(),
+        amountXLM: 100,
+        transactionHash: "invalid",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Invalid transaction hash");
+  });
+
+  test("returns 404 for unknown project", async () => {
+    createMockClient({ rows: [] });
+
+    const res = await request(app)
+      .post("/api/donations")
+      .send({
+        projectId: "nonexistent",
+        donorAddress: makePublicKey(),
+        amountXLM: 100,
+        transactionHash: makeTxHash(),
+      })
+      .expect(404);
+
+    expect(res.body.error).toContain("Project not found");
+  });
+
+  test("deduplicates by transaction hash", async () => {
+    createMockClient({ rows: [MOCK_PROJECT] }, { rows: [MOCK_DONATION_ROW] });
+
+    const res = await request(app)
+      .post("/api/donations")
+      .send({
+        projectId: "proj-1",
+        donorAddress: makePublicKey(),
+        amountXLM: 100,
+        transactionHash: makeTxHash(),
+      })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  test("rejects zero amount", async () => {
+    createMockClient({ rows: [MOCK_PROJECT] });
+
+    const res = await request(app)
+      .post("/api/donations")
+      .send({
+        projectId: "proj-1",
+        donorAddress: makePublicKey(),
+        amountXLM: 0,
+        transactionHash: makeTxHash(),
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Invalid amount");
+  });
+
+  test("rejects negative amount", async () => {
+    createMockClient({ rows: [MOCK_PROJECT] });
+
+    const res = await request(app)
+      .post("/api/donations")
+      .send({
+        projectId: "proj-1",
+        donorAddress: makePublicKey(),
+        amountXLM: -50,
+        transactionHash: makeTxHash(),
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Invalid amount");
+  });
+});
+
+describe("GET /api/donations/project/:projectId", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("returns donations for a project", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_DONATION_ROW] });
+
+    const res = await request(app)
+      .get("/api/donations/project/proj-1")
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  test("returns empty array for project with no donations", async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+
+    const res = await request(app)
+      .get("/api/donations/project/proj-1")
+      .expect(200);
+
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe("GET /api/donations/donor/:publicKey", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("returns donations for a donor", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_DONATION_ROW] });
+
+    const res = await request(app)
+      .get(`/api/donations/donor/${makePublicKey()}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  test("rejects invalid donor key", async () => {
+    await request(app)
+      .get("/api/donations/donor/invalid")
+      .expect(400);
+  });
+});

--- a/backend/src/routes/projects.test.js
+++ b/backend/src/routes/projects.test.js
@@ -1,0 +1,182 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+jest.mock("../services/redis", () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+jest.mock("../services/stellar", () => ({
+  getOnChainProject: jest.fn(),
+  CONTRACT_ID: "test-contract",
+  server: {},
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+}));
+
+jest.mock("../services/summaryQueue", () => ({
+  enqueueAISummary: jest.fn(),
+}));
+
+const pool = require("../db/pool");
+const redis = require("../services/redis");
+const express = require("express");
+const request = require("supertest");
+const projectsRouter = require("./projects");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/projects", projectsRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message || "Internal server error" });
+  });
+  return app;
+}
+
+const MOCK_PROJECT_ROW = {
+  id: "proj-1",
+  name: "Test Project",
+  description: "A test climate project",
+  category: "Reforestation",
+  location: "Brazil",
+  wallet_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  goal_xlm: "10000",
+  raised_xlm: "5000",
+  donor_count: 42,
+  co2_offset_kg: 50000,
+  status: "active",
+  verified: true,
+  on_chain_verified: false,
+  tags: ["reforestation", "amazon"],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+describe("GET /api/projects", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    redis.get.mockResolvedValue(null);
+    jest.clearAllMocks();
+  });
+
+  test("returns projects list with default pagination", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_PROJECT_ROW] });
+
+    const res = await request(app).get("/api/projects").expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe("Test Project");
+    expect(res.body.has_more).toBe(false);
+  });
+
+  test("filters by category", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_PROJECT_ROW] });
+
+    await request(app).get("/api/projects?category=Reforestation").expect(200);
+
+    const query = pool.query.mock.calls[0][0];
+    expect(query).toContain("category =");
+  });
+
+  test("filters by verified status", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_PROJECT_ROW] });
+
+    await request(app).get("/api/projects?verified=true").expect(200);
+
+    const query = pool.query.mock.calls[0][0];
+    expect(query).toContain("verified = true");
+  });
+
+  test("filters by status", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_PROJECT_ROW] });
+
+    await request(app).get("/api/projects?status=active").expect(200);
+
+    const query = pool.query.mock.calls[0][0];
+    expect(query).toContain("status =");
+  });
+
+  test("handles search query", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_PROJECT_ROW] });
+
+    await request(app).get("/api/projects?search=amazon").expect(200);
+
+    const query = pool.query.mock.calls[0][0];
+    expect(query).toContain("ILIKE");
+  });
+
+  test("rejects invalid cursor", async () => {
+    await request(app).get("/api/projects?cursor=invalid").expect(400);
+  });
+
+  test("returns cached response when available", async () => {
+    const cached = { success: true, data: [MOCK_PROJECT_ROW], has_more: false };
+    redis.get.mockResolvedValue(cached);
+
+    const res = await request(app).get("/api/projects").expect(200);
+    expect(res.body).toEqual(cached);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  test("respects limit parameter", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_PROJECT_ROW] });
+
+    await request(app).get("/api/projects?limit=5").expect(200);
+
+    const query = pool.query.mock.calls[0][0];
+    expect(query).toContain("LIMIT");
+  });
+});
+
+describe("GET /api/projects/:id", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    redis.get.mockResolvedValue(null);
+    jest.clearAllMocks();
+  });
+
+  test("returns a single project", async () => {
+    pool.query.mockResolvedValue({ rows: [MOCK_PROJECT_ROW] });
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_PROJECT_ROW] });
+    pool.query.mockResolvedValueOnce({ rows: [] }); // campaigns
+    pool.query.mockResolvedValueOnce({ rows: [] }); // milestones
+    pool.query.mockResolvedValueOnce({ rows: [] }); // ratings
+
+    const res = await request(app).get("/api/projects/proj-1").expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.name).toBe("Test Project");
+  });
+
+  test("returns 404 for non-existent project", async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+
+    await request(app).get("/api/projects/nonexistent").expect(404);
+  });
+});
+
+describe("POST /api/projects (admin)", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("rejects unauthenticated requests", async () => {
+    const res = await request(app)
+      .post("/api/projects/admin/register")
+      .send({ name: "Test" });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/frontend/e2e/leaderboard.spec.ts
+++ b/frontend/e2e/leaderboard.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+const MOCK_PUBLIC_KEY = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGLEWZE5BGYTG2XTGQBC3VP";
+const MOCK_PUBLIC_KEY_2 = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+const MOCK_LEADERBOARD = [
+  {
+    rank: 1,
+    publicKey: MOCK_PUBLIC_KEY,
+    displayName: "EcoChampion",
+    totalDonatedXLM: "5000",
+    projectsSupported: 8,
+    topBadge: "earth",
+  },
+  {
+    rank: 2,
+    publicKey: MOCK_PUBLIC_KEY_2,
+    displayName: "GreenDonor",
+    totalDonatedXLM: "1200",
+    projectsSupported: 3,
+    topBadge: "forest",
+  },
+  {
+    rank: 3,
+    publicKey: "GBCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFGH",
+    displayName: "TreeHugger",
+    totalDonatedXLM: "500",
+    projectsSupported: 2,
+    topBadge: "tree",
+  },
+  {
+    rank: 4,
+    publicKey: "GDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFGHIJ",
+    displayName: undefined,
+    totalDonatedXLM: "50",
+    projectsSupported: 1,
+    topBadge: "seedling",
+  },
+];
+
+const ok = (data: unknown) => ({ json: { success: true, data } });
+
+async function mockApi(page: Page) {
+  await page.route("**/api/**", (r: Route) => r.fulfill(ok([])));
+  await page.route("**/horizon-testnet.stellar.org/**", (r) =>
+    r.fulfill({
+      json: {
+        _embedded: { records: [] },
+        balances: [{ asset_type: "native", balance: "500.0000000" }],
+      },
+    }),
+  );
+  await page.route("**/api/leaderboard**", (r) => r.fulfill(ok(MOCK_LEADERBOARD)));
+  await page.route("**/api/stats/global", (r) =>
+    r.fulfill(ok({ totalDonations: 1, totalXLMRaised: "100", totalCO2OffsetKg: 1000 })),
+  );
+  await page.route("**/api/stats/categories", (r) =>
+    r.fulfill(ok([{ category: "Reforestation", count: 1 }])),
+  );
+}
+
+test.describe("Leaderboard page", () => {
+  test("donors are sorted by total XLM descending", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/leaderboard");
+
+    const rows = page.locator(".space-y-2 > div");
+    await expect(rows.first()).toBeVisible();
+
+    const amounts = await rows.evaluateAll((els) =>
+      els
+        .map((el) => {
+          const text = el.querySelector(".font-mono")?.textContent ?? "";
+          const match = text.match(/([\d,.]+)/);
+          return match ? parseFloat(match[1].replace(/,/g, "")) : 0;
+        })
+        .filter((n) => n > 0),
+    );
+
+    for (let i = 1; i < amounts.length; i++) {
+      expect(amounts[i]).toBeLessThanOrEqual(amounts[i - 1]);
+    }
+  });
+
+  test("badge icons appear for correct tiers", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/leaderboard");
+
+    await expect(page.getByText("🌍").first()).toBeVisible();
+    await expect(page.getByText("🌲").first()).toBeVisible();
+    await expect(page.getByText("🌳").first()).toBeVisible();
+    await expect(page.getByText("🌱").first()).toBeVisible();
+  });
+
+  test("clicking a donor name opens their public profile", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/leaderboard");
+
+    const donorLink = page.getByText("EcoChampion").first();
+    await expect(donorLink).toBeVisible();
+    await donorLink.click();
+
+    await expect(page).toHaveURL(new RegExp(MOCK_PUBLIC_KEY));
+  });
+
+  test("shows donor display names", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/leaderboard");
+
+    await expect(page.getByText("EcoChampion")).toBeVisible();
+    await expect(page.getByText("GreenDonor")).toBeVisible();
+    await expect(page.getByText("TreeHugger")).toBeVisible();
+  });
+
+  test("shows fallback address when no display name", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/leaderboard");
+
+    const fourthRow = page.locator(".space-y-2 > div").nth(3);
+    await expect(fourthRow).toBeVisible();
+  });
+
+  test("shows badge tier legend", async ({ page }) => {
+    await mockApi(page);
+    await page.goto("/leaderboard");
+
+    await expect(page.getByText("Impact Badge Tiers")).toBeVisible();
+    await expect(page.getByText("Seedling").first()).toBeVisible();
+    await expect(page.getByText("Earth Guardian").first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for leaderboard page (sorting, badges, navigation)
- Add integration tests for `/api/projects` endpoints with filters and pagination
- Add integration tests for `/api/donations` endpoints with validation and dedup

Closes #186
Closes #143
Closes #141
Closes #140