### PR TITLE
Add frontend workflow for Playwright e2e

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,123 @@
+name: Frontend Build and E2E
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  frontend-build-and-e2e:
+    name: Frontend Build and Playwright E2E
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: greenpay
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d greenpay"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+        env:
+          NEXT_PUBLIC_STELLAR_NETWORK: testnet
+          NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
+          NEXT_PUBLIC_API_URL: http://localhost:4000
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Start backend server
+        working-directory: backend
+        run: npm start &
+        env:
+          NODE_ENV: test
+          PORT: "4000"
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/greenpay
+          ALLOWED_ORIGINS: http://localhost:3000
+
+      - name: Wait for backend
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:4000/health > /dev/null; then
+              echo "Backend is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Backend failed to start"
+          exit 1
+
+      - name: Start frontend server
+        working-directory: frontend
+        run: npm run start &
+        env:
+          NEXT_PUBLIC_STELLAR_NETWORK: testnet
+          NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
+          NEXT_PUBLIC_API_URL: http://localhost:4000
+
+      - name: Wait for frontend
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:3000 > /dev/null; then
+              echo "Frontend is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Frontend failed to start"
+          exit 1
+
+      - name: Run Playwright tests
+        working-directory: frontend
+        run: npx playwright test
+        env:
+          CI: ""
+          NEXT_PUBLIC_STELLAR_NETWORK: testnet
+          NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
+          NEXT_PUBLIC_API_URL: http://localhost:4000
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: |
+            frontend/test-results/**/trace.zip
+            frontend/test-results/**/*.png
+            frontend/test-results/**/*.webm
+            frontend/playwright-report/
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
Summary
Adds a new GitHub Actions workflow at `.github/workflows/frontend.yml` to automate frontend build and Playwright E2E checks.

This workflow now:
- Installs frontend dependencies and runs `npm ci && npm run build` in `frontend/`
- Installs backend dependencies
- Starts Postgres (service), backend server, and frontend server
- Waits for backend (`/health`) and frontend readiness before test execution
- Runs `npx playwright test`
- Uploads Playwright traces/artifacts on failure (`frontend/test-results/**/trace.zip`, media, and `frontend/playwright-report/`)

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #458

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
N/A (no UI changes)