### PR TITLE
fix(security/perf): restrict host_permissions, input validation, SQL audit, pool tuning, ETags

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,3 +24,8 @@ ADMIN_PASSWORD=
 
 # Anthropic Claude API — required for AI project summaries
 ANTHROPIC_API_KEY=
+
+# PostgreSQL connection pool tuning
+DB_POOL_MAX=20
+DB_POOL_IDLE_TIMEOUT=30000
+DB_POOL_CONNECT_TIMEOUT=2000

--- a/backend/src/db/pool.js
+++ b/backend/src/db/pool.js
@@ -8,6 +8,9 @@ const DATABASE_URL =
 const pool = new Pool({
   connectionString: DATABASE_URL,
   ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+  max: parseInt(process.env.DB_POOL_MAX || "20", 10),
+  idleTimeoutMillis: parseInt(process.env.DB_POOL_IDLE_TIMEOUT || "30000", 10),
+  connectionTimeoutMillis: parseInt(process.env.DB_POOL_CONNECT_TIMEOUT || "2000", 10),
 });
 
 pool.on("error", (err) => {

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -176,7 +176,9 @@ router.get("/", async (req, res, next) => {
     }
     query += `ORDER BY created_at DESC, id DESC LIMIT $${limitIdx}`;
 
-    // eslint-disable-next-line sql-injection/no-sql-injection
+    // All user-controlled values (status, category, search, cursor fields) are
+    // passed as parameterised $N placeholders in `values`. Dynamic WHERE clauses
+    // are built only from whitelisted enum strings, so no injection surface exists.
     const result = await pool.query(query, values);
     const rows = result.rows;
     const hasMore = rows.length > pageSize;
@@ -192,6 +194,45 @@ router.get("/", async (req, res, next) => {
     await redis.set(cacheKey, responseBody, PROJECTS_LIST_CACHE_TTL);
 
     res.json(responseBody);
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * POST /api/projects
+ * Create a new project. Validates string lengths to prevent database bloat.
+ */
+router.post("/", async (req, res, next) => {
+  try {
+    const { name, description, location, category, wallet_address, goal_xlm = 0, tags = [] } = req.body || {};
+
+    if (!name || typeof name !== "string" || name.trim().length < 3 || name.trim().length > 120) {
+      return res.status(400).json({ error: "name must be between 3 and 120 characters" });
+    }
+    if (!description || typeof description !== "string" || description.trim().length < 10 || description.trim().length > 5000) {
+      return res.status(400).json({ error: "description must be between 10 and 5000 characters" });
+    }
+    if (!location || typeof location !== "string" || location.trim().length < 2 || location.trim().length > 200) {
+      return res.status(400).json({ error: "location must be between 2 and 200 characters" });
+    }
+    if (!category || !VALID_CATEGORIES.includes(category)) {
+      return res.status(400).json({ error: `category must be one of: ${VALID_CATEGORIES.join(", ")}` });
+    }
+    if (!wallet_address || typeof wallet_address !== "string") {
+      return res.status(400).json({ error: "wallet_address is required" });
+    }
+
+    const id = uuid();
+    const result = await pool.query(
+      `INSERT INTO projects (id, name, description, category, location, wallet_address, goal_xlm, tags)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [id, name.trim(), description.trim(), category, location.trim(), wallet_address, goal_xlm, tags],
+    );
+
+    await redis.deletePattern(PROJECTS_LIST_CACHE_PREFIX + "*");
+    res.status(201).json({ success: true, data: mapProjectRow(result.rows[0]) });
   } catch (e) {
     next(e);
   }

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -2,6 +2,7 @@
  * src/routes/projects.js
  */
 "use strict";
+const crypto = require("crypto");
 const express = require("express");
 const router = express.Router();
 const { v4: uuid } = require("uuid");
@@ -494,6 +495,16 @@ router.get("/:id", async (req, res, next) => {
   try {
     const projectResult = await pool.query("SELECT * FROM projects WHERE id = $1", [req.params.id]);
     if (!projectResult.rows[0]) return res.status(404).json({ error: "Project not found" });
+
+    const updatedAt = projectResult.rows[0].updated_at;
+    const etag = `"${crypto.createHash("md5").update(String(updatedAt)).digest("hex")}"`;
+    const lastModified = new Date(updatedAt).toUTCString();
+    res.set("ETag", etag);
+    res.set("Last-Modified", lastModified);
+    if (req.headers["if-none-match"] === etag) {
+      return res.status(304).end();
+    }
+
     const campaigns = await fetchCampaignsForProject(req.params.id);
     const onChainProject = await getOnChainProject(req.params.id);
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,11 +13,12 @@
     "scripting"
   ],
   "host_permissions": [
-    "<all_urls>"
+    "https://app.greenpay.io/*",
+    "https://testnet.greenpay.io/*"
   ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://app.greenpay.io/*", "https://testnet.greenpay.io/*"],
       "js": ["dist/content-script.js"],
       "run_at": "document_end"
     }


### PR DESCRIPTION
## Summary

- **#471**: `extension/manifest.json` — replaced `<all_urls>` in `host_permissions` and content script `matches` with the two GreenPay domains (`app.greenpay.io`, `testnet.greenpay.io`), removing the broad host permission flag
- **#467**: `backend/src/routes/projects.js` — added `POST /api/projects` with explicit length validation: `name` (3–120 chars), `description` (10–5000 chars), `location` (2–200 chars); returns 400 with a clear error message when limits are exceeded
- **#475**: `backend/src/routes/projects.js` — removed `eslint-disable sql-injection` suppression; replaced with an explanatory comment confirming all user-controlled values are parameterised and dynamic WHERE clauses are built from whitelisted enums only
- **#477**: `backend/src/db/pool.js` — added `max`, `idleTimeoutMillis`, and `connectionTimeoutMillis` driven by `DB_POOL_MAX`, `DB_POOL_IDLE_TIMEOUT`, `DB_POOL_CONNECT_TIMEOUT` env vars (defaults: 20 / 30 000 ms / 2 000 ms); documented in `backend/.env.example`
- **#478**: `backend/src/routes/projects.js` — `GET /api/projects/:id` now sets `ETag` (MD5 of `updated_at`) and `Last-Modified` headers; responds `304 Not Modified` when `If-None-Match` matches, eliminating redundant response bodies on repeated loads

Closes #471, Closes #467, Closes #475, Closes #477, Closes #478