### PR TITLE
feat(contract): add GlobalStats struct and get_global_stats() to reduce RPC round trips

### DIFF
--- a/contracts/greenpay-contract/src/lib.rs
+++ b/contracts/greenpay-contract/src/lib.rs
@@ -97,6 +97,25 @@ pub struct VoteProposal {
     pub resolved:        bool,
 }
 
+/// Aggregated platform-wide counters returned by `get_global_stats`.
+///
+/// Bundles the four values that the landing page hero section needs in a
+/// single RPC call, avoiding the four separate `get_global_total`,
+/// `get_global_co2`, `get_donation_count`, and `get_project_count` round
+/// trips that were required before this type existed.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlobalStats {
+    /// Total XLM (in stroops) donated across all projects and all currencies.
+    pub total_raised:    i128,
+    /// Cumulative CO₂ offset in grams across every donation ever recorded.
+    pub co2_offset_grams: i128,
+    /// Total number of individual donation transactions recorded on-chain.
+    pub donation_count:  u32,
+    /// Total number of climate projects registered with the contract.
+    pub project_count:   u32,
+}
+
 #[contracttype]
 pub enum DataKey {
     Admin,
@@ -325,6 +344,33 @@ impl GreenPayContract {
 
     pub fn get_donation_count(env: Env) -> u32 {
         env.storage().instance().get(&DataKey::DonationCount).unwrap_or(0)
+    }
+
+    /// Returns all four global counters in a single contract call.
+    ///
+    /// This eliminates the four separate RPC round trips that were previously
+    /// required to populate the landing page hero section (total raised, CO₂
+    /// offset, donation count, project count).  Clients should prefer this
+    /// function over calling the individual getters when all four values are
+    /// needed at the same time.
+    ///
+    /// # Example (JavaScript SDK)
+    /// ```js
+    /// const stats = await contract.get_global_stats();
+    /// console.log(stats.total_raised, stats.co2_offset_grams,
+    ///             stats.donation_count, stats.project_count);
+    /// ```
+    pub fn get_global_stats(env: Env) -> GlobalStats {
+        GlobalStats {
+            total_raised:     env.storage().instance()
+                                  .get(&DataKey::GlobalTotalRaised).unwrap_or(0),
+            co2_offset_grams: env.storage().instance()
+                                  .get(&DataKey::GlobalCO2OffsetGrams).unwrap_or(0),
+            donation_count:   env.storage().instance()
+                                  .get(&DataKey::DonationCount).unwrap_or(0),
+            project_count:    env.storage().instance()
+                                  .get(&DataKey::ProjectCount).unwrap_or(0),
+        }
     }
 
     pub fn get_admin(env: Env) -> Address {
@@ -629,6 +675,66 @@ mod tests {
         assert_eq!(client.get_project_count(), 0);
         assert_eq!(client.get_donation_count(), 0);
         assert_eq!(client.get_global_total(), 0);
+    }
+
+    /// `get_global_stats` should return a zero-valued struct immediately after
+    /// initialization, before any projects are registered or donations made.
+    #[test]
+    fn test_get_global_stats_initial_zeros() {
+        let env    = Env::default();
+        let id     = env.register_contract(None, GreenPayContract);
+        let client = GreenPayContractClient::new(&env, &id);
+        let admin  = Address::generate(&env);
+        client.initialize(&admin);
+
+        let stats = client.get_global_stats();
+        assert_eq!(stats.total_raised,     0);
+        assert_eq!(stats.co2_offset_grams, 0);
+        assert_eq!(stats.donation_count,   0);
+        assert_eq!(stats.project_count,    0);
+    }
+
+    /// `get_global_stats` should return values consistent with the individual
+    /// getters (`get_global_total`, `get_global_co2`, `get_donation_count`,
+    /// `get_project_count`) after a donation has been processed.
+    #[test]
+    fn test_get_global_stats_matches_individual_getters() {
+        let env    = Env::default();
+        env.mock_all_auths();
+        let id     = env.register_contract(None, GreenPayContract);
+        let client = GreenPayContractClient::new(&env, &id);
+        let admin  = Address::generate(&env);
+        client.initialize(&admin);
+
+        // Register a project (co2_per_xlm = 200 grams per XLM)
+        let pid    = String::from_str(&env, "proj-stats");
+        let wallet = Address::generate(&env);
+        client.register_project(
+            &admin, &pid,
+            &String::from_str(&env, "Stats Project"),
+            &wallet, &200u32,
+        );
+
+        // Mint tokens and donate
+        let token_admin = Address::generate(&env);
+        let token       = env.register_stellar_asset_contract_v2(token_admin).address();
+        let donor       = Address::generate(&env);
+        let amount      = 50 * STROOP; // 50 XLM
+        soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&donor, &amount);
+        client.donate(&token, &donor, &pid, &amount, &1u32);
+
+        // get_global_stats must agree with each individual getter
+        let stats = client.get_global_stats();
+        assert_eq!(stats.total_raised,     client.get_global_total());
+        assert_eq!(stats.co2_offset_grams, client.get_global_co2());
+        assert_eq!(stats.donation_count,   client.get_donation_count());
+        assert_eq!(stats.project_count,    client.get_project_count());
+
+        // Spot-check concrete values
+        assert_eq!(stats.total_raised,     amount);
+        assert_eq!(stats.co2_offset_grams, 50 * 200i128); // 10 000 g
+        assert_eq!(stats.donation_count,   1);
+        assert_eq!(stats.project_count,    1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the optimization requested in #415.

The landing-page hero section currently makes **four separate Soroban RPC calls** to read the
platform-wide counters (`get_global_total`, `get_global_co2`, `get_donation_count`,
`get_project_count`). This PR bundles all four values into a single `get_global_stats()` call,
reducing that to **one RPC round trip**.

### What was added

**`GlobalStats` struct** (`#[contracttype]`)

| Field | Type | Description |
|---|---|---|
| `total_raised` | `i128` | Total XLM donated in stroops across all projects and currencies |
| `co2_offset_grams` | `i128` | Cumulative CO₂ offset in grams across all recorded donations |
| `donation_count` | `u32` | Total number of individual donation transactions |
| `project_count` | `u32` | Total number of climate projects registered |

**`get_global_stats(env: Env) -> GlobalStats`** — new read-only function on `GreenPayContract`
that performs four `instance().get()` lookups and returns them in a single serialised struct.
No new storage keys are introduced; the function reads the four existing `DataKey` entries
(`GlobalTotalRaised`, `GlobalCO2OffsetGrams`, `DonationCount`, `ProjectCount`) that are already
written by `initialize()`, `donate()`, `donate_usdc()`, and `register_project()`.

### Why this is safe / non-breaking

- **No storage schema changes** — zero new `DataKey` variants.
- **No mutation** — the function is a pure getter; it cannot affect contract state.
- All four individual getters (`get_global_total`, `get_global_co2`, `get_donation_count`,
  `get_project_count`) are **kept intact** for backward compatibility with existing callers.
- The `GlobalStats` struct is marked `#[contracttype]` (XDR-serialisable), `Clone`, `Debug`,
  and `PartialEq`, consistent with every other struct in the contract.
- `unwrap_or(0)` default on every field mirrors the identical guard in each individual getter,
  so calling `get_global_stats` on a freshly deployed contract cannot panic.

### Performance impact

| Scenario | Before | After |
|---|---|---|
| Hero stats on page load | 4 × RPC round trip | 1 × RPC round trip |
| Existing individual getters | unchanged | unchanged |

On Testnet (≈ 200–400 ms per RPC call) this shaves roughly **600–1 200 ms** off the hero
section first-contentful-paint on cold load.

---

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Smart contract change

## Related Issue
Closes #415

## Testing

### New tests added (`contracts/greenpay-contract/src/lib.rs`)

**`test_get_global_stats_initial_zeros`**
Verifies that immediately after `initialize()` the struct returns all-zero values — matches the
behaviour of each individual getter at the same point.

**`test_get_global_stats_matches_individual_getters`**
Registers a project (`co2_per_xlm = 200`), mints a token, performs a 50 XLM donation, then
asserts:
- `stats.total_raised == get_global_total()`
- `stats.co2_offset_grams == get_global_co2()`
- `stats.donation_count == get_donation_count()`
- `stats.project_count == get_project_count()`
- Concrete spot-checks: `total_raised == 500_000_000` (50 XLM in stroops),
  `co2_offset_grams == 10_000` (50 × 200 g), `donation_count == 1`, `project_count == 1`

> **Note:** Rust / Cargo is not available in the CI codespace for this PR. The Soroban unit
> test suite is validated by the `contracts` CI workflow (`.github/workflows/ci.yml`) which
> runs `cargo test --features testutils` in the merge queue. All existing tests remain
> unchanged and continue to cover the full donate / governance / upgrade flows.

- [x] No TypeScript / Rust errors (manual code review — struct and getter follow the exact same
  patterns as all existing `#[contracttype]` structs and instance-storage getters in the file)
- [ ] Tested locally on Testnet
- [x] Docs updated if needed (inline rustdoc on both the struct fields and the function,
  including a JavaScript SDK usage example in the doc comment)

## Screenshots (if UI change)
N/A — contract-only change. Frontend integration (replacing the 4 individual calls with a
single `get_global_stats()` call) is a natural follow-up and can be tracked separately.
