### PR TITLE
All fix for the CI have been don succesfully

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,32 @@ jobs:
       - run: cargo test --workspace
       - run: cargo build --workspace --target wasm32-unknown-unknown --release
 
+  helm:
+    name: Helm Chart Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v3
+        with:
+          version: latest
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: latest
+      - run: helm lint helm/greenpay/
+      - run: helm template greenpay helm/greenpay/ | kubectl apply --dry-run=client -f -
+
+  gitleaks:
+    name: Secret scanning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gitleaks
+        run: |
+          curl -sL "https://github.com/zricethezav/gitleaks/releases/latest/download/gitleaks_$(uname -s)_$(uname -m).tar.gz" | tar xzf -
+          sudo mv gitleaks /usr/local/bin/gitleaks
+      - name: Secret scanning
+        run: gitleaks detect --config .gitleaks.toml --source . --exit-code 1
+
   zap_scan:
     name: DAST Security Scan (OWASP ZAP)
     runs-on: ubuntu-latest

--- a/backend/src/routes/csrf.test.js
+++ b/backend/src/routes/csrf.test.js
@@ -11,6 +11,7 @@ describe("CSRF protection", () => {
     expect(res.body).toEqual(expect.objectContaining({ success: true }));
     expect(typeof res.body.csrfToken).toBe("string");
     expect(res.body.csrfToken.length).toBeGreaterThan(0);
+    expect(res.headers["content-security-policy"]).toBe("default-src 'none'; frame-ancestors 'none'");
   });
 
   it("rejects mutating requests without an X-CSRF-Token header", async () => {

--- a/backend/src/routes/donations.js
+++ b/backend/src/routes/donations.js
@@ -9,6 +9,7 @@ const logger = require("../logger");
 const pool = require("../db/pool");
 const { createRateLimiter } = require("../middleware/rateLimiter");
 const { computeBadges, mapDonationRow } = require("../services/store");
+const { enqueueProfileUpdate } = require("../services/profileQueue");
 const donationLimiter = createRateLimiter(10, 1); // 10 requests per minute
 
 function validateKey(k) {
@@ -122,47 +123,12 @@ async function recordDonation(req, res, next) {
       [currency === "XLM" ? parsedAmount : 0, projectId],
     );
 
-    // Update donor profile
-    const existingProfileResult = await client.query(
-      "SELECT * FROM profiles WHERE public_key = $1",
-      [donorAddress],
-    );
-    const existingProfile = existingProfileResult.rows[0];
-    const previousTotal = existingProfile
-      ? Number.parseFloat(existingProfile.total_donated_xlm || "0")
-      : 0;
-    const newTotal = currency === "XLM" ? previousTotal + parsedAmount : previousTotal;
-    const projectsSupportedResult = await client.query(
-      `SELECT COUNT(DISTINCT project_id) AS count
-       FROM donations
-       WHERE donor_address = $1`,
-      [donorAddress],
-    );
-    const projectsSupported = Number.parseInt(projectsSupportedResult.rows[0].count, 10) || 0;
-    const badges = computeBadges(newTotal);
-
-    await client.query(
-      `INSERT INTO profiles (
-        public_key, display_name, bio, total_donated_xlm, projects_supported, badges, created_at, updated_at
-      )
-      VALUES ($1, $2, $3, $4, $5, $6::jsonb, NOW(), NOW())
-      ON CONFLICT (public_key) DO UPDATE SET
-        total_donated_xlm = EXCLUDED.total_donated_xlm,
-        projects_supported = EXCLUDED.projects_supported,
-        badges = EXCLUDED.badges,
-        updated_at = EXCLUDED.updated_at`,
-      [
-        donorAddress,
-        existingProfile?.display_name || null,
-        existingProfile?.bio || null,
-        newTotal.toFixed(7),
-        projectsSupported,
-        JSON.stringify(badges),
-      ],
-    );
-
     await client.query("COMMIT");
     inTransaction = false;
+
+    enqueueProfileUpdate(donorAddress).catch((err) => {
+      logger.error({ event: "profile_update_enqueue_failed", err, donorAddress }, "Failed to enqueue profile update job");
+    });
 
     (req.log || logger).info({
       event: "donation_recorded",

--- a/backend/src/routes/donations.test.js
+++ b/backend/src/routes/donations.test.js
@@ -8,8 +8,13 @@ jest.mock("../middleware/rateLimiter", () => ({
   createRateLimiter: () => (req, res, next) => next(),
 }));
 
+jest.mock("../services/profileQueue", () => ({
+  enqueueProfileUpdate: jest.fn(),
+}));
+
 const pool = require("../db/pool");
 const { computeBadges } = require("../services/store");
+const { enqueueProfileUpdate } = require("../services/profileQueue");
 const { recordDonation } = require("./donations");
 
 function makePublicKey(char = "A") {
@@ -160,9 +165,7 @@ describe("POST /api/donations", () => {
       queryResult([donationRow]),              // INSERT donation
       queryResult([]),                         // SELECT donation_matches (empty)
       queryResult(),                           // UPDATE projects
-      queryResult([]),                         // SELECT * FROM profiles (new donor)
-      queryResult([{ count: "1" }]),           // SELECT COUNT(DISTINCT project_id)
-      queryResult(),                           // INSERT INTO profiles
+      queryResult(),                           // COMMIT
     );
 
     const { res, next } = await invokeRecordDonation({
@@ -187,14 +190,7 @@ describe("POST /api/donations", () => {
       }),
     );
     expect(client.release).toHaveBeenCalledTimes(1);
-
-    const profileUpsertCall = findQueryCall(client, "INSERT INTO profiles");
-    expect(profileUpsertCall[1][0]).toBe(donorAddress);
-    expect(profileUpsertCall[1][3]).toBe("10.0000000");
-    expect(profileUpsertCall[1][4]).toBe(1);
-    expect(JSON.parse(profileUpsertCall[1][5])).toEqual([
-      expect.objectContaining({ tier: "seedling", earnedAt: expect.any(String) }),
-    ]);
+    expect(enqueueProfileUpdate).toHaveBeenCalledWith(donorAddress);
   });
 
   test("returns 404 for an unknown project id", async () => {
@@ -298,9 +294,7 @@ describe("POST /api/donations", () => {
       }]),                                      // INSERT donation
       queryResult([]),                          // SELECT donation_matches (empty)
       queryResult(),                            // UPDATE projects
-      queryResult([]),                          // SELECT * FROM profiles (new donor)
-      queryResult([{ count: "1" }]),            // SELECT COUNT(DISTINCT project_id)
-      queryResult(),                            // INSERT INTO profiles
+      queryResult(),                            // COMMIT
     );
 
     const { res, next } = await invokeRecordDonation({
@@ -312,6 +306,7 @@ describe("POST /api/donations", () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(201);
+    expect(enqueueProfileUpdate).toHaveBeenCalledWith(makePublicKey("E"));
 
     const updateProjectCall = findQueryCall(client, "UPDATE projects");
     expect(updateProjectCall[1]).toEqual([5.5, "project-2"]);
@@ -336,14 +331,7 @@ describe("POST /api/donations", () => {
       }]),                                      // INSERT donation
       queryResult([]),                          // SELECT donation_matches (empty)
       queryResult(),                            // UPDATE projects
-      queryResult([{                            // SELECT * FROM profiles (returning existing)
-        public_key: donorAddress,
-        display_name: "Existing Donor",
-        bio: "Already donated before",
-        total_donated_xlm: "99.0000000",
-      }]),
-      queryResult([{ count: "3" }]),            // SELECT COUNT(DISTINCT project_id)
-      queryResult(),                            // INSERT INTO profiles
+      queryResult(),                            // COMMIT
     );
 
     const { res, next } = await invokeRecordDonation({
@@ -355,13 +343,7 @@ describe("POST /api/donations", () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(201);
-
-    const profileUpsertCall = findQueryCall(client, "INSERT INTO profiles");
-    expect(profileUpsertCall[1][3]).toBe("100.0000000");
-    expect(profileUpsertCall[1][4]).toBe(3);
-    expect(JSON.parse(profileUpsertCall[1][5])).toEqual([
-      expect.objectContaining({ tier: "tree", earnedAt: expect.any(String) }),
-    ]);
+    expect(enqueueProfileUpdate).toHaveBeenCalledWith(donorAddress);
   });
 
   test("does not pass undefined as COMMIT query — transaction is explicitly committed", async () => {
@@ -400,6 +382,7 @@ describe("POST /api/donations", () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(201);
+    expect(enqueueProfileUpdate).toHaveBeenCalledWith(donorAddress);
     const calls = client.query.mock.calls.map(([sql]) => sql);
     expect(calls).toContain("COMMIT");
   });
@@ -483,16 +466,7 @@ describe("profile upsert on first donation", () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(201);
-
-    const upsert = findQueryCall(client, "INSERT INTO profiles");
-    expect(upsert[1][0]).toBe(donorAddress);
-    expect(upsert[1][1]).toBeNull();          // display_name: null (no existing profile)
-    expect(upsert[1][2]).toBeNull();          // bio: null
-    expect(upsert[1][3]).toBe("500.0000000"); // total_donated_xlm = first donation amount
-    expect(upsert[1][4]).toBe(1);             // projects_supported from COUNT query
-    expect(JSON.parse(upsert[1][5])).toEqual([
-      expect.objectContaining({ tier: "forest", earnedAt: expect.any(String) }),
-    ]);
+    expect(enqueueProfileUpdate).toHaveBeenCalledWith(donorAddress);
   });
 
   test("preserves display_name and bio from an existing profile on upsert", async () => {
@@ -536,14 +510,7 @@ describe("profile upsert on first donation", () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(201);
-
-    const upsert = findQueryCall(client, "INSERT INTO profiles");
-    expect(upsert[1][1]).toBe("Green Donor");      // display_name preserved
-    expect(upsert[1][2]).toBe("I care about the planet.");  // bio preserved
-    expect(upsert[1][3]).toBe("100.0000000");       // 90 + 10 accumulated
-    expect(JSON.parse(upsert[1][5])).toEqual([
-      expect.objectContaining({ tier: "tree", earnedAt: expect.any(String) }),
-    ]);
+    expect(enqueueProfileUpdate).toHaveBeenCalledWith(donorAddress);
   });
 
   test("does not increment total_donated_xlm for non-XLM donations", async () => {
@@ -568,14 +535,7 @@ describe("profile upsert on first donation", () => {
       queryResult([donationRow]),
       // no donation_matches query for non-XLM
       queryResult(),                          // UPDATE projects (raises_xlm += 0)
-      queryResult([{
-        public_key: donorAddress,
-        display_name: null,
-        bio: null,
-        total_donated_xlm: "200.0000000",    // pre-existing XLM total
-      }]),
-      queryResult([{ count: "3" }]),
-      queryResult(),
+      queryResult(),                          // COMMIT
     );
 
     const { res, next } = await invokeRecordDonation({
@@ -588,9 +548,6 @@ describe("profile upsert on first donation", () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(201);
-
-    const upsert = findQueryCall(client, "INSERT INTO profiles");
-    // total_donated_xlm must remain unchanged (200) for non-XLM donations
-    expect(upsert[1][3]).toBe("200.0000000");
+    expect(enqueueProfileUpdate).toHaveBeenCalledWith(donorAddress);
   });
 });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -21,6 +21,8 @@ const { runMigrations } = require("./db/migrate");
 const { startTurretsServer } = require("./services/turrets");
 const http = require("http");
 const { Server } = require("socket.io");
+const { start: startSummaryQueue } = require("./services/summaryQueue");
+const { start: startProfileQueue } = require("./services/profileQueue");
 const { startIndexer } = require("./services/indexerService");
 const { createCorsMiddleware, getAllowedOrigins } = require("./middleware/corsPolicy");
 
@@ -39,6 +41,10 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 app.use(helmet());
+app.use((req, res, next) => {
+  res.setHeader("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'");
+  next();
+});
 app.use(requestLogger);
 app.use(express.json({ limit: "20kb" }));
 app.use(cookieParser());
@@ -113,8 +119,8 @@ app.use((err, req, res, next) => {
 async function startServer() {
   await runMigrations();
 
-  const { start: startSummaryQueue } = require("./services/summaryQueue");
   await startSummaryQueue(io);
+  await startProfileQueue(io);
 
   startIndexer(io).catch(err => logger.error({ event: "indexer_startup_error", err }, err.message));
 

--- a/backend/src/services/profileQueue.js
+++ b/backend/src/services/profileQueue.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const PgBoss = require("pg-boss");
+const pool = require("../db/pool");
+const { computeBadges } = require("./store");
+
+const QUEUE = "profile-update";
+let boss = null;
+
+async function start(io) {
+  const connectionString =
+    process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/greenpay";
+
+  boss = new PgBoss(connectionString);
+  boss.on("error", (err) => console.error("[profileQueue] pg-boss error:", err.message));
+
+  await boss.start();
+
+  await boss.work(QUEUE, { teamSize: 2, teamConcurrency: 1 }, async (job) => {
+    const { donorAddress } = job.data;
+
+    const totalResult = await pool.query(
+      `SELECT COALESCE(SUM(amount_xlm), 0)::numeric AS total
+       FROM donations
+       WHERE donor_address = $1
+         AND amount_xlm IS NOT NULL`,
+      [donorAddress],
+    );
+
+    const totalDonatedXlm = parseFloat(totalResult.rows[0]?.total || "0");
+
+    const projectsSupportedResult = await pool.query(
+      `SELECT COUNT(DISTINCT project_id) AS count
+       FROM donations
+       WHERE donor_address = $1`,
+      [donorAddress],
+    );
+
+    const projectsSupported = Number.parseInt(projectsSupportedResult.rows[0]?.count || "0", 10);
+    const badges = computeBadges(totalDonatedXlm);
+
+    const existingProfileResult = await pool.query(
+      "SELECT display_name, bio FROM profiles WHERE public_key = $1",
+      [donorAddress],
+    );
+
+    const existingProfile = existingProfileResult.rows[0] || {};
+
+    await pool.query(
+      `INSERT INTO profiles (
+         public_key,
+         display_name,
+         bio,
+         total_donated_xlm,
+         projects_supported,
+         badges,
+         created_at,
+         updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, NOW(), NOW())
+       ON CONFLICT (public_key) DO UPDATE SET
+         total_donated_xlm = EXCLUDED.total_donated_xlm,
+         projects_supported = EXCLUDED.projects_supported,
+         badges = EXCLUDED.badges,
+         updated_at = EXCLUDED.updated_at`,
+      [
+        donorAddress,
+        existingProfile.display_name || null,
+        existingProfile.bio || null,
+        totalDonatedXlm.toFixed(7),
+        projectsSupported,
+        JSON.stringify(badges),
+      ],
+    );
+
+    if (io) {
+      io.emit("profile_updated", {
+        donorAddress,
+        totalDonatedXLM: totalDonatedXlm.toFixed(7),
+        projectsSupported,
+        badges,
+      });
+    }
+  });
+
+  console.log("[profileQueue] pg-boss started, worker registered on queue:", QUEUE);
+}
+
+async function enqueueProfileUpdate(donorAddress) {
+  if (!boss) {
+    throw new Error("profileQueue not started — call start(io) first");
+  }
+  return boss.send(QUEUE, { donorAddress }, { retryLimit: 3, retryDelay: 10 });
+}
+
+module.exports = { start, enqueueProfileUpdate };


### PR DESCRIPTION
Complete Breakdown of Issues Solved


# CLOSES #462 ✔️ 
```
devops: add helm lint check in CI
```
I updated [ci.yml](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/).
I added a new [helm](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/) job that:
checks out the repo
installs [helm](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/)
installs kubectl
runs helm lint helm/greenpay/
runs [helm template greenpay helm/greenpay/ | kubectl apply --dry-run=client -f -](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/)
This ensures broken Helm charts are validated as part of CI.

# CLOSES #464 ✔️ 
```
devops: add Gitleaks pre-commit hook step to CI
```
I updated [ci.yml](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/).
I added a new gitleaks job that:
checks out the repo
installs gitleaks
runs gitleaks detect --config .gitleaks.toml --source . --exit-code 1
This enforces secret scanning as a required CI status check.

# CLOSES #469 ✔️ 
```
security: add Content-Security-Policy header to all API responses
```
I updated [server.js](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/).
I added global middleware that sets:
Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
I also added a regression assertion in [csrf.test.js](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/) to verify the header is present on API responses.

# CLOSES #479  ✔️ 
```
performance: update profiles.total_donated_xlm asynchronously after donation instead of in critical path
```
I implemented [profileQueue.js](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/) to enqueue and process profile update jobs using [pg-boss](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/).
I updated [donations.js](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/):
removed inline profile upsert logic from the donation transaction
committed the donation and project updates first
enqueued [enqueueProfileUpdate(donorAddress)](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/) after the transaction commit
I updated [server.js](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/) to start the profile queue service alongside the existing summary queue.
I adjusted [donations.test.js](https://friendly-bassoon-g6wqgj6xrw5394qj.github.dev/) to assert that profile updates are enqueued asynchronously rather than updated inline.