### PR TITLE
test: cover computeBadges tier threshold boundaries

### DIFF
--- a/backend/src/services/store.test.js
+++ b/backend/src/services/store.test.js
@@ -36,6 +36,37 @@ describe("BADGE_THRESHOLDS contract spec", () => {
   });
 });
 
+describe("computeBadges tier threshold boundaries", () => {
+  // Exhaustive boundary coverage per issue #432: every tier threshold and the
+  // value immediately below it (to 7 decimal places — stroop-level XLM precision).
+  const tierAt = (xlm) => {
+    const earned = computeBadges(xlm);
+    return earned.length ? earned[0].tier : null;
+  };
+
+  const cases = [
+    [0, null, "0 XLM earns no badge"],
+    [9.9999999, null, "just below seedling earns no badge"],
+    [10, "seedling", "exactly 10 XLM earns seedling"],
+    [99.9999999, "seedling", "just below tree stays seedling"],
+    [100, "tree", "exactly 100 XLM earns tree"],
+    [499.9999999, "tree", "just below forest stays tree"],
+    [500, "forest", "exactly 500 XLM earns forest"],
+    [1999.9999999, "forest", "just below earth guardian stays forest"],
+    [2000, "earth", "exactly 2000 XLM earns earth guardian"],
+  ];
+
+  test.each(cases)("computeBadges(%p) → %p (%s)", (xlm, expectedTier) => {
+    expect(tierAt(xlm)).toBe(expectedTier);
+  });
+
+  test("computeBadges returns at most one (highest) tier per call", () => {
+    for (const [xlm] of cases) {
+      expect(computeBadges(xlm).length).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
 describe("store utility functions", () => {
   test("computeBadges returns no badge below 10 XLM", () => {
     expect(computeBadges(9)).toEqual([]);


### PR DESCRIPTION
## Summary

Adds exhaustive boundary coverage for `computeBadges` in `backend/src/services/store.js`, closing the gaps left by the existing integer-only assertions.

The current suite checks integer values (9, 99, 499, 1999) but never exercises the values *immediately* below each threshold at XLM precision (7 decimals). Those are exactly the points where an off-by-epsilon error in the tier comparison would slip through.

## What's covered

Every tier threshold and the value just below it:

| Input (XLM) | Expected tier |
|---|---|
| 0 | none |
| 9.9999999 | none |
| 10 | seedling |
| 99.9999999 | seedling |
| 100 | tree |
| 499.9999999 | tree |
| 500 | forest |
| 1999.9999999 | forest |
| 2000 | earth |

Plus a guard asserting `computeBadges` returns at most one (highest) tier per call.

Implemented as a table-driven `test.each` block so future tier changes only touch the data table.

## Testing

```
npx jest src/services/store.test.js
# 30 passed
```

Closes #432