### PR TITLE
fix: restrict extension host_permissions, add project input validation, SQL audit, pg pool tuning

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,3 +24,8 @@ ADMIN_PASSWORD=
 
 # Anthropic Claude API — required for AI project summaries
 ANTHROPIC_API_KEY=
+
+# PostgreSQL connection pool tuning
+DB_POOL_MAX=20
+DB_POOL_IDLE_TIMEOUT=30000
+DB_POOL_CONNECT_TIMEOUT=2000

--- a/backend/src/db/pool.js
+++ b/backend/src/db/pool.js
@@ -8,6 +8,9 @@ const DATABASE_URL =
 const pool = new Pool({
   connectionString: DATABASE_URL,
   ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+  max: parseInt(process.env.DB_POOL_MAX || "20", 10),
+  idleTimeoutMillis: parseInt(process.env.DB_POOL_IDLE_TIMEOUT || "30000", 10),
+  connectionTimeoutMillis: parseInt(process.env.DB_POOL_CONNECT_TIMEOUT || "2000", 10),
 });
 
 pool.on("error", (err) => {

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -176,7 +176,9 @@ router.get("/", async (req, res, next) => {
     }
     query += `ORDER BY created_at DESC, id DESC LIMIT $${limitIdx}`;
 
-    // eslint-disable-next-line sql-injection/no-sql-injection
+    // All user-controlled values (status, category, search, cursor fields) are
+    // passed as parameterised $N placeholders in `values`. Dynamic WHERE clauses
+    // are built only from whitelisted enum strings, so no injection surface exists.
     const result = await pool.query(query, values);
     const rows = result.rows;
     const hasMore = rows.length > pageSize;
@@ -192,6 +194,45 @@ router.get("/", async (req, res, next) => {
     await redis.set(cacheKey, responseBody, PROJECTS_LIST_CACHE_TTL);
 
     res.json(responseBody);
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * POST /api/projects
+ * Create a new project. Validates string lengths to prevent database bloat.
+ */
+router.post("/", async (req, res, next) => {
+  try {
+    const { name, description, location, category, wallet_address, goal_xlm = 0, tags = [] } = req.body || {};
+
+    if (!name || typeof name !== "string" || name.trim().length < 3 || name.trim().length > 120) {
+      return res.status(400).json({ error: "name must be between 3 and 120 characters" });
+    }
+    if (!description || typeof description !== "string" || description.trim().length < 10 || description.trim().length > 5000) {
+      return res.status(400).json({ error: "description must be between 10 and 5000 characters" });
+    }
+    if (!location || typeof location !== "string" || location.trim().length < 2 || location.trim().length > 200) {
+      return res.status(400).json({ error: "location must be between 2 and 200 characters" });
+    }
+    if (!category || !VALID_CATEGORIES.includes(category)) {
+      return res.status(400).json({ error: `category must be one of: ${VALID_CATEGORIES.join(", ")}` });
+    }
+    if (!wallet_address || typeof wallet_address !== "string") {
+      return res.status(400).json({ error: "wallet_address is required" });
+    }
+
+    const id = uuid();
+    const result = await pool.query(
+      `INSERT INTO projects (id, name, description, category, location, wallet_address, goal_xlm, tags)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [id, name.trim(), description.trim(), category, location.trim(), wallet_address, goal_xlm, tags],
+    );
+
+    await redis.deletePattern(PROJECTS_LIST_CACHE_PREFIX + "*");
+    res.status(201).json({ success: true, data: mapProjectRow(result.rows[0]) });
   } catch (e) {
     next(e);
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,11 +13,12 @@
     "scripting"
   ],
   "host_permissions": [
-    "<all_urls>"
+    "https://app.greenpay.io/*",
+    "https://testnet.greenpay.io/*"
   ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://app.greenpay.io/*", "https://testnet.greenpay.io/*"],
       "js": ["dist/content-script.js"],
       "run_at": "document_end"
     }


### PR DESCRIPTION
## Summary

- **#471**: `extension/manifest.json` — replaced `<all_urls>` in `host_permissions` and content script `matches` with `["https://app.greenpay.io/*", "https://testnet.greenpay.io/*"]`, eliminating the broad host permission flag
- **#467**: `backend/src/routes/projects.js` — added `POST /api/projects` handler with explicit length validation: `name` (3–120), `description` (10–5000), `location` (2–200); returns 400 with a clear error message when limits are exceeded
- **#475**: `backend/src/routes/projects.js` — removed `// eslint-disable-next-line sql-injection/no-sql-injection` suppression comment; replaced it with an explanatory comment confirming all user-controlled values are parameterised and dynamic WHERE clauses are built only from whitelisted enum strings
- **#477**: `backend/src/db/pool.js` — added `max`, `idleTimeoutMillis`, and `connectionTimeoutMillis` pool options driven by `DB_POOL_MAX`, `DB_POOL_IDLE_TIMEOUT`, `DB_POOL_CONNECT_TIMEOUT` env vars (defaults: 20 / 30000 / 2000); documented in `backend/.env.example`

Closes #471, Closes #467, Closes #475, Closes #477