### PR TITLE
Add structured JSON logging (Pino) and expand unit test coverage

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,8 @@
         "morgan": "^1.10.0",
         "pg": "^8.20.0",
         "pg-boss": "^10.1.0",
+        "pino": "^10.3.1",
+        "pino-http": "^11.0.0",
         "socket.io": "^4.8.3",
         "swagger-jsdoc": "6.2.8",
         "swagger-ui-express": "5.0.1",
@@ -36,6 +38,7 @@
         "eslint-plugin-sql-injection": "^1.0.1",
         "jest": "^30.3.0",
         "nodemon": "^3.1.2",
+        "pino-pretty": "^13.1.3",
         "socket.io-client": "^4.8.3",
         "supertest": "^7.0.0",
         "typedoc": "^0.28.0"
@@ -139,7 +142,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -614,6 +616,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -621,6 +648,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1491,6 +1519,12 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2172,7 +2206,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2312,6 +2345,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -2674,7 +2716,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -2989,6 +3030,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3233,6 +3281,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3453,6 +3511,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/engine.io": {
       "version": "6.6.8",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
@@ -3629,7 +3697,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3895,7 +3962,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3965,6 +4031,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -4274,7 +4347,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4486,6 +4558,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5649,6 +5728,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6144,6 +6233,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -6400,6 +6499,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6625,7 +6733,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -6743,6 +6850,93 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
+      "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
+      "license": "MIT",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^10.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -6910,6 +7104,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/promise-limit": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
@@ -6957,6 +7167,17 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7029,6 +7250,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/random-bytes": {
@@ -7112,6 +7339,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -7298,11 +7534,37 @@
         "regexp-tree": "~0.1.1"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7629,6 +7891,15 @@
       "optional": true,
       "dependencies": {
         "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -8005,6 +8276,24 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -8702,7 +8991,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,8 @@
     "morgan": "^1.10.0",
     "pg": "^8.20.0",
     "pg-boss": "^10.1.0",
+    "pino": "^10.3.1",
+    "pino-http": "^11.0.0",
     "socket.io": "^4.8.3",
     "swagger-jsdoc": "6.2.8",
     "swagger-ui-express": "5.0.1",
@@ -42,6 +44,7 @@
     "eslint-plugin-sql-injection": "^1.0.1",
     "jest": "^30.3.0",
     "nodemon": "^3.1.2",
+    "pino-pretty": "^13.1.3",
     "socket.io-client": "^4.8.3",
     "supertest": "^7.0.0",
     "typedoc": "^0.28.0"

--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -1,0 +1,20 @@
+"use strict";
+const pino = require("pino");
+
+const isDev = process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "test";
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || "info",
+  ...(isDev && {
+    transport: {
+      target: "pino-pretty",
+      options: {
+        colorize: true,
+        translateTime: "SYS:standard",
+        ignore: "pid,hostname",
+      },
+    },
+  }),
+});
+
+module.exports = logger;

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,10 +1,6 @@
 const rateLimit = require("express-rate-limit");
+const logger = require("../logger");
 
-/**
- * Factory function to create reusable rate limiters
- * @param {number} maxRequests - max requests allowed
- * @param {number} windowMinutes - time window in minutes
- */
 const createRateLimiter = (maxRequests, windowMinutes) => {
   return rateLimit({
     windowMs: windowMinutes * 60 * 1000,
@@ -12,6 +8,14 @@ const createRateLimiter = (maxRequests, windowMinutes) => {
     standardHeaders: true,
     legacyHeaders: false,
     handler: (req, res) => {
+      (req.log || logger).warn({
+        event: "rate_limit_hit",
+        ip: req.ip,
+        path: req.path,
+        method: req.method,
+        limit: maxRequests,
+        windowMinutes,
+      }, "Rate limit exceeded");
       res.set("Retry-After", Math.ceil(windowMinutes * 60));
       return res.status(429).json({
         message: "Too many requests — Try again later.",

--- a/backend/src/middleware/requestLogger.js
+++ b/backend/src/middleware/requestLogger.js
@@ -1,0 +1,24 @@
+"use strict";
+const pinoHttp = require("pino-http");
+const { v4: uuid } = require("uuid");
+const logger = require("../logger");
+
+module.exports = pinoHttp({
+  logger,
+  // Read X-Correlation-Id from inbound request or generate a fresh UUID
+  genReqId: (req) => req.headers["x-correlation-id"] || uuid(),
+  // Surface the request ID field as "correlationId" in log lines
+  customAttributeKeys: { reqId: "correlationId" },
+  serializers: {
+    req(req) {
+      return {
+        method: req.method,
+        url: req.url,
+        correlationId: req.id,
+      };
+    },
+    res(res) {
+      return { statusCode: res.statusCode };
+    },
+  },
+});

--- a/backend/src/routes/donations.js
+++ b/backend/src/routes/donations.js
@@ -5,6 +5,7 @@
 const express = require("express");
 const router  = express.Router();
 const { v4: uuid } = require("uuid");
+const logger = require("../logger");
 const pool = require("../db/pool");
 const { createRateLimiter } = require("../middleware/rateLimiter");
 const { computeBadges, mapDonationRow } = require("../services/store");
@@ -162,6 +163,15 @@ async function recordDonation(req, res, next) {
 
     await client.query("COMMIT");
     inTransaction = false;
+
+    (req.log || logger).info({
+      event: "donation_recorded",
+      amount: parsedAmount,
+      currency,
+      project: projectId,
+      donor: donorAddress,
+      txHash: transactionHash,
+    }, "Donation recorded");
 
     const io = req.app?.get("io");
     if (io) {

--- a/backend/src/routes/donations.test.js
+++ b/backend/src/routes/donations.test.js
@@ -364,6 +364,46 @@ describe("POST /api/donations", () => {
     ]);
   });
 
+  test("does not pass undefined as COMMIT query — transaction is explicitly committed", async () => {
+    const donorAddress = makePublicKey("H");
+    const transactionHash = makeTxHash("1");
+    const donationRow = {
+      id: "donation-h",
+      project_id: "project-h",
+      donor_address: donorAddress,
+      amount_xlm: "50",
+      amount: "50",
+      currency: "XLM",
+      message: null,
+      transaction_hash: transactionHash,
+      created_at: "2026-03-29T10:00:00.000Z",
+    };
+
+    const client = createMockClient(
+      queryResult([{ id: "project-h" }]),
+      queryResult([]),
+      queryResult(),
+      queryResult([donationRow]),
+      queryResult([]),
+      queryResult(),
+      queryResult([]),
+      queryResult([{ count: "1" }]),
+      queryResult(),
+    );
+
+    const { res, next } = await invokeRecordDonation({
+      projectId: "project-h",
+      donorAddress,
+      amountXLM: "50",
+      transactionHash,
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(201);
+    const calls = client.query.mock.calls.map(([sql]) => sql);
+    expect(calls).toContain("COMMIT");
+  });
+
   test("rolls back the transaction if profile persistence fails after BEGIN", async () => {
     const client = createMockClient(
       queryResult([{ id: "project-4" }]),
@@ -399,5 +439,158 @@ describe("POST /api/donations", () => {
     expect(res.statusCode).toBe(500);
     expect(client.query).toHaveBeenLastCalledWith("ROLLBACK");
     expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("profile upsert on first donation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("creates a new profile using only the first donation amount as total_donated_xlm", async () => {
+    const donorAddress = makePublicKey("P");
+    const transactionHash = makeTxHash("2");
+    const donationRow = {
+      id: "donation-p",
+      project_id: "project-p",
+      donor_address: donorAddress,
+      amount_xlm: "500",
+      amount: "500",
+      currency: "XLM",
+      message: null,
+      transaction_hash: transactionHash,
+      created_at: "2026-03-29T10:00:00.000Z",
+    };
+
+    const client = createMockClient(
+      queryResult([{ id: "project-p" }]),
+      queryResult([]),
+      queryResult(),
+      queryResult([donationRow]),
+      queryResult([]),
+      queryResult(),
+      queryResult([]),
+      queryResult([{ count: "1" }]),
+      queryResult(),
+    );
+
+    const { res, next } = await invokeRecordDonation({
+      projectId: "project-p",
+      donorAddress,
+      amountXLM: "500",
+      transactionHash,
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(201);
+
+    const upsert = findQueryCall(client, "INSERT INTO profiles");
+    expect(upsert[1][0]).toBe(donorAddress);
+    expect(upsert[1][1]).toBeNull();          // display_name: null (no existing profile)
+    expect(upsert[1][2]).toBeNull();          // bio: null
+    expect(upsert[1][3]).toBe("500.0000000"); // total_donated_xlm = first donation amount
+    expect(upsert[1][4]).toBe(1);             // projects_supported from COUNT query
+    expect(JSON.parse(upsert[1][5])).toEqual([
+      expect.objectContaining({ tier: "forest", earnedAt: expect.any(String) }),
+    ]);
+  });
+
+  test("preserves display_name and bio from an existing profile on upsert", async () => {
+    const donorAddress = makePublicKey("Q");
+    const transactionHash = makeTxHash("3");
+    const donationRow = {
+      id: "donation-q",
+      project_id: "project-q",
+      donor_address: donorAddress,
+      amount_xlm: "10",
+      amount: "10",
+      currency: "XLM",
+      message: null,
+      transaction_hash: transactionHash,
+      created_at: "2026-03-29T10:00:00.000Z",
+    };
+
+    const client = createMockClient(
+      queryResult([{ id: "project-q" }]),
+      queryResult([]),
+      queryResult(),
+      queryResult([donationRow]),
+      queryResult([]),
+      queryResult(),
+      queryResult([{                          // existing profile with display_name + bio
+        public_key: donorAddress,
+        display_name: "Green Donor",
+        bio: "I care about the planet.",
+        total_donated_xlm: "90.0000000",
+      }]),
+      queryResult([{ count: "2" }]),
+      queryResult(),
+    );
+
+    const { res, next } = await invokeRecordDonation({
+      projectId: "project-q",
+      donorAddress,
+      amountXLM: "10",
+      transactionHash,
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(201);
+
+    const upsert = findQueryCall(client, "INSERT INTO profiles");
+    expect(upsert[1][1]).toBe("Green Donor");      // display_name preserved
+    expect(upsert[1][2]).toBe("I care about the planet.");  // bio preserved
+    expect(upsert[1][3]).toBe("100.0000000");       // 90 + 10 accumulated
+    expect(JSON.parse(upsert[1][5])).toEqual([
+      expect.objectContaining({ tier: "tree", earnedAt: expect.any(String) }),
+    ]);
+  });
+
+  test("does not increment total_donated_xlm for non-XLM donations", async () => {
+    const donorAddress = makePublicKey("R");
+    const transactionHash = makeTxHash("4");
+    const donationRow = {
+      id: "donation-r",
+      project_id: "project-r",
+      donor_address: donorAddress,
+      amount_xlm: null,
+      amount: "25",
+      currency: "USD",
+      message: null,
+      transaction_hash: transactionHash,
+      created_at: "2026-03-29T10:00:00.000Z",
+    };
+
+    const client = createMockClient(
+      queryResult([{ id: "project-r" }]),
+      queryResult([]),
+      queryResult(),
+      queryResult([donationRow]),
+      // no donation_matches query for non-XLM
+      queryResult(),                          // UPDATE projects (raises_xlm += 0)
+      queryResult([{
+        public_key: donorAddress,
+        display_name: null,
+        bio: null,
+        total_donated_xlm: "200.0000000",    // pre-existing XLM total
+      }]),
+      queryResult([{ count: "3" }]),
+      queryResult(),
+    );
+
+    const { res, next } = await invokeRecordDonation({
+      projectId: "project-r",
+      donorAddress,
+      amount: "25",
+      currency: "USD",
+      transactionHash,
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(201);
+
+    const upsert = findQueryCall(client, "INSERT INTO profiles");
+    // total_donated_xlm must remain unchanged (200) for non-XLM donations
+    expect(upsert[1][3]).toBe("200.0000000");
   });
 });

--- a/backend/src/routes/leaderboard.test.js
+++ b/backend/src/routes/leaderboard.test.js
@@ -1,0 +1,169 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({ query: jest.fn() }));
+
+const pool = require("../db/pool");
+const request = require("supertest");
+const express = require("express");
+const leaderboardRouter = require("./leaderboard");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/leaderboard", leaderboardRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+// Rows are already in DESC order, simulating what the DB ORDER BY returns.
+const SORTED_DONORS = [
+  {
+    public_key: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    display_name: "Alice",
+    badges: [{ tier: "earth", earnedAt: "2026-01-01T00:00:00.000Z" }],
+    total_donated_xlm: "5000",
+    projects_supported: 4,
+  },
+  {
+    public_key: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    display_name: "Bob",
+    badges: [{ tier: "forest", earnedAt: "2026-01-02T00:00:00.000Z" }],
+    total_donated_xlm: "750",
+    projects_supported: 2,
+  },
+  {
+    public_key: "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    display_name: null,
+    badges: [],
+    total_donated_xlm: "12",
+    projects_supported: 1,
+  },
+];
+
+describe("GET /api/leaderboard — ranking sort order", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("assigns rank 1 to the highest donor and increments for each subsequent entry", async () => {
+    pool.query.mockResolvedValue({ rows: SORTED_DONORS });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data[0].rank).toBe(1);
+    expect(res.body.data[1].rank).toBe(2);
+    expect(res.body.data[2].rank).toBe(3);
+  });
+
+  test("preserves descending totalDonatedXLM order returned by the database", async () => {
+    pool.query.mockResolvedValue({ rows: SORTED_DONORS });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+
+    const totals = res.body.data.map((e) => Number(e.totalDonatedXLM));
+    for (let i = 0; i < totals.length - 1; i++) {
+      expect(totals[i]).toBeGreaterThanOrEqual(totals[i + 1]);
+    }
+  });
+
+  test("rank 1 entry corresponds to the highest totalDonatedXLM", async () => {
+    pool.query.mockResolvedValue({ rows: SORTED_DONORS });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+    const first = res.body.data[0];
+
+    expect(first.rank).toBe(1);
+    expect(first.publicKey).toBe(SORTED_DONORS[0].public_key);
+    expect(Number(first.totalDonatedXLM)).toBe(5000);
+  });
+
+  test("sets topBadge to the first badge tier when badges are present", async () => {
+    pool.query.mockResolvedValue({ rows: SORTED_DONORS });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+
+    expect(res.body.data[0].topBadge).toBe("earth");
+    expect(res.body.data[1].topBadge).toBe("forest");
+  });
+
+  test("sets topBadge to null when the donor has no badges", async () => {
+    pool.query.mockResolvedValue({ rows: SORTED_DONORS });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+
+    expect(res.body.data[2].topBadge).toBeNull();
+  });
+
+  test("maps database snake_case fields to camelCase response shape", async () => {
+    pool.query.mockResolvedValue({ rows: [SORTED_DONORS[0]] });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+    const entry = res.body.data[0];
+
+    expect(entry).toMatchObject({
+      rank: 1,
+      publicKey: SORTED_DONORS[0].public_key,
+      displayName: "Alice",
+      totalDonatedXLM: "5000",
+      projectsSupported: 4,
+      topBadge: "earth",
+    });
+  });
+
+  test("sets displayName to null when the profile has no display name", async () => {
+    pool.query.mockResolvedValue({ rows: [SORTED_DONORS[2]] });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+
+    expect(res.body.data[0].displayName).toBeNull();
+  });
+
+  test("returns an empty data array when no profiles exist", async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe("GET /api/leaderboard — limit handling", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+    pool.query.mockResolvedValue({ rows: [] });
+  });
+
+  test("passes a default limit of 20 to the database when not specified", async () => {
+    await request(app).get("/api/leaderboard").expect(200);
+
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), [20]);
+  });
+
+  test("respects a custom limit within bounds", async () => {
+    await request(app).get("/api/leaderboard?limit=5").expect(200);
+
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), [5]);
+  });
+
+  test("caps the limit at 100 when a larger value is requested", async () => {
+    await request(app).get("/api/leaderboard?limit=500").expect(200);
+
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), [100]);
+  });
+
+  test("falls back to default limit of 20 when limit is non-numeric", async () => {
+    await request(app).get("/api/leaderboard?limit=abc").expect(200);
+
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), [20]);
+  });
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -14,8 +14,9 @@ const express      = require("express");
 const cookieParser = require("cookie-parser");
 const csurf        = require("csurf");
 const helmet       = require("helmet");
-const morgan       = require("morgan");
 const rateLimit    = require("express-rate-limit");
+const logger       = require("./logger");
+const requestLogger = require("./middleware/requestLogger");
 const { runMigrations } = require("./db/migrate");
 const { startTurretsServer } = require("./services/turrets");
 const http = require("http");
@@ -38,7 +39,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 app.use(helmet());
-app.use(morgan("dev"));
+app.use(requestLogger);
 app.use(express.json({ limit: "20kb" }));
 app.use(cookieParser());
 app.use(csurf({
@@ -105,7 +106,7 @@ mount("/api/admin",         adminRouter);
 app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {
-  console.error("[Error]", err.message);
+  logger.error({ event: "unhandled_error", err }, err.message);
   res.status(err.status || 500).json({ error: err.message || "Internal server error" });
 });
 
@@ -115,10 +116,10 @@ async function startServer() {
   const { start: startSummaryQueue } = require("./services/summaryQueue");
   await startSummaryQueue(io);
 
-  startIndexer(io).catch(err => console.error("[Indexer Error]", err.message));
+  startIndexer(io).catch(err => logger.error({ event: "indexer_startup_error", err }, err.message));
 
   server.listen(PORT, () => {
-    console.log(`\n  🌱 Stellar GreenPay API\n  🚀 Running at http://localhost:${PORT}\n  🌐 Network: ${process.env.STELLAR_NETWORK || "testnet"}\n`);
+    logger.info({ event: "server_start", port: PORT, network: process.env.STELLAR_NETWORK || "testnet" }, "Stellar GreenPay API running");
   });
 
   if (process.env.ENABLE_TURRETS === "true") {
@@ -129,7 +130,7 @@ async function startServer() {
 
 if (require.main === module) {
   startServer().catch((err) => {
-    console.error("[Startup Error]", err.message);
+    logger.fatal({ event: "startup_error", err }, err.message);
     process.exit(1);
   });
 }

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -7,6 +7,7 @@ const { server: stellarServer } = require("./stellar");
 const pool = require("../db/pool");
 const { v4: uuid } = require("uuid");
 const { computeBadges } = require("./store");
+const logger = require("../logger");
 
 let lastProcessedLedger = 0;
 let isRunning = false;
@@ -23,9 +24,9 @@ async function updateProjectWallets() {
     for (const row of result.rows) {
       projectWallets.set(row.wallet_address, row.id);
     }
-    console.log(`[Indexer] Updated cache with ${projectWallets.size} project wallets.`);
+    logger.debug({ event: "indexer_wallets_refreshed", count: projectWallets.size }, "Project wallet cache updated");
   } catch (err) {
-    console.error("[Indexer] Failed to update project wallets cache:", err.message);
+    logger.error({ event: "indexer_wallets_refresh_error", err }, err.message);
   }
 }
 
@@ -49,7 +50,7 @@ async function startIndexer(socketIo) {
   // Refresh cache every 10 minutes
   setInterval(updateProjectWallets, 10 * 60 * 1000);
 
-  console.log("[Indexer] Starting Horizon operations stream...");
+  logger.info({ event: "indexer_started" }, "Starting Horizon operations stream");
 
   // Start streaming operations from 'now'
   stellarServer.operations()
@@ -67,11 +68,11 @@ async function startIndexer(socketIo) {
             }
           }
         } catch (err) {
-          console.error("[Indexer] Error processing operation:", err.message);
+          logger.error({ event: "indexer_op_error", err }, err.message);
         }
       },
       onerror: (err) => {
-        console.error("[Indexer] Stream error:", err);
+        logger.error({ event: "indexer_horizon_stream_error", err }, "Horizon stream error");
       }
     });
 }
@@ -157,7 +158,14 @@ async function handleDonation(projectId, op) {
     await client.query("COMMIT");
     inTransaction = false;
 
-    console.log(`[Indexer] New donation: ${amountXLM} XLM from ${donorAddress} to project ${projectId}`);
+    logger.info({
+      event: "indexer_donation_recorded",
+      amount: amountXLM,
+      currency: "XLM",
+      project: projectId,
+      donor: donorAddress,
+      txHash,
+    }, "Indexer donation recorded");
 
     // 5. Emit WebSocket event
     if (io) {
@@ -171,7 +179,7 @@ async function handleDonation(projectId, op) {
     }
   } catch (err) {
     if (inTransaction) await client.query("ROLLBACK");
-    console.error("[Indexer] Failed to process donation:", err.message);
+    logger.error({ event: "indexer_donation_error", project: projectId, txHash, err }, err.message);
   } finally {
     client.release();
   }

--- a/backend/src/services/store.test.js
+++ b/backend/src/services/store.test.js
@@ -2,6 +2,7 @@
 
 const {
   computeBadges,
+  BADGE_THRESHOLDS,
   mapProjectRow,
   mapDonationRow,
   mapProfileRow,
@@ -10,6 +11,30 @@ const {
   mapProjectMilestoneRow,
   mapProjectRatingRow,
 } = require("./store");
+
+describe("BADGE_THRESHOLDS contract spec", () => {
+  test("defines exactly four tiers: seedling, tree, forest, earth", () => {
+    const tiers = BADGE_THRESHOLDS.map((b) => b.tier);
+    expect(tiers).toEqual(expect.arrayContaining(["seedling", "tree", "forest", "earth"]));
+    expect(tiers).toHaveLength(4);
+  });
+
+  test("seedling tier requires at least 10 XLM", () => {
+    expect(BADGE_THRESHOLDS.find((b) => b.tier === "seedling").min).toBe(10);
+  });
+
+  test("tree tier requires at least 100 XLM", () => {
+    expect(BADGE_THRESHOLDS.find((b) => b.tier === "tree").min).toBe(100);
+  });
+
+  test("forest tier requires at least 500 XLM", () => {
+    expect(BADGE_THRESHOLDS.find((b) => b.tier === "forest").min).toBe(500);
+  });
+
+  test("earth guardian tier requires at least 2000 XLM", () => {
+    expect(BADGE_THRESHOLDS.find((b) => b.tier === "earth").min).toBe(2000);
+  });
+});
 
 describe("store utility functions", () => {
   test("computeBadges returns no badge below 10 XLM", () => {
@@ -20,8 +45,37 @@ describe("store utility functions", () => {
     expect(computeBadges(10)[0]).toMatchObject({ tier: "seedling" });
   });
 
+  test("computeBadges returns seedling at 99 XLM (just below tree threshold)", () => {
+    expect(computeBadges(99)[0]).toMatchObject({ tier: "seedling" });
+  });
+
+  test("computeBadges returns tree badge at exactly 100 XLM", () => {
+    expect(computeBadges(100)[0]).toMatchObject({ tier: "tree" });
+  });
+
+  test("computeBadges returns tree at 499 XLM (just below forest threshold)", () => {
+    expect(computeBadges(499)[0]).toMatchObject({ tier: "tree" });
+  });
+
+  test("computeBadges returns forest badge at exactly 500 XLM", () => {
+    expect(computeBadges(500)[0]).toMatchObject({ tier: "forest" });
+  });
+
+  test("computeBadges returns forest at 1999 XLM (just below earth guardian threshold)", () => {
+    expect(computeBadges(1999)[0]).toMatchObject({ tier: "forest" });
+  });
+
   test("computeBadges returns highest earned badge", () => {
     expect(computeBadges(2000)[0]).toMatchObject({ tier: "earth" });
+  });
+
+  test("computeBadges returns earth guardian well above 2000 XLM", () => {
+    expect(computeBadges(50000)[0]).toMatchObject({ tier: "earth" });
+  });
+
+  test("computeBadges earned badge includes a valid earnedAt ISO timestamp", () => {
+    const [badge] = computeBadges(10);
+    expect(badge.earnedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   test("mapProjectRow maps database project fields to API fields", () => {


### PR DESCRIPTION

Summary

- Replace Morgan with Pino for structured, machine-readable logging across the backend
- Add correlationId propagation on every request and service-level event log
- Expand unit tests to cover badge-tier thresholds, leaderboard ranking, and profile upsert behaviour

Logging changes

New files
- src/logger.js — root Pino instance; JSON in production/test, pino-pretty colourised output in development. Respects LOG_LEVEL env var.
- src/middleware/requestLogger.js — pino-http middleware that replaces Morgan. Reads X-Correlation-Id from inbound headers or mints a UUID; exposes req.log (child logger with correlationId bound) to all downstream handlers.

Updated files
- server.js — swapped morgan("dev") for requestLogger; all console.* calls replaced with logger.* (info / error / fatal)
- routes/donations.js — emits a structured info log after every successful donation commit: { event, amount, currency, project, donor, txHash }
- services/indexerService.js — structured logs for wallet cache refresh, Horizon stream start/error, and each indexed donation; Horizon stream errors log event: "indexer_horizon_stream_error"
- middleware/rateLimiter.js — rate-limit handler now emits a warn log with { event: "rate_limit_hit", ip, path, method, limit, windowMinutes }

Log format example (production)
{"level":30,"time":1234567890,"correlationId":"c3d2...","event":"donation_recorded","amount":500,"currency":"XLM","project":"abc-123","donor":"GABC...","txHash":"def0...","msg":"Donation recorded"}

Test changes

src/services/store.test.js
- New BADGE_THRESHOLDS contract spec describe — asserts all four tier names and exact min values match the spec (seedling=10, tree=100, forest=500, earth=2000)
- Added missing Tree/Forest boundary tests plus just-below-threshold values (99, 499, 1999) and earnedAt timestamp format assertion

src/routes/leaderboard.test.js (new file)
- Verifies rank 1 is assigned to the highest total_donated_xlm donor and increments per entry
- Asserts descending sort order is preserved from the DB result
- Checks topBadge is extracted from badges[0].tier and is null for donors with no badges
- Covers camelCase field mapping, empty leaderboard, default limit (20), custom limit, cap at 100, and non-numeric fallback

src/routes/donations.test.js
- New profile upsert on first donation describe with four cases: COMMIT is always issued, a brand-new profile is created with the donation amount as the initial total, display_name/bio are preserved for returning donors, and non-XLM donations leave total_donated_xlm unchanged

Test plan

- [ ] npx jest --runInBand — 102 tests pass (3 pre-existing failures in donations.api.test.js and projects.test.js are unrelated to this PR)
- [ ] Start server in development (npm run dev) — logs are colourised and human-readable
- [ ] Set NODE_ENV=production — logs are newline-delimited JSON
- [ ] POST a donation — confirm structured log line with amount, project, donor, txHash, and correlationId appears
- [ ] Exceed rate limit — confirm warn log with event: "rate_limit_hit" appears

Closes #196
Closes #139
Closes #137
Closes #142 