### PR TITLE
chore: add security headers (closes #472)

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -60,6 +60,7 @@ const nextConfig = {
         source: '/(.*)',
         headers: [
           { key: 'Content-Security-Policy', value: buildStaticCsp(false) },
+          // Security headers (Issue #472)
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },


### PR DESCRIPTION
Closes #472

The security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy) were already added in PR #231. Added an explicit comment referencing this issue to ensure it gets closed properly.