### PR TITLE
feat: add WalletAddressQRCode for scan-to-donate on project detail page

### DIFF
--- a/frontend/components/WalletAddressQRCode.tsx
+++ b/frontend/components/WalletAddressQRCode.tsx
@@ -1,0 +1,104 @@
+/**
+ * WalletAddressQRCode.tsx
+ *
+ * Renders a compact, inline QR code for a Stellar project wallet address
+ * encoded as a SEP-0007 `web+stellar:pay` URI. Intended for the project detail
+ * page so donors on Freighter mobile can scan-to-donate without copying the
+ * address manually.
+ *
+ * Usage:
+ *   <WalletAddressQRCode
+ *     walletAddress="G..."
+ *     projectName="Amazon Reforestation"
+ *   />
+ */
+import React, { useState } from "react";
+import { QRCodeCanvas } from "qrcode.react";
+
+interface WalletAddressQRCodeProps {
+  /** Stellar public key of the project's receiving wallet */
+  walletAddress: string;
+  /** Human-readable project name – used in the SEP-0007 memo */
+  projectName: string;
+  /**
+   * Pixel size of the QR canvas. Defaults to 160 — small enough for a sidebar
+   * card but crisp enough for a phone camera at arm's length.
+   */
+  size?: number;
+}
+
+/**
+ * Builds a SEP-0007 payment URI:
+ *   web+stellar:pay?destination=<address>&memo=GreenPay:<name>&memo_type=MEMO_TEXT
+ *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md
+ */
+function buildSep0007Uri(walletAddress: string, projectName: string): string {
+  const params = new URLSearchParams();
+  params.set("destination", walletAddress);
+  // Keep the memo short — Stellar text memos are limited to 28 bytes
+  const memoText = `GreenPay:${projectName}`.slice(0, 28);
+  params.set("memo", memoText);
+  params.set("memo_type", "MEMO_TEXT");
+  return `web+stellar:pay?${params.toString()}`;
+}
+
+const WalletAddressQRCode: React.FC<WalletAddressQRCodeProps> = ({
+  walletAddress,
+  projectName,
+  size = 160,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const stellarUri = buildSep0007Uri(walletAddress, projectName);
+
+  return (
+    <div className="wallet-qr">
+      {/* Toggle button */}
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex items-center gap-2 text-xs font-semibold text-forest-700 hover:text-forest-900 transition-colors focus:outline-none focus:ring-2 focus:ring-forest-400 rounded"
+        aria-expanded={expanded}
+        aria-controls="wallet-qr-panel"
+      >
+        <span className="text-base" aria-hidden="true">
+          {expanded ? "▲" : "▼"}
+        </span>
+        {expanded ? "Hide QR" : "📱 Scan to donate"}
+      </button>
+
+      {/* Collapsible panel */}
+      {expanded && (
+        <div
+          id="wallet-qr-panel"
+          role="region"
+          aria-label={`QR code to donate to ${projectName}`}
+          className="mt-3 flex flex-col items-center gap-2 animate-fade-in"
+        >
+          {/* White border so the QR has adequate quiet zone on coloured backgrounds */}
+          <div className="bg-white p-2 rounded-lg shadow-sm border border-forest-100 inline-block">
+            <QRCodeCanvas
+              value={stellarUri}
+              size={size}
+              level="H"
+              includeMargin={false}
+              style={{ display: "block" }}
+            />
+          </div>
+
+          <p className="text-[11px] text-[#5a7a5a] font-body text-center leading-snug max-w-[200px]">
+            Open <strong>Freighter</strong> or any Stellar wallet and scan to
+            send XLM directly on-chain.
+          </p>
+
+          <p className="text-[10px] text-[#8aaa8a] font-body font-mono break-all text-center max-w-[200px]">
+            {walletAddress}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WalletAddressQRCode;
+export { buildSep0007Uri };

--- a/frontend/components/__tests__/WalletAddressQRCode.test.tsx
+++ b/frontend/components/__tests__/WalletAddressQRCode.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * WalletAddressQRCode.test.tsx
+ *
+ * Unit tests for the WalletAddressQRCode component (issue #405).
+ *
+ * Covers:
+ *  1. buildSep0007Uri – URI format, memo truncation.
+ *  2. Toggle button renders and collapses/expands the QR panel.
+ *  3. When expanded, the wallet address is visible and the canvas is present.
+ *  4. aria-expanded tracks open/closed state.
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import WalletAddressQRCode, { buildSep0007Uri } from "../WalletAddressQRCode";
+
+// qrcode.react renders a <canvas> which jsdom cannot fully support; mock it
+// so the DOM tree exists without triggering canvas-not-implemented errors.
+jest.mock("qrcode.react", () => ({
+  QRCodeCanvas: ({ value }: { value: string }) => (
+    <canvas data-testid="qr-canvas" data-value={value} />
+  ),
+}));
+
+const WALLET = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+const PROJECT_NAME = "Amazon Reforestation";
+
+// ── buildSep0007Uri ───────────────────────────────────────────────────────────
+
+describe("buildSep0007Uri", () => {
+  it("starts with the web+stellar:pay? scheme", () => {
+    const uri = buildSep0007Uri(WALLET, PROJECT_NAME);
+    expect(uri).toMatch(/^web\+stellar:pay\?/);
+  });
+
+  it("includes the destination param equal to the wallet address", () => {
+    const uri = buildSep0007Uri(WALLET, PROJECT_NAME);
+    const params = new URLSearchParams(uri.split("?")[1]);
+    expect(params.get("destination")).toBe(WALLET);
+  });
+
+  it("includes a memo_type of MEMO_TEXT", () => {
+    const uri = buildSep0007Uri(WALLET, PROJECT_NAME);
+    const params = new URLSearchParams(uri.split("?")[1]);
+    expect(params.get("memo_type")).toBe("MEMO_TEXT");
+  });
+
+  it("includes a memo that starts with 'GreenPay:'", () => {
+    const uri = buildSep0007Uri(WALLET, PROJECT_NAME);
+    const params = new URLSearchParams(uri.split("?")[1]);
+    expect(params.get("memo")).toMatch(/^GreenPay:/);
+  });
+
+  it("truncates the memo to 28 characters (Stellar text-memo limit)", () => {
+    const longName = "A Very Long Project Name That Exceeds The Limit";
+    const uri = buildSep0007Uri(WALLET, longName);
+    const params = new URLSearchParams(uri.split("?")[1]);
+    expect(params.get("memo")!.length).toBeLessThanOrEqual(28);
+  });
+});
+
+// ── WalletAddressQRCode component ────────────────────────────────────────────
+
+describe("WalletAddressQRCode", () => {
+  it("renders the toggle button collapsed by default", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    const btn = screen.getByRole("button", { name: /scan to donate/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("does not show the QR canvas or wallet address before expanding", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    expect(screen.queryByTestId("qr-canvas")).not.toBeInTheDocument();
+    expect(screen.queryByText(WALLET)).not.toBeInTheDocument();
+  });
+
+  it("expands the panel and shows the QR canvas when the button is clicked", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /scan to donate/i }));
+
+    expect(screen.getByTestId("qr-canvas")).toBeInTheDocument();
+  });
+
+  it("shows the wallet address text when expanded", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /scan to donate/i }));
+
+    expect(screen.getByText(WALLET)).toBeInTheDocument();
+  });
+
+  it("sets aria-expanded=true after expanding", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    const btn = screen.getByRole("button", { name: /scan to donate/i });
+    fireEvent.click(btn);
+
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("collapses the panel again when the button is clicked a second time", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn); // expand
+    fireEvent.click(btn); // collapse
+
+    expect(screen.queryByTestId("qr-canvas")).not.toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("passes a valid SEP-0007 URI as the QR value", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /scan to donate/i }));
+
+    const canvas = screen.getByTestId("qr-canvas");
+    const qrValue = canvas.getAttribute("data-value") ?? "";
+    expect(qrValue).toMatch(/^web\+stellar:pay\?/);
+    expect(qrValue).toContain(WALLET);
+  });
+
+  it("renders an accessible region with a descriptive aria-label when expanded", () => {
+    render(
+      <WalletAddressQRCode walletAddress={WALLET} projectName={PROJECT_NAME} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /scan to donate/i }));
+
+    const region = screen.getByRole("region", {
+      name: new RegExp(`donate to ${PROJECT_NAME}`, "i"),
+    });
+    expect(region).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/projects/[id].tsx
+++ b/frontend/pages/projects/[id].tsx
@@ -13,6 +13,7 @@ import WalletConnect from "@/components/WalletConnect";
 import CircularProgress from "@/components/CircularProgress";
 import MonthlyGivingSetup from "@/components/MonthlyGivingSetup";
 import DescriptionAccordion from "@/components/DescriptionAccordion";
+import WalletAddressQRCode from "@/components/WalletAddressQRCode";
 import { fetchProject, fetchProjectUpdates, subscribeToProject, fetchSubscriberCount, createProjectCampaign, fetchProjectMatches, generateProjectSummary, toggleUpdateLike } from "@/lib/api";
 import { useI18n } from "@/lib/i18n";
 import { formatXLM, formatCO2, progressPercent, timeAgo, statusClass, statusLabel, CATEGORY_ICONS, copyToClipboard, shortenAddress } from "@/utils/format";
@@ -1041,6 +1042,15 @@ export default function ProjectDetail({
                   </svg>
                 )}
               </button>
+            </div>
+
+            {/* QR code — tap to reveal; lets Freighter mobile scan-to-donate
+                without copying the wallet address manually (issue #405) */}
+            <div className="mt-3">
+              <WalletAddressQRCode
+                walletAddress={project.walletAddress}
+                projectName={project.name}
+              />
             </div>
           </div>
 


### PR DESCRIPTION
- Add WalletAddressQRCode component (frontend/components/WalletAddressQRCode.tsx)
  * Renders a collapsible QR code of project.walletAddress
  * Encodes a SEP-0007 web+stellar:pay URI so Freighter mobile can scan-to-donate without copying the address manually
  * Memo truncated to 28 bytes to respect Stellar text-memo limit
  * Accessible: aria-expanded toggle, aria-label region on the panel
- Integrate WalletAddressQRCode into pages/projects/[id].tsx
  * Placed directly below the wallet address / copy-button row
  * Hidden by default; '📱 Scan to donate' button expands it
- Add 13-test suite (frontend/components/__tests__/WalletAddressQRCode.test.tsx)
  * Covers buildSep0007Uri URI format, memo truncation
  * Covers toggle expand/collapse, aria attributes, QR canvas value
- All 13 tests pass; tsc --noEmit exits 0

Closes #405

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
