### PR TITLE
security: verify transactionHash is confirmed on Stellar before recor…

### DIFF
--- a/backend/src/routes/donations.api.test.js
+++ b/backend/src/routes/donations.api.test.js
@@ -14,6 +14,10 @@ jest.mock("../services/redis", () => ({
   set: jest.fn(),
 }));
 
+jest.mock("../services/stellar", () => ({
+  server: { getTransaction: jest.fn().mockResolvedValue({ successful: true }) },
+}));
+
 const pool = require("../db/pool");
 const express = require("express");
 const request = require("supertest");

--- a/backend/src/routes/donations.js
+++ b/backend/src/routes/donations.js
@@ -8,6 +8,7 @@ const { v4: uuid } = require("uuid");
 const pool = require("../db/pool");
 const { createRateLimiter } = require("../middleware/rateLimiter");
 const { computeBadges, mapDonationRow } = require("../services/store");
+const { server } = require("../services/stellar");
 const donationLimiter = createRateLimiter(10, 1); // 10 requests per minute
 
 function validateKey(k) {
@@ -43,6 +44,18 @@ async function recordDonation(req, res, next) {
       [transactionHash],
     );
     if (existingResult.rows[0]) return res.json({ success: true, data: mapDonationRow(existingResult.rows[0]) });
+
+    // Verify the transaction is confirmed on-chain before recording it.
+    // Prevents a caller from inflating raised_xlm with a fake or unconfirmed tx hash.
+    let onChainTx;
+    try {
+      onChainTx = await server.getTransaction(transactionHash);
+    } catch {
+      const e = new Error("Transaction not found on Stellar"); e.status = 400; throw e;
+    }
+    if (!onChainTx || onChainTx.successful !== true) {
+      const e = new Error("Transaction not confirmed on Stellar"); e.status = 400; throw e;
+    }
 
     await client.query("BEGIN");
     inTransaction = true;

--- a/backend/src/routes/donations.socket.test.js
+++ b/backend/src/routes/donations.socket.test.js
@@ -4,6 +4,9 @@ jest.mock("../db/pool", () => ({ connect: jest.fn() }));
 jest.mock("../middleware/rateLimiter", () => ({
   createRateLimiter: () => (req, res, next) => next(),
 }));
+jest.mock("../services/stellar", () => ({
+  server: { getTransaction: jest.fn().mockResolvedValue({ successful: true }) },
+}));
 
 const http = require("http");
 const express = require("express");

--- a/backend/src/routes/donations.test.js
+++ b/backend/src/routes/donations.test.js
@@ -8,6 +8,11 @@ jest.mock("../middleware/rateLimiter", () => ({
   createRateLimiter: () => (req, res, next) => next(),
 }));
 
+jest.mock("../services/stellar", () => ({
+  server: { getTransaction: jest.fn().mockResolvedValue({ successful: true }) },
+}));
+
+const { server } = require("../services/stellar");
 const pool = require("../db/pool");
 const { computeBadges } = require("../services/store");
 const { recordDonation } = require("./donations");
@@ -362,6 +367,49 @@ describe("POST /api/donations", () => {
     expect(JSON.parse(profileUpsertCall[1][5])).toEqual([
       expect.objectContaining({ tier: "tree", earnedAt: expect.any(String) }),
     ]);
+  });
+
+  test("rejects a transaction that is not confirmed on Stellar", async () => {
+    server.getTransaction.mockResolvedValueOnce({ successful: false });
+    const client = createMockClient(
+      queryResult([{ id: "project-1" }]),   // SELECT project
+      queryResult([]),                         // dedup check
+    );
+
+    const { res, next } = await invokeRecordDonation({
+      projectId: "project-1",
+      donorAddress: makePublicKey("H"),
+      amountXLM: "10",
+      transactionHash: makeTxHash("9"),
+    });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Transaction not confirmed on Stellar");
+    // No DB write transaction should have been opened.
+    expect(client.query).not.toHaveBeenCalledWith("BEGIN");
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a transaction hash that cannot be found on Stellar", async () => {
+    server.getTransaction.mockRejectedValueOnce(new Error("404 Not Found"));
+    const client = createMockClient(
+      queryResult([{ id: "project-1" }]),   // SELECT project
+      queryResult([]),                         // dedup check
+    );
+
+    const { res, next } = await invokeRecordDonation({
+      projectId: "project-1",
+      donorAddress: makePublicKey("I"),
+      amountXLM: "10",
+      transactionHash: makeTxHash("8"),
+    });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("Transaction not found on Stellar");
+    expect(client.query).not.toHaveBeenCalledWith("BEGIN");
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 
   test("rolls back the transaction if profile persistence fails after BEGIN", async () => {


### PR DESCRIPTION
Close #468 

### Summary
The `POST /api/donations` endpoint recorded donations based solely on the caller's claimed `transactionHash`. The hash was only regex-validated (`/^[a-fA-F0-9]{64}$/`) — never checked on-chain. A bad actor could submit any well-formed but **fake or unconfirmed** transaction hash to inflate `raised_xlm`, donor totals, and even trigger matching-donation payouts.

This PR adds on-chain verification: the transaction must exist on Stellar and be confirmed (`successful === true`) before any record is written.

### The vulnerability
`backend/src/routes/donations.js` → `recordDonation` inserted a donation and then:
- incremented `projects.raised_xlm`
- updated the donor's cumulative total and badges
- inserted matching donations and updated `donation_matches`

...all driven by an unverified, caller-supplied hash.

### Changes
**`backend/src/routes/donations.js`**
- Import the shared `server` (Horizon) from `../services/stellar` — the same instance already used for transaction verification in `projects.js`.
- After the dedup check and **before** the DB write transaction (`BEGIN`), call `server.getTransaction(transactionHash)` and require `successful === true`.
- Reject with:
  - **400 "Transaction not found on Stellar"** if the lookup throws (e.g. unknown hash)
  - **400 "Transaction not confirmed on Stellar"** if the tx exists but is not successful
- Placement rationale: duplicate submissions still short-circuit early (no redundant network call), and nothing is written for an unverified tx.

**Tests** (`donations.test.js`, `donations.api.test.js`, `donations.socket.test.js`)
- Added a default `../services/stellar` mock (`getTransaction → { successful: true }`) so suites don't make real network calls.
- Added two new tests covering the security behavior: unconfirmed tx and not-found tx → `400`, with no `BEGIN` issued.

### Testing
- `npx jest src/routes/donations.test.js` → **19/19 pass** (includes the 2 new tests).

### Notes
- One unrelated test, `records a valid donation` in `donations.api.test.js`, fails on `main` **before this change** (verified via `git stash`) due to a miscounted mock query sequence. Left untouched as it's out of scope for this security fix — flagging it for a separate cleanup.

### Security impact
- **Before:** anyone could inflate fundraising totals with a fabricated hash.
- **After:** only genuinely confirmed on-chain transactions can record a donation.
