### PR TITLE
perf: add ETag and Last-Modified headers to GET /api/projects/:id

### DIFF
--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -2,6 +2,7 @@
  * src/routes/projects.js
  */
 "use strict";
+const crypto = require("crypto");
 const express = require("express");
 const router = express.Router();
 const { v4: uuid } = require("uuid");
@@ -453,6 +454,18 @@ router.get("/:id", async (req, res, next) => {
   try {
     const projectResult = await pool.query("SELECT * FROM projects WHERE id = $1", [req.params.id]);
     if (!projectResult.rows[0]) return res.status(404).json({ error: "Project not found" });
+
+    const updatedAt = projectResult.rows[0].updated_at;
+    const etag = `"${crypto.createHash("md5").update(String(updatedAt)).digest("hex")}"`;
+    const lastModified = new Date(updatedAt).toUTCString();
+
+    res.set("ETag", etag);
+    res.set("Last-Modified", lastModified);
+
+    if (req.headers["if-none-match"] === etag) {
+      return res.status(304).end();
+    }
+
     const campaigns = await fetchCampaignsForProject(req.params.id);
     const onChainProject = await getOnChainProject(req.params.id);
 


### PR DESCRIPTION
## Summary

- Computes an ETag from `project.updated_at` using an MD5 hash and sets it on every `GET /api/projects/:id` response alongside a `Last-Modified` header
- Checks `If-None-Match` on each request; returns `304 Not Modified` (no body) when the client's cached ETag still matches, reducing bandwidth on repeated project page loads
- Added `require("crypto")` (Node built-in, no new dependency)

Closes #478