### PR TITLE
devops: add CODEOWNERS file mapping directories to responsible mainta…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+/contracts/   @contracts-team
+/frontend/    @frontend-team
+/backend/     @backend-team
+/mobile/      @mobile-team
+/extension/   @extension-team
+/k8s/         @devops-team


### PR DESCRIPTION
Close #463 

### Summary
Adds a `.github/CODEOWNERS` file that maps top-level project directories to their responsible teams. GitHub will now automatically request the correct team as a reviewer whenever a PR touches files under these paths.

### Changes
Created `.github/CODEOWNERS` with the following mappings:

| Path           | Owner             |
| -------------- | ----------------- |
| `/contracts/`  | `@contracts-team` |
| `/frontend/`   | `@frontend-team`  |
| `/backend/`    | `@backend-team`   |
| `/mobile/`     | `@mobile-team`    |
| `/extension/`  | `@extension-team` |
| `/k8s/`        | `@devops-team`    |

### Why
- Ensures the right reviewers are auto-requested on every PR, reducing back-and-forth over "who should review this."
- Establishes clear ownership boundaries across the codebase.
- Can be paired with branch protection rules to require code-owner approval before merge.

### Notes
- The `@*-team` handles must exist as actual GitHub teams in the org with **write access** to this repo for the auto-request to take effect — otherwise GitHub silently ignores the entry.

### Testing
- File placed at `.github/CODEOWNERS` (GitHub's recognized location).
- Syntax follows the standard `path  @owner` format; no app/build changes involved.
