### PR TITLE
docs: add ADR-004 documenting CEI pattern in donate/donate_usdc

### DIFF
--- a/docs/adr/ADR-004-cei-pattern.md
+++ b/docs/adr/ADR-004-cei-pattern.md
@@ -1,0 +1,38 @@
+# ADR-004: Checks-Effects-Interactions (CEI) Pattern in Donation Functions
+
+## Status
+
+Accepted
+
+## Context
+
+`donate()` and `donate_usdc()` accept a caller-supplied token address (`token` / `usdc_token`) and call `token::Client::transfer()` to move funds. If the token contract is malicious or a reentrancy-enabled wrapper, it can call back into the GreenPay contract during the transfer before any state has been written. Without CEI ordering, a reentrant call could:
+
+- Over-credit a donor (multiple badge tier upgrades from one payment)
+- Inflate `project.total_raised`, `donor_count`, or global counters
+- Mint duplicate Impact NFTs
+
+The Soroban security guidance (Stellar docs) emphasizes minimizing token contract surface and avoiding unnecessary external calls. Every cross-contract invocation transfers control to untrusted code.
+
+## Decision
+
+Apply the Checks-Effects-Interactions pattern in both `donate()` and `donate_usdc()`:
+
+1. **Checks** — `require_auth`, amount validation, project active check, USDC token whitelist check
+2. **Effects** — all state mutations: project totals, donor stats, badge computation, NFT mint, global counters
+3. **Interactions** — `token.transfer()` as the last meaningful operation before the event emit
+
+No state write occurs after the external transfer. The `donated` event is the only post-interaction step and reads only data already computed before the transfer.
+
+## Consequences
+
+- A reentrant call from a malicious token will find all state already committed, making any state-based reentrancy (badge tiers, duplicate counting) harmless.
+- The contract minimizes its token interaction to exactly one `transfer` call — no unnecessary `balance_of`, `allowance`, or other token queries.
+- The code is slightly longer because all effects are written out before the transfer, but the safety gain outweighs the readability cost.
+- This pattern is enforced by CI tests that verify end-to-end state correctness after the CEI ordering.
+
+## Soroban Security References
+
+- [Soroban Token Interface docs](https://developers.stellar.org/docs/soroban/token-interface) — minimize cross-contract calls
+- [GreenPay SECURITY.md](../../contracts/greenpay-contract/SECURITY.md) — finding H-01 documents the pre-fix violation and fix
+- [contract-integration.md](../contract-integration.md) — CEI best practices for cross-contract callers


### PR DESCRIPTION
## Summary

Adds ADR-004 documenting why the Checks-Effects-Interactions (CEI) pattern is applied in `donate()` and `donate_usdc()`.

## Changes

- `docs/adr/ADR-004-cei-pattern.md` — new ADR covering:
  - Reentrancy risk from caller-supplied token contracts
  - Why all state writes precede the external `token.transfer()` call
  - How CEI prevents badge/NFT/counter inflation on reentrant calls
  - References to Soroban security guidance and existing SECURITY.md

## Workflows

All 6 workflow files (CI, release, secret-scanning, mobile, extension, database-backup) checked — none reference `docs/` paths, no breakage.
Workflows checked:
- ci.yml — unaffected
- release.yml — only triggers on [release] commit messages
- secret-scanning.yml — gitleaks, not path-dependent
- mobile.yml — EAS build, no docs dependency
- extension.yml — tag-triggered build
- database-backup.yml — cron backup, no docs dependency

closes #447