### PR TITLE
Require admin key for admin write endpoints

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -15,6 +15,8 @@ const envSchema = z.object({
   JWT_SECRET: z.string().optional().default(""),
   ADMIN_USERNAME: z.string().optional().default("admin"),
   ADMIN_PASSWORD: z.string().optional().default(""),
+  ADMIN_API_KEY: z.string().optional().default(""),
+  ADMIN_API_KEYS: z.string().optional().default(""),
   ANTHROPIC_API_KEY: z.string().optional().default(""),
   REDIS_URL: z.string().optional().default("redis://localhost:6379"),
   ENABLE_TURRETS: z.enum(["true", "false"]).optional().default("false"),

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,4 +1,5 @@
 "use strict";
+const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
 
 function getSecret() {
@@ -13,7 +14,63 @@ function verifyToken(token) {
   return jwt.verify(token, getSecret());
 }
 
+function getConfiguredAdminKeys() {
+  return [
+    process.env.ADMIN_API_KEY,
+    ...(process.env.ADMIN_API_KEYS || "").split(","),
+  ]
+    .map((key) => (typeof key === "string" ? key.trim() : ""))
+    .filter(Boolean);
+}
+
+function timingSafeEquals(a, b) {
+  const aHash = crypto.createHash("sha256").update(a).digest();
+  const bHash = crypto.createHash("sha256").update(b).digest();
+  return crypto.timingSafeEqual(aHash, bHash);
+}
+
+function isValidAdminKey(value) {
+  if (!value || typeof value !== "string") return false;
+  return getConfiguredAdminKeys().some((configuredKey) =>
+    timingSafeEquals(value, configuredKey),
+  );
+}
+
+function attachAdminKeyPrincipal(req) {
+  req.admin = {
+    role: "admin",
+    sub: "admin-key",
+    authMethod: "x-admin-key",
+  };
+}
+
+function adminKeyRequired(req, res, next) {
+  const configuredKeys = getConfiguredAdminKeys();
+  const adminKey = req.get("X-Admin-Key");
+
+  if (!adminKey) {
+    return res.status(401).json({ error: "Missing X-Admin-Key header" });
+  }
+
+  if (configuredKeys.length === 0) {
+    return res.status(503).json({ error: "Admin key authentication not configured on this server" });
+  }
+
+  if (!isValidAdminKey(adminKey)) {
+    return res.status(401).json({ error: "Invalid X-Admin-Key header" });
+  }
+
+  attachAdminKeyPrincipal(req);
+  next();
+}
+
 function adminRequired(req, res, next) {
+  const adminKey = req.get("X-Admin-Key");
+  if (adminKey && isValidAdminKey(adminKey)) {
+    attachAdminKeyPrincipal(req);
+    return next();
+  }
+
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     return res.status(401).json({ error: "Missing or malformed Authorization header" });
@@ -31,4 +88,4 @@ function adminRequired(req, res, next) {
   }
 }
 
-module.exports = { signToken, verifyToken, adminRequired };
+module.exports = { signToken, verifyToken, adminRequired, adminKeyRequired, isValidAdminKey };

--- a/backend/src/routes/admin.test.js
+++ b/backend/src/routes/admin.test.js
@@ -1,7 +1,7 @@
 "use strict";
 const express = require("express");
 const request = require("supertest");
-const { signToken, adminRequired } = require("../middleware/auth");
+const { signToken, adminRequired, adminKeyRequired } = require("../middleware/auth");
 
 jest.mock("../middleware/rateLimiter", () => ({
   createRateLimiter: () => (req, res, next) => next(),
@@ -9,6 +9,7 @@ jest.mock("../middleware/rateLimiter", () => ({
 
 process.env.ADMIN_USERNAME = "admin";
 process.env.ADMIN_PASSWORD = "testpass";
+process.env.ADMIN_API_KEY = "test-admin-key";
 process.env.JWT_SECRET = "test-secret-for-jest";
 
 function buildApp() {
@@ -134,6 +135,53 @@ describe("adminRequired middleware", () => {
   it("allows requests with valid token", async () => {
     const token = signToken({ role: "admin", sub: "admin" }, "1h");
     const res = await request(app).get("/protected").set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("allows requests with valid X-Admin-Key", async () => {
+    const res = await request(app).get("/protected").set("X-Admin-Key", "test-admin-key");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.user.authMethod).toBe("x-admin-key");
+  });
+});
+
+describe("adminKeyRequired middleware", () => {
+  let app;
+
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = "test-admin-key";
+    delete process.env.ADMIN_API_KEYS;
+    app = express();
+    app.use(express.json());
+    app.post("/protected", adminKeyRequired, (req, res) => res.json({ ok: true, user: req.admin }));
+  });
+
+  it("rejects requests without X-Admin-Key", async () => {
+    const res = await request(app).post("/protected").send({});
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Missing X-Admin-Key header");
+  });
+
+  it("rejects requests with an invalid X-Admin-Key", async () => {
+    const res = await request(app).post("/protected").set("X-Admin-Key", "wrong").send({});
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid X-Admin-Key header");
+  });
+
+  it("allows requests with the configured X-Admin-Key", async () => {
+    const res = await request(app).post("/protected").set("X-Admin-Key", "test-admin-key").send({});
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.user.role).toBe("admin");
+  });
+
+  it("allows rotated comma-separated keys from ADMIN_API_KEYS", async () => {
+    delete process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEYS = "old-key, new-key";
+
+    const res = await request(app).post("/protected").set("X-Admin-Key", "new-key").send({});
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
   });

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -7,6 +7,7 @@ const router = express.Router();
 const { v4: uuid } = require("uuid");
 const pool = require("../db/pool");
 const { logAdminAction } = require("../services/audit");
+const { adminKeyRequired } = require("../middleware/auth");
 const { mapProjectRow, mapProjectMilestoneRow } = require("../services/store");
 const { getOnChainProject, CONTRACT_ID, server, NETWORK_PASSPHRASE } = require("../services/stellar");
 const { enqueueAISummary } = require("../services/summaryQueue");
@@ -244,7 +245,7 @@ router.get("/:id/verify", async (req, res) => {
   }
 });
 
-router.post("/:id/campaigns", async (req, res, next) => {
+router.post("/:id/campaigns", adminKeyRequired, async (req, res, next) => {
   try {
     const { title, goalXLM, deadline, description } = req.body || {};
     const trimmedTitle = typeof title === "string" ? title.trim() : "";
@@ -320,7 +321,7 @@ router.get("/:id/milestones", async (req, res, next) => {
   }
 });
 
-router.post("/:id/milestones", async (req, res, next) => {
+router.post("/:id/milestones", adminKeyRequired, async (req, res, next) => {
   try {
     const { title, percentage } = req.body;
     if (!title || typeof percentage !== "number") {
@@ -348,7 +349,7 @@ router.post("/:id/milestones", async (req, res, next) => {
   }
 });
 
-router.post("/:id/milestones/:milestoneId/reach", async (req, res, next) => {
+router.post("/:id/milestones/:milestoneId/reach", adminKeyRequired, async (req, res, next) => {
   try {
     const { transactionHash } = req.body;
     const result = await pool.query(
@@ -380,7 +381,7 @@ router.post("/:id/milestones/:milestoneId/reach", async (req, res, next) => {
  * Builds a Soroban transaction to register a project on-chain.
  * Returns the XDR for the admin to sign.
  */
-router.post("/admin/register", async (req, res) => {
+router.post("/admin/register", adminKeyRequired, async (req, res) => {
   try {
     const { projectId, name, wallet, co2PerXLM, adminAddress } = req.body;
     
@@ -417,7 +418,7 @@ router.post("/admin/register", async (req, res) => {
  * POST /api/projects/admin/confirm
  * Verifies a registration transaction and updates the local store.
  */
-router.post("/admin/confirm", async (req, res) => {
+router.post("/admin/confirm", adminKeyRequired, async (req, res) => {
   try {
     const { transactionHash, projectId } = req.body;
     
@@ -517,7 +518,7 @@ router.get("/:id", async (req, res, next) => {
  * Response: { success: true, data: { aiSummary, aiSummaryGeneratedAt,
  *                                    aiSummaryModel, aiSummarySourceHash } }
  */
-router.post("/:id/generate-summary", async (req, res, next) => {
+router.post("/:id/generate-summary", adminKeyRequired, async (req, res, next) => {
   try {
     const { adminAddress } = req.body || {};
     if (!adminAddress || typeof adminAddress !== "string") {
@@ -556,7 +557,7 @@ router.post("/:id/generate-summary", async (req, res, next) => {
   }
 });
 
-router.post("/:id/matching", async (req, res, next) => {
+router.post("/:id/matching", adminKeyRequired, async (req, res, next) => {
   try {
     const { matcherAddress, capXLM, multiplier, expiresAt } = req.body || {};
 
@@ -649,7 +650,7 @@ router.get("/:id/matching", async (req, res, next) => {
  * Approve or reject a project. Body: { status: "active" | "rejected", reason?: string }
  * `adminAddress` must match the project wallet (owner) or be a platform admin.
  */
-router.patch("/:id/status", async (req, res, next) => {
+router.patch("/:id/status", adminKeyRequired, async (req, res, next) => {
   try {
     const { status, reason, adminAddress } = req.body || {};
     const validStatuses = ["active", "rejected", "paused"];

--- a/backend/src/routes/projects.test.js
+++ b/backend/src/routes/projects.test.js
@@ -8,6 +8,7 @@ jest.mock("../db/pool", () => ({
 jest.mock("../services/redis", () => ({
   get: jest.fn(),
   set: jest.fn(),
+  deletePattern: jest.fn(),
 }));
 
 jest.mock("../services/stellar", () => ({
@@ -26,6 +27,8 @@ const redis = require("../services/redis");
 const express = require("express");
 const request = require("supertest");
 const projectsRouter = require("./projects");
+
+process.env.ADMIN_API_KEY = "test-admin-key";
 
 function buildApp() {
   const app = express();
@@ -178,5 +181,30 @@ describe("POST /api/projects (admin)", () => {
       .send({ name: "Test" });
 
     expect(res.status).toBe(401);
+  });
+
+  test("rejects requests with an invalid admin key", async () => {
+    const res = await request(app)
+      .patch("/api/projects/proj-1/status")
+      .set("X-Admin-Key", "wrong")
+      .send({ status: "active", adminAddress: "GADMIN" });
+
+    expect(res.status).toBe(401);
+  });
+
+  test("allows status updates with a valid admin key", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [MOCK_PROJECT_ROW] })
+      .mockResolvedValueOnce({ rows: [{ ...MOCK_PROJECT_ROW, status: "paused" }] });
+    redis.deletePattern.mockResolvedValue(0);
+
+    const res = await request(app)
+      .patch("/api/projects/proj-1/status")
+      .set("X-Admin-Key", "test-admin-key")
+      .send({ status: "paused", reason: "maintenance", adminAddress: "GADMIN" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(redis.deletePattern).toHaveBeenCalledWith("projects:list:*");
   });
 });

--- a/backend/src/services/turrets.js
+++ b/backend/src/services/turrets.js
@@ -302,6 +302,7 @@ async function generatePreSignedTransactions({
  */
 function startTurretsServer(port = 3001) {
   const express = require("express");
+  const { adminKeyRequired } = require("../middleware/auth");
   const app = express();
 
   app.use(express.json());
@@ -324,7 +325,7 @@ function startTurretsServer(port = 3001) {
   });
 
   // Endpoint to generate pre-signed transactions
-  app.post("/admin/presign", async (req, res) => {
+  app.post("/admin/presign", adminKeyRequired, async (req, res) => {
     try {
       const {
         matcherAddress,


### PR DESCRIPTION
Summary
- Adds an `X-Admin-Key` authentication path for admin-only backend operations so admin routes no longer rely on `adminAddress` in the request body as proof of authority.
- Supports key rotation through environment variables without code changes: set `ADMIN_API_KEY` for a single key or `ADMIN_API_KEYS` for comma-separated active keys during rotation.
- Keeps existing signed JWT admin auth working for `/api/admin` routes while allowing the same middleware to accept a valid admin key when needed.

Issue
- Closes #474

Changes
- Added constant-time admin key validation in `backend/src/middleware/auth.js`.
- Added `adminKeyRequired` middleware for routes that perform admin writes or generate sensitive admin transactions.
- Protected project admin/write endpoints including campaign creation, milestone writes, project registration/confirmation, summary generation, matching setup, and status changes.
- Protected the Turrets `/admin/presign` endpoint with the same admin key middleware.
- Added `ADMIN_API_KEY` and `ADMIN_API_KEYS` to backend env validation.
- Added backend tests for missing, invalid, valid, and rotated admin keys, plus a protected project status update path.

Validation
- Passed: `git diff --check`
- Not run: Jest/lint/build because this fresh clone does not have `backend/node_modules` installed.

Notes
- To rotate keys, deploy with `ADMIN_API_KEYS="old-key,new-key"`, update clients to the new key, then remove the old key from the environment.
