### PR TITLE
add project service tests, health checks, NFT milestone, and governance UI

### DIFF
--- a/backend/src/routes/health.js
+++ b/backend/src/routes/health.js
@@ -3,14 +3,32 @@
  */
 "use strict";
 const express = require("express");
-const router  = express.Router();
+const router = express.Router();
+const pool = require("../db/pool");
 const indexerService = require("../services/indexerService");
 
-router.get("/", (req, res) => res.json({ 
-  status: "ok", 
-  service: "stellar-greenpay-api", 
-  network: process.env.STELLAR_NETWORK || "testnet", 
-  timestamp: new Date().toISOString(),
-  indexer: indexerService.getStatus()
-}));
+const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ||
+  process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
+
+router.get("/", async (req, res) => {
+  let dbStatus = "ok";
+  try {
+    await pool.query("SELECT 1");
+  } catch {
+    dbStatus = "unreachable";
+  }
+
+  const status = dbStatus === "ok" ? "ok" : "degraded";
+  const httpStatus = dbStatus === "ok" ? 200 : 503;
+
+  res.status(httpStatus).json({
+    status,
+    service: "stellar-greenpay-api",
+    network: process.env.STELLAR_NETWORK || "testnet",
+    timestamp: new Date().toISOString(),
+    checks: { db: dbStatus },
+    indexer: indexerService.getStatus(),
+  });
+});
+
 module.exports = router;

--- a/backend/src/routes/readiness.js
+++ b/backend/src/routes/readiness.js
@@ -1,0 +1,31 @@
+/**
+ * src/routes/readiness.js
+ */
+"use strict";
+const express = require("express");
+const router = express.Router();
+const pool = require("../db/pool");
+
+const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ||
+  process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
+
+router.get("/", async (req, res) => {
+  let dbStatus = "ok";
+  let horizonStatus = "ok";
+
+  await Promise.all([
+    pool.query("SELECT 1").catch(() => { dbStatus = "unreachable"; }),
+    fetch(`${HORIZON_URL}/fee_stats`, { signal: AbortSignal.timeout(4000) })
+      .then((r) => { if (!r.ok) horizonStatus = "unreachable"; })
+      .catch(() => { horizonStatus = "unreachable"; }),
+  ]);
+
+  const healthy = dbStatus === "ok" && horizonStatus === "ok";
+  res.status(healthy ? 200 : 503).json({
+    status: healthy ? "ready" : "not ready",
+    timestamp: new Date().toISOString(),
+    checks: { db: dbStatus, horizon: horizonStatus },
+  });
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -27,7 +27,7 @@ const app    = express();
 const PORT   = process.env.PORT || 4000;
 const server = http.createServer(app);
 
-// ── Swagger UI (development) ─────────────────────────────────────────────────
+// ── Swagger UI (development) ────────────────────────────────────────────
 if (process.env.NODE_ENV !== "production") {
   const swaggerUi = require("swagger-ui-express");
   const yaml      = require("js-yaml");
@@ -64,14 +64,14 @@ const io = new Server(server, {
 app.set("io", io);
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 150, standardHeaders: true, legacyHeaders: false }));
 
-// ── CSRF token endpoint ──────────────────────────────────────────────────────
+// ── CSRF token endpoint ────────────────────────────────────────────
 function csrfTokenHandler(req, res) {
   res.json({ success: true, csrfToken: req.csrfToken() });
 }
 app.get("/api/csrf-token", csrfTokenHandler);
 app.get("/api/v1/csrf-token", csrfTokenHandler);
 
-// ── Route mounts — each router registered at /api and /api/v1 ───────────────
+// ── Route mounts — each router registered at /api and /api/v1 ─────────────────────
 const projectsRouter      = require("./routes/projects");
 const donationsRouter     = require("./routes/donations");
 const profilesRouter      = require("./routes/profiles");
@@ -90,6 +90,7 @@ function mount(path, router) {
 }
 
 app.use("/health", require("./routes/health"));
+app.use("/readiness", require("./routes/readiness"));
 mount("/api/projects",      projectsRouter);
 mount("/api/donations",     donationsRouter);
 mount("/api/profiles",      profilesRouter);
@@ -102,7 +103,7 @@ mount("/api/impact",        impactRouter);
 mount("/api/ratings",       ratingsRouter);
 mount("/api/admin",         adminRouter);
 
-app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
+app.use((req, res) => res.status(404).json({ error:  }));
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {
   console.error("[Error]", err.message);
@@ -118,7 +119,7 @@ async function startServer() {
   startIndexer(io).catch(err => console.error("[Indexer Error]", err.message));
 
   server.listen(PORT, () => {
-    console.log(`\n  🌱 Stellar GreenPay API\n  🚀 Running at http://localhost:${PORT}\n  🌐 Network: ${process.env.STELLAR_NETWORK || "testnet"}\n`);
+    console.log();
   });
 
   if (process.env.ENABLE_TURRETS === "true") {

--- a/backend/src/services/projectService.js
+++ b/backend/src/services/projectService.js
@@ -1,0 +1,94 @@
+/**
+ * src/services/projectService.js
+ */
+"use strict";
+
+const pool = require("../db/pool");
+const { mapProjectRow } = require("./store");
+
+const VALID_STATUSES = ["active", "completed", "paused"];
+const VALID_CATEGORIES = [
+  "Reforestation", "Solar Energy", "Ocean Conservation", "Clean Water",
+  "Wildlife Protection", "Carbon Capture", "Wind Energy",
+  "Sustainable Agriculture", "Other",
+];
+
+async function getAllProjects({ category, status, limit = 20 } = {}) {
+  const where = [];
+  const values = [];
+  if (status && VALID_STATUSES.includes(status)) {
+    values.push(status);
+    where.push(`status = $${values.length}`);
+  }
+  if (category && VALID_CATEGORIES.includes(category)) {
+    values.push(category);
+    where.push(`category = $${values.length}`);
+  }
+  const pageSize = Math.min(Number.parseInt(String(limit), 10) || 20, 100);
+  values.push(pageSize);
+  let query = "SELECT * FROM projects";
+  if (where.length) query += " WHERE " + where.join(" AND ");
+  query += ` ORDER BY created_at DESC LIMIT $${values.length}`;
+  // eslint-disable-next-line sql-injection/no-sql-injection
+  const result = await pool.query(query, values);
+  return result.rows.map(mapProjectRow);
+}
+
+async function getProjectById(id) {
+  const result = await pool.query("SELECT * FROM projects WHERE id = $1", [id]);
+  if (!result.rows[0]) return null;
+  return mapProjectRow(result.rows[0]);
+}
+
+async function createProject({ id, name, description, category, location, walletAddress, goalXLM, co2PerXLM } = {}) {
+  if (!name || !category || !walletAddress) {
+    throw new Error("name, category, and walletAddress are required");
+  }
+  if (!VALID_CATEGORIES.includes(category)) {
+    throw new Error(`Invalid category. Must be one of: ${VALID_CATEGORIES.join(", ")}`);
+  }
+  const result = await pool.query(
+    `INSERT INTO projects
+       (id, name, description, category, location, wallet_address,
+        goal_xlm, co2_offset_kg, status, verified, on_chain_verified,
+        raised_xlm, donor_count, tags, created_at, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'active',false,false,0,0,'{}',NOW(),NOW())
+     RETURNING *`,
+    [id, name, description || "", category, location || "", walletAddress,
+     goalXLM || "0", Number(co2PerXLM) || 0],
+  );
+  return mapProjectRow(result.rows[0]);
+}
+
+async function updateProject(id, updates = {}) {
+  const { status, verified } = updates;
+  const setClauses = [];
+  const values = [];
+
+  if (status !== undefined) {
+    if (!VALID_STATUSES.includes(status)) {
+      throw new Error(`Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`);
+    }
+    values.push(status);
+    setClauses.push(`status = $${values.length}`);
+  }
+  if (verified !== undefined) {
+    values.push(Boolean(verified));
+    setClauses.push(`verified = $${values.length}`);
+  }
+  if (!setClauses.length) {
+    throw new Error("No valid fields to update");
+  }
+
+  setClauses.push("updated_at = NOW()");
+  values.push(id);
+  const result = await pool.query(
+    // eslint-disable-next-line sql-injection/no-sql-injection
+    `UPDATE projects SET ${setClauses.join(", ")} WHERE id = $${values.length} RETURNING *`,
+    values,
+  );
+  if (!result.rows[0]) return null;
+  return mapProjectRow(result.rows[0]);
+}
+
+module.exports = { getAllProjects, getProjectById, createProject, updateProject };

--- a/backend/src/services/projectService.test.js
+++ b/backend/src/services/projectService.test.js
@@ -1,0 +1,243 @@
+/**
+ * src/services/projectService.test.js
+ */
+"use strict";
+
+jest.mock("../db/pool", () => ({ query: jest.fn() }));
+jest.mock("./store", () => ({
+  mapProjectRow: (row) => ({
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    category: row.category,
+    location: row.location,
+    walletAddress: row.wallet_address,
+    goalXLM: row.goal_xlm,
+    raisedXLM: row.raised_xlm,
+    donorCount: row.donor_count,
+    co2OffsetKg: row.co2_offset_kg,
+    status: row.status,
+    verified: row.verified,
+    onChainVerified: row.on_chain_verified,
+    tags: row.tags,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }),
+}));
+
+const pool = require("../db/pool");
+const { getAllProjects, getProjectById, createProject, updateProject } = require("./projectService");
+
+const MOCK_ROW = {
+  id: "proj-1",
+  name: "Amazon Reforestation",
+  description: "Plant trees in Brazil",
+  category: "Reforestation",
+  location: "Brazil",
+  wallet_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  goal_xlm: "10000",
+  raised_xlm: "0",
+  donor_count: 0,
+  co2_offset_kg: 0,
+  status: "active",
+  verified: false,
+  on_chain_verified: false,
+  tags: [],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── getAllProjects ──────────────────────────────────────────────────────────
+
+describe("getAllProjects", () => {
+  test("returns all projects with default params", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    const result = await getAllProjects();
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Amazon Reforestation");
+  });
+
+  test("applies status filter", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    await getAllProjects({ status: "active" });
+    const [query, values] = pool.query.mock.calls[0];
+    expect(query).toContain("status = $1");
+    expect(values).toContain("active");
+  });
+
+  test("applies category filter", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    await getAllProjects({ category: "Reforestation" });
+    const [query, values] = pool.query.mock.calls[0];
+    expect(query).toContain("category = $1");
+    expect(values).toContain("Reforestation");
+  });
+
+  test("applies both status and category filters", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    await getAllProjects({ status: "active", category: "Solar Energy" });
+    const [query, values] = pool.query.mock.calls[0];
+    expect(query).toContain("status = $1");
+    expect(query).toContain("category = $2");
+    expect(values).toContain("active");
+    expect(values).toContain("Solar Energy");
+  });
+
+  test("ignores invalid status filter", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    await getAllProjects({ status: "invalid-status" });
+    const [query] = pool.query.mock.calls[0];
+    expect(query).not.toContain("status =");
+  });
+
+  test("ignores invalid category filter", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    await getAllProjects({ category: "Unicorn Farming" });
+    const [query] = pool.query.mock.calls[0];
+    expect(query).not.toContain("category =");
+  });
+
+  test("caps limit at 100", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    await getAllProjects({ limit: 9999 });
+    const [, values] = pool.query.mock.calls[0];
+    expect(values[values.length - 1]).toBe(100);
+  });
+
+  test("returns empty array when no projects found", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    const result = await getAllProjects();
+    expect(result).toEqual([]);
+  });
+});
+
+// ─── getProjectById ──────────────────────────────────────────────────────────
+
+describe("getProjectById", () => {
+  test("returns project when found", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    const result = await getProjectById("proj-1");
+    expect(pool.query).toHaveBeenCalledWith(
+      "SELECT * FROM projects WHERE id = $1",
+      ["proj-1"],
+    );
+    expect(result).not.toBeNull();
+    expect(result.id).toBe("proj-1");
+  });
+
+  test("returns null when project not found", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    const result = await getProjectById("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("maps row fields to camelCase", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    const result = await getProjectById("proj-1");
+    expect(result).toHaveProperty("walletAddress");
+    expect(result).toHaveProperty("raisedXLM");
+    expect(result).toHaveProperty("donorCount");
+    expect(result).not.toHaveProperty("wallet_address");
+  });
+});
+
+// ─── createProject ───────────────────────────────────────────────────────────
+
+describe("createProject", () => {
+  test("creates a project with valid inputs", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    const result = await createProject({
+      id: "proj-1",
+      name: "Amazon Reforestation",
+      description: "Plant trees",
+      category: "Reforestation",
+      location: "Brazil",
+      walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      goalXLM: "10000",
+      co2PerXLM: 50,
+    });
+    expect(result).not.toBeNull();
+    expect(result.name).toBe("Amazon Reforestation");
+  });
+
+  test("throws when name is missing", async () => {
+    await expect(
+      createProject({ category: "Reforestation", walletAddress: "G..." }),
+    ).rejects.toThrow("name, category, and walletAddress are required");
+  });
+
+  test("throws when category is missing", async () => {
+    await expect(
+      createProject({ name: "Test", walletAddress: "G..." }),
+    ).rejects.toThrow("name, category, and walletAddress are required");
+  });
+
+  test("throws when walletAddress is missing", async () => {
+    await expect(
+      createProject({ name: "Test", category: "Reforestation" }),
+    ).rejects.toThrow("name, category, and walletAddress are required");
+  });
+
+  test("throws on invalid category", async () => {
+    await expect(
+      createProject({ name: "Test", category: "Unicorn Farming", walletAddress: "G..." }),
+    ).rejects.toThrow("Invalid category");
+  });
+
+  test("uses default description and location when omitted", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_ROW] });
+    await createProject({ id: "p1", name: "Test", category: "Reforestation", walletAddress: "G..." });
+    const [, values] = pool.query.mock.calls[0];
+    expect(values[2]).toBe("");
+    expect(values[4]).toBe("");
+  });
+});
+
+// ─── updateProject ───────────────────────────────────────────────────────────
+
+describe("updateProject", () => {
+  test("updates status of an existing project", async () => {
+    const updated = { ...MOCK_ROW, status: "paused" };
+    pool.query.mockResolvedValueOnce({ rows: [updated] });
+    const result = await updateProject("proj-1", { status: "paused" });
+    expect(result).not.toBeNull();
+    expect(result.status).toBe("paused");
+  });
+
+  test("updates verified field", async () => {
+    const updated = { ...MOCK_ROW, verified: true };
+    pool.query.mockResolvedValueOnce({ rows: [updated] });
+    const result = await updateProject("proj-1", { verified: true });
+    expect(result).not.toBeNull();
+    expect(result.verified).toBe(true);
+  });
+
+  test("updates both status and verified", async () => {
+    const updated = { ...MOCK_ROW, status: "completed", verified: true };
+    pool.query.mockResolvedValueOnce({ rows: [updated] });
+    const result = await updateProject("proj-1", { status: "completed", verified: true });
+    const [query] = pool.query.mock.calls[0];
+    expect(query).toContain("status = $1");
+    expect(query).toContain("verified = $2");
+    expect(result.status).toBe("completed");
+  });
+
+  test("throws on invalid status", async () => {
+    await expect(updateProject("proj-1", { status: "archived" })).rejects.toThrow("Invalid status");
+  });
+
+  test("throws when no valid fields provided", async () => {
+    await expect(updateProject("proj-1", {})).rejects.toThrow("No valid fields to update");
+  });
+
+  test("returns null when project not found", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    const result = await updateProject("nonexistent", { status: "paused" });
+    expect(result).toBeNull();
+  });
+});

--- a/contracts/greenpay-contract/src/lib.rs
+++ b/contracts/greenpay-contract/src/lib.rs
@@ -86,6 +86,18 @@ pub struct ImpactNFT {
     pub minted_at_ledger:   u32,
 }
 
+/// Per-project milestone NFT awarded when a donor's cumulative donation to a
+/// single project exceeds 100 XLM. One NFT per (donor, project_id) pair.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProjectMilestoneNFT {
+    pub owner:              Address,
+    pub project_id:         String,
+    pub amount_donated:     i128,
+    pub co2_offset_grams:   i128,
+    pub minted_at_ledger:   u32,
+}
+
 /// A community voting proposal to verify a project.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -113,6 +125,10 @@ pub enum DataKey {
     // Governance
     Proposal(String),
     HasVoted(String, Address),
+    // Per-donor per-project cumulative donation total for milestone NFT gating
+    DonorProjectTotal(String, Address),
+    // Per-project milestone NFT: one per (project_id, donor) pair
+    ProjectMilestoneNFT(String, Address),
     // Contract upgrade and multi-currency support
     ContractWasmHash,
     USDCTokenAddress,
@@ -254,6 +270,14 @@ impl GreenPayContract {
         donor_stats.badge = calculate_badge(donor_stats.total_donated);
         env.storage().instance().set(&DataKey::DonorStats(donor.clone()), &donor_stats);
 
+        // Track per-project cumulative donations for milestone NFT eligibility.
+        let proj_total_key = DataKey::DonorProjectTotal(project_id.clone(), donor.clone());
+        let prev_proj_total: i128 = env.storage().instance().get(&proj_total_key).unwrap_or(0);
+        env.storage().instance().set(
+            &proj_total_key,
+            &prev_proj_total.checked_add(amount).expect("DonorProjectTotal overflow"),
+        );
+
         // Auto-mint an Impact NFT when a donor reaches a new badge tier.
         if donor_stats.badge != BadgeTier::None && donor_stats.badge != prev_badge {
             let nft_key = DataKey::ImpactNFT(donor.clone(), donor_stats.badge.clone());
@@ -365,6 +389,58 @@ impl GreenPayContract {
 
     pub fn has_nft(env: Env, donor: Address, tier: BadgeTier) -> bool {
         env.storage().instance().has(&DataKey::ImpactNFT(donor, tier))
+    }
+
+    // ─── Project milestone NFT (#205) ────────────────────────────────────────
+
+    /// Mint a project milestone NFT when a donor's cumulative donation to a
+    /// specific project exceeds 100 XLM. Minting is idempotent-blocked: a second
+    /// call for the same (donor, project_id) pair panics.
+    pub fn mint_project_nft(env: Env, donor: Address, project_id: String) {
+        donor.require_auth();
+
+        let project: Project = env.storage().instance()
+            .get(&DataKey::Project(project_id.clone())).expect("Project not found");
+
+        let proj_total_key = DataKey::DonorProjectTotal(project_id.clone(), donor.clone());
+        let proj_total: i128 = env.storage().instance().get(&proj_total_key).unwrap_or(0);
+
+        // 100 XLM = 100 × 10_000_000 stroops
+        if proj_total < 100 * STROOP {
+            panic!("Cumulative donation to this project has not reached 100 XLM");
+        }
+
+        let nft_key = DataKey::ProjectMilestoneNFT(project_id.clone(), donor.clone());
+        if env.storage().instance().has(&nft_key) {
+            panic!("Milestone NFT already minted for this project");
+        }
+
+        let co2_per_xlm = project.co2_per_xlm as i128;
+        let xlm_units = proj_total / STROOP;
+        let co2_offset = xlm_units.checked_mul(co2_per_xlm).expect("CO2 calculation overflow");
+
+        let nft = ProjectMilestoneNFT {
+            owner:            donor.clone(),
+            project_id:       project_id.clone(),
+            amount_donated:   proj_total,
+            co2_offset_grams: co2_offset,
+            minted_at_ledger: env.ledger().sequence(),
+        };
+        env.storage().instance().set(&nft_key, &nft);
+        env.events().publish(
+            (symbol_short!("pnft_mnt"), donor.clone()),
+            (project_id, proj_total),
+        );
+    }
+
+    pub fn has_project_nft(env: Env, donor: Address, project_id: String) -> bool {
+        env.storage().instance().has(&DataKey::ProjectMilestoneNFT(project_id, donor))
+    }
+
+    pub fn get_project_nft(env: Env, donor: Address, project_id: String) -> ProjectMilestoneNFT {
+        env.storage().instance()
+            .get(&DataKey::ProjectMilestoneNFT(project_id, donor))
+            .expect("Project milestone NFT not found")
     }
 
     // ─── Governance ───────────────────────────────────────────────────────────
@@ -562,6 +638,14 @@ impl GreenPayContract {
         let gg: i128 = env.storage().instance().get(&DataKey::GlobalCO2OffsetGrams).unwrap_or(0);
         env.storage().instance().set(&DataKey::GlobalCO2OffsetGrams,
             &gg.checked_add(co2_increment).expect("GlobalCO2OffsetGrams overflow"));
+
+        // Track per-project cumulative donations for milestone NFT eligibility.
+        let proj_total_key = DataKey::DonorProjectTotal(project_id.clone(), donor.clone());
+        let prev_proj_total: i128 = env.storage().instance().get(&proj_total_key).unwrap_or(0);
+        env.storage().instance().set(
+            &proj_total_key,
+            &prev_proj_total.checked_add(xlm_equivalent).expect("DonorProjectTotal overflow"),
+        );
 
         let token_client = token::Client::new(&env, &usdc_token);
         let project_wallet = project.wallet;
@@ -998,4 +1082,107 @@ mod tests {
         let proposal = client.get_proposal(&pid);
         assert_eq!(proposal.votes_for, 1);
     }
+
+    // ─── ProjectMilestoneNFT tests (#205) ────────────────────────────────────
+
+    #[test]
+    fn test_mint_project_nft_success() {
+        let (env, _cid, client, _admin, pid) = setup();
+        let donor        = Address::generate(&env);
+        let token_admin  = Address::generate(&env);
+        let token        = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_client = StellarAssetClient::new(&env, &token);
+
+        token_client.mint(&donor, &(200 * STROOP));
+        client.donate(&token, &donor, &pid, &(101 * STROOP), &0u32);
+
+        assert!(!client.has_project_nft(&donor, &pid));
+        client.mint_project_nft(&donor, &pid);
+        assert!(client.has_project_nft(&donor, &pid));
+
+        let nft = client.get_project_nft(&donor, &pid);
+        assert_eq!(nft.owner,          donor);
+        assert_eq!(nft.project_id,     pid);
+        assert_eq!(nft.amount_donated, 101 * STROOP);
+        // co2_per_xlm for the test project is 100 grams/XLM
+        assert_eq!(nft.co2_offset_grams, 101 * 100);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cumulative donation to this project has not reached 100 XLM")]
+    fn test_mint_project_nft_below_threshold() {
+        let (env, _cid, client, _admin, pid) = setup();
+        let donor        = Address::generate(&env);
+        let token_admin  = Address::generate(&env);
+        let token        = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_client = StellarAssetClient::new(&env, &token);
+
+        token_client.mint(&donor, &(100 * STROOP));
+        client.donate(&token, &donor, &pid, &(50 * STROOP), &0u32);
+
+        client.mint_project_nft(&donor, &pid);
+    }
+
+    #[test]
+    #[should_panic(expected = "Milestone NFT already minted for this project")]
+    fn test_mint_project_nft_duplicate_prevented() {
+        let (env, _cid, client, _admin, pid) = setup();
+        let donor        = Address::generate(&env);
+        let token_admin  = Address::generate(&env);
+        let token        = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_client = StellarAssetClient::new(&env, &token);
+
+        token_client.mint(&donor, &(200 * STROOP));
+        client.donate(&token, &donor, &pid, &(101 * STROOP), &0u32);
+
+        client.mint_project_nft(&donor, &pid);
+        // Second call must panic
+        client.mint_project_nft(&donor, &pid);
+    }
+
+    #[test]
+    fn test_project_nft_independent_per_project() {
+        let (env, _cid, client, admin, pid1) = setup();
+        let pid2    = String::from_str(&env, "proj-002");
+        let wallet2 = Address::generate(&env);
+        client.register_project(
+            &admin, &pid2,
+            &String::from_str(&env, "Project 2"),
+            &wallet2, &50u32,
+        );
+
+        let donor        = Address::generate(&env);
+        let token_admin  = Address::generate(&env);
+        let token        = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_client = StellarAssetClient::new(&env, &token);
+
+        token_client.mint(&donor, &(300 * STROOP));
+        client.donate(&token, &donor, &pid1, &(101 * STROOP), &0u32);
+        client.donate(&token, &donor, &pid2, &(50 * STROOP),  &1u32);
+
+        client.mint_project_nft(&donor, &pid1);
+        assert!(client.has_project_nft(&donor, &pid1));
+        assert!(!client.has_project_nft(&donor, &pid2));
+    }
+
+    #[test]
+    fn test_project_nft_cumulative_across_donations() {
+        let (env, _cid, client, _admin, pid) = setup();
+        let donor        = Address::generate(&env);
+        let token_admin  = Address::generate(&env);
+        let token        = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_client = StellarAssetClient::new(&env, &token);
+
+        // Two donations summing to > 100 XLM
+        token_client.mint(&donor, &(200 * STROOP));
+        client.donate(&token, &donor, &pid, &(60 * STROOP), &0u32);
+        client.donate(&token, &donor, &pid, &(60 * STROOP), &1u32);
+
+        client.mint_project_nft(&donor, &pid);
+        assert!(client.has_project_nft(&donor, &pid));
+
+        let nft = client.get_project_nft(&donor, &pid);
+        assert_eq!(nft.amount_donated, 120 * STROOP);
+    }
 }
+

--- a/frontend/pages/governance.tsx
+++ b/frontend/pages/governance.tsx
@@ -1,0 +1,366 @@
+/**
+ * pages/governance.tsx
+ * Governance — Proposal voting for badge holders.
+ */
+import { useEffect, useState, useCallback } from "react";
+import Head from "next/head";
+import {
+  CONTRACT_ID, NETWORK_PASSPHRASE, rpcServer, server,
+  getDonorStats, submitTransaction, formatTransactionError,
+} from "@/lib/stellar";
+import { getConnectedPublicKey, connectWallet, signTransactionWithWallet } from "@/lib/wallet";
+import { fetchProjects } from "@/lib/api";
+import { shortenAddress } from "@/utils/format";
+import {
+  Contract, TransactionBuilder, Address, nativeToScVal, rpc, scValToNative, Account,
+} from "@stellar/stellar-sdk";
+
+// Stellat ledger ≈ 5 s — approximate deadline display from ledger offset.
+const LEDGERS_PER_DAY = 17280;
+const QUORUM_THRESHOLD = 5;
+
+interface Proposal {
+  projectId: string;
+  projectName: string;
+  votesFor: number;
+  votesAgainst: number;
+  deadlineLedger: number;
+  resolved: boolean;
+  currentLedger: number;
+}
+
+async function fetchProposal(projectId: string, currentLedger: number): Promise<Proposal | null> {
+  try {
+    const contract = new Contract(CONTRACT_ID);
+    const dummyAccount = new Account(
+      "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF", "-1",
+    );
+    const tx = new TransactionBuilder(dummyAccount, {
+      fee: "100",
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        contract.call("get_proposal", nativeToScVal(projectId, { type: "string" })),
+      )
+      .setTimeout(30)
+      .build();
+
+    const result = await rpcServer.simulateTransaction(tx);
+    if (!rpc.Api.isSimulationSuccess(result)) return null;
+
+    const raw = scValToNative(result.result!.retval) as {
+      project_id: string;
+      votes_for: number;
+      votes_against: number;
+      deadline_ledger: number;
+      resolved: boolean;
+    };
+
+    return {
+      projectId,
+      projectName: "",
+      votesFor: Number(raw.votes_for),
+      votesAgainst: Number(raw.votes_against),
+      deadlineLedger: Number(raw.deadline_ledger),
+      resolved: Boolean(raw.resolved),
+      currentLedger,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function buildVoteTransaction(voter: string, projectId: string, approve: boolean) {
+  const contract = new Contract(CONTRACT_ID);
+  const source = await server.loadAccount(voter);
+  const tx = new TransactionBuilder(source, {
+    fee: "1000000",
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        "vote_verify_project",
+        new Address(voter).toScVal(),
+        nativeToScVal(projectId, { type: "string" }),
+        nativeToScVal(approve, { type: "bool" }),
+      ),
+    )
+    .setTimeout(60)
+    .build();
+
+  const simulated = await rpcServer.simulateTransaction(tx);
+  if (rpc.Api.isSimulationSuccess(simulated)) {
+    return rpc.assembleTransaction(tx, simulated).build();
+  }
+  throw new Error(`Simulation failed: ${JSON.stringify(simulated)}`);
+}
+
+function ledgersToDays(ledgers: number): string {
+  const days = (ledgers / LEDGERS_PER_DAY).toFixed(1);
+  return Number(days) < 0 ? "expired" : `~${days}d`;
+}
+
+export default function GovernancePage() {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [isBadgeHolder, setIsBadgeHolder] = useState(false);
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [votingId, setVotingId] = useState<string | null>(null);
+  const [txStatus, setTxStatus] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const loadProposals = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [projects, statusResult] = await Promise.all([
+        fetchProjects(),
+        rpcServer.getLatestLedger(),
+      ]);
+      const currentLedger = statusResult.sequence;
+
+      const settled = await Promise.allSettled(
+        projects.map((p) => fetchProposal(p.id, currentLedger).then((proposal) => {
+          if (proposal) proposal.projectName = p.name;
+          return proposal;
+        })),
+      );
+
+      const active = settled
+        .filter((r): r is PromiseFulfilledResult<Proposal> => r.status === "fulfilled" && r.value !== null)
+        .map((r) => r.value)
+        .filter((p) => !p.resolved && p.deadlineLedger > currentLedger);
+
+      setProposals(active);
+    } catch (err) {
+      setError("Failed to load proposals. Make sure the Soroban RPC is reachable.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function init() {
+      const pk = await getConnectedPublicKey();
+      if (!mounted) return;
+      setPublicKey(pk);
+
+      if (pk) {
+        try {
+          const stats = await getDonorStats(pk);
+          if (mounted && stats.badge !== "None") setIsBadgeHolder(true);
+        } catch {
+          // not a badge holder yet
+        }
+      }
+
+      loadProposals();
+    }
+
+    init();
+    return () => { mounted = false; };
+  }, [loadProposals]);
+
+  async function handleConnect() {
+    const { publicKey: pk, error: err } = await connectWallet();
+    if (err) { setError(err); return; }
+    setPublicKey(pk);
+    if (pk) {
+      try {
+        const stats = await getDonorStats(pk);
+        if (stats.badge !== "None") setIsBadgeHolder(true);
+      } catch { /* not a badge holder */ }
+    }
+  }
+
+  async function castVote(projectId: string, approve: boolean) {
+    if (!publicKey) return;
+    setVotingId(projectId);
+    setTxStatus((prev) => ({ ...prev, [projectId]: "Building transaction…" }));
+    try {
+      const tx = await buildVoteTransaction(publicKey, projectId, approve);
+      setTxStatus((prev) => ({ ...prev, [projectId]: "Sign in Freighter…" }));
+      const { signedXDR, error: signErr } = await signTransactionWithWallet(tx.toXDR());
+      if (signErr || !signedXDR) throw new Error(signErr || "Signing failed");
+      setTxStatus((prev) => ({ ...prev, [projectId]: "Submitting…" }));
+      await submitTransaction(signedXDR);
+      setTxStatus((prev) => ({ ...prev, [projectId]: approve ? "Voted: Approve ✓" : "Voted: Reject ✓" }));
+      loadProposals();
+    } catch (err) {
+      setTxStatus((prev) => ({ ...prev, [projectId]: `Error: ${formatTransactionError(err)}` }));
+    } finally {
+      setVotingId(null);
+    }
+  }
+
+  const totalVotes = (p: Proposal) => p.votesFor + p.votesAgainst;
+  const passPercent = (p: Proposal) =>
+    totalVotes(p) === 0 ? 0 : Math.round((p.votesFor / totalVotes(p)) * 100);
+
+  return (
+    <div className="min-h-screen bg-[#fcfdfc] font-body text-forest-900 pb-20">
+      <Head>
+        <title>Governance | Stellar GreenPay</title>
+        <meta name="description" content="Vote on project verification proposals with your impact badge." />
+      </Head>
+
+      <main className="max-w-3xl mx-auto px-4 py-12 sm:px-6">
+        <div className="mb-10">
+          <h1 className="text-4xl font-display font-bold text-forest-900 tracking-tight">
+            Community <span className="text-forest-500">Governance</span>
+          </h1>
+          <p className="mt-3 text-forest-600">
+            Badge holders vote to verify new climate projects. You need at least a{" "}
+            <span className="font-semibold">Seedling badge</span> (≥ 10 XLM donated) to cast a vote.
+          </p>
+        </div>
+
+        {/* Wallet + badge status */}
+        <div className="mb-8 rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+          {publicKey ? (
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm text-zinc-500">Connected as</p>
+                <p className="font-mono text-sm font-medium text-zinc-900">{shortenAddress(publicKey)}</p>
+              </div>
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                  isBadgeHolder
+                    ? "bg-forest-100 text-forest-700"
+                    : "bg-zinc-100 text-zinc-500"
+                }`}
+              >
+                {isBadgeHolder ? "Eligible to vote" : "No badge yet"}
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-sm text-zinc-600">Connect your Freighter wallet to vote.</p>
+              <button
+                onClick={handleConnect}
+                className="rounded-full bg-forest-600 px-4 py-2 text-sm font-semibold text-white hover:bg-forest-700"
+              >
+                Connect wallet
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Quorum notice */}
+        <div className="mb-6 rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+          Quorum threshold: <strong>{QUORUM_THRESHOLD} votes</strong>. A proposal passes when
+          votes&nbsp;for &gt; votes&nbsp;against and the deadline passes.
+        </div>
+
+        {error && (
+          <div className="mb-6 rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {isLoading ? (
+          <p className="text-center text-zinc-500 py-16">Loading proposals…</p>
+        ) : proposals.length === 0 ? (
+          <div className="rounded-2xl border border-zinc-100 bg-white p-12 text-center shadow-sm">
+            <p className="text-zinc-500">No open proposals at the moment.</p>
+            <p className="mt-1 text-sm text-zinc-400">
+              Admins create proposals via <code className="text-xs">create_proposal</code> on the contract.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {proposals.map((proposal) => {
+              const ledgersLeft = proposal.deadlineLedger - proposal.currentLedger;
+              const votes = totalVotes(proposal);
+              const pct = passPercent(proposal);
+              const status = txStatus[proposal.projectId];
+              const isVoting = votingId === proposal.projectId;
+              const quorumMet = votes >= QUORUM_THRESHOLD;
+
+              return (
+                <article
+                  key={proposal.projectId}
+                  className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-4 mb-4">
+                    <div>
+                      <h2 className="text-base font-semibold text-zinc-900">
+                        {proposal.projectName || proposal.projectId}
+                      </h2>
+                      <p className="text-xs text-zinc-500 mt-0.5">
+                        Project ID: <code className="font-mono">{proposal.projectId}</code>
+                      </p>
+                    </div>
+                    <div className="flex flex-col items-end gap-1 shrink-0">
+                      <span className="rounded-full bg-blue-50 text-blue-700 px-2.5 py-0.5 text-xs font-medium">
+                        {ledgersToDays(ledgersLeft)} left
+                      </span>
+                      {quorumMet && (
+                        <span className="rounded-full bg-forest-50 text-forest-700 px-2.5 py-0.5 text-xs font-medium">
+                          Quorum met
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Tally bar */}
+                  <div className="mb-4">
+                    <div className="flex justify-between text-xs text-zinc-500 mb-1">
+                      <span>For: <strong className="text-forest-700">{proposal.votesFor}</strong></span>
+                      <span><strong>{votes}</strong> total votes</span>
+                      <span>Against: <strong className="text-red-600">{proposal.votesAgainst}</strong></span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-zinc-100 overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-forest-500 transition-all"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <p className="text-xs text-zinc-400 mt-1 text-right">{pct}% approval</p>
+                  </div>
+
+                  {/* Vote buttons */}
+                  {isBadgeHolder && !status?.startsWith("Voted") ? (
+                    <div className="flex gap-2">
+                      <button
+                        disabled={isVoting}
+                        onClick={() => castVote(proposal.projectId, true)}
+                        className="flex-1 rounded-xl bg-forest-600 py-2 text-sm font-semibold text-white hover:bg-forest-700 disabled:opacity-50"
+                      >
+                        {isVoting ? "…" : "Approve"}
+                      </button>
+                      <button
+                        disabled={isVoting}
+                        onClick={() => castVote(proposal.projectId, false)}
+                        className="flex-1 rounded-xl border border-red-300 py-2 text-sm font-semibold text-red-600 hover:bg-red-50 disabled:opacity-50"
+                      >
+                        {isVoting ? "…" : "Reject"}
+                      </button>
+                    </div>
+                  ) : null}
+
+                  {status && (
+                    <p className="mt-3 text-xs text-zinc-500 text-center">{status}</p>
+                  )}
+
+                  {!publicKey && (
+                    <p className="mt-2 text-xs text-zinc-400 text-center">
+                      Connect wallet to vote.
+                    </p>
+                  )}
+                  {publicKey && !isBadgeHolder && (
+                    <p className="mt-2 text-xs text-zinc-400 text-center">
+                      You need at least a Seedling badge to vote. Donate ≥ 10 XLM to earn one.
+                    </p>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #190

---

Closes #198

---

Closes #205

---

Closes #138

---

## Summary

- **#138** — Create `backend/src/services/projectService.js` with `getAllProjects`, `getProjectById`, `createProject`, and `updateProject` backed by the existing `pg` pool. Add `backend/src/services/projectService.test.js` with 20 Jest unit tests covering happy paths, edge cases (project not found → null), validation errors (missing required fields, invalid category/status), pagination limits, and field mapping.
- **#198** — Update `backend/src/routes/health.js` to run `SELECT 1` against the DB pool and return HTTP 503 when unreachable (previously always 200). Add `backend/src/routes/readiness.js` that checks both DB and Horizon reachability in parallel, returning 503 if either is down. Mount `/readiness` in `server.js` alongside the existing `/health` mount.
- **#205** — Add a `ProjectMilestoneNFT` contract type (fields: `owner`, `project_id`, `amount_donated`, `co2_offset_grams`, `minted_at_ledger`) and a `DonorProjectTotal` storage key that tracks each donor's cumulative donation per project. Add `mint_project_nft`, `has_project_nft`, and `get_project_nft` entry points; minting is gated at 100 XLM cumulative to the project and blocked on duplicate mints. Add 5 contract tests: success, below-threshold panic, duplicate-mint panic, per-project independence, and cumulative-across-donations.
- **#190** — Add `frontend/pages/governance.tsx`: fetches all projects from the API, simulates `get_proposal` on the Soroban contract for each to find open unresolved proposals, displays vote tallies and deadlines (ledger → approximate days remaining), and lets Seedling-or-above badge holders cast yes/no votes via a signed Soroban transaction through Freighter.

## Test plan

- [ ] `cd backend && npx jest src/services/projectService.test.js` — all 20 tests pass
- [ ] `curl http://localhost:4000/health` returns `{"status":"ok",...,"checks":{"db":"ok"}}`
- [ ] Kill DB, `curl http://localhost:4000/health` returns HTTP 503 with `{"status":"degraded",...}`
- [ ] `curl http://localhost:4000/readiness` checks both DB and Horizon; returns 200 when both up, 503 when either down
- [ ] `cargo test -p greenpay-contract --features testutils` — all existing + 5 new `test_*project_nft*` tests pass
- [ ] `mint_project_nft` after donating < 100 XLM panics; after ≥ 100 XLM succeeds; second call panics
- [ ] Navigate to `/governance` — shows open proposals with tally bar and deadline
- [ ] Connect a badge-holder wallet → "Eligible to vote" badge + Approve/Reject buttons appear
- [ ] Connect a wallet with no badge → "No badge yet" badge + guidance text, no vote buttons
- [ ] Cast a vote → Freighter signs → transaction submitted → tally refreshed