### PR TITLE
test: harden donation_event WebSocket broadcast coverage

### DIFF
--- a/backend/src/routes/donations.socket.test.js
+++ b/backend/src/routes/donations.socket.test.js
@@ -273,3 +273,308 @@ describe("POST /api/donations → donation_event WebSocket broadcast", () => {
     2000,
   );
 });
+
+describe("POST /api/donations → broadcast hardening", () => {
+  let httpServer;
+  let ioServer;
+  let request;
+  let baseUrl;
+
+  beforeAll((done) => {
+    const app = express();
+    app.use(express.json());
+    httpServer = http.createServer(app);
+    ioServer = new SocketServer(httpServer, {
+      cors: { origin: "*" },
+      transports: ["websocket"],
+    });
+    app.set("io", ioServer);
+    app.use("/api/donations", require("./donations"));
+
+    httpServer.listen(0, () => {
+      baseUrl = `http://localhost:${httpServer.address().port}`;
+      request = supertest(httpServer);
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    ioServer.close(done);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Resolves once the socket is connected so POSTs never race the handshake.
+  function connectClient() {
+    return new Promise((resolve, reject) => {
+      const socket = ioc(baseUrl, { transports: ["websocket"], forceNew: true });
+      socket.once("connect", () => resolve(socket));
+      socket.once("connect_error", reject);
+    });
+  }
+
+  function successfulXlmDonation(donationRow) {
+    // Mirrors the query order of recordDonation for a new donor, no active matches.
+    createMockClient(
+      queryResult([{ id: donationRow.project_id }]), // SELECT project
+      queryResult([]),                                // dedup check (none)
+      queryResult(),                                  // BEGIN
+      queryResult([donationRow]),                     // INSERT donation
+      queryResult([]),                                // SELECT donation_matches (none)
+      queryResult(),                                  // UPDATE projects
+      queryResult([]),                                // SELECT profile (new donor)
+      queryResult([{ count: "1" }]),                  // COUNT(DISTINCT project_id)
+      queryResult(),                                  // INSERT profile
+      queryResult(),                                  // COMMIT
+    );
+  }
+
+  test(
+    "fans the donation_event out to every connected client",
+    async () => {
+      const donorAddress = makePublicKey("F");
+      const transactionHash = makeTxHash("a");
+      successfulXlmDonation({
+        id: "fanout-1",
+        project_id: "project-fan",
+        donor_address: donorAddress,
+        amount_xlm: "42",
+        amount: "42",
+        currency: "XLM",
+        message: null,
+        transaction_hash: transactionHash,
+        created_at: new Date().toISOString(),
+      });
+
+      const clients = await Promise.all([connectClient(), connectClient(), connectClient()]);
+      try {
+        const received = clients.map(
+          (socket) =>
+            new Promise((resolve, reject) => {
+              const timer = setTimeout(
+                () => reject(new Error("client did not receive donation_event")),
+                500,
+              );
+              socket.on("donation_event", (data) => {
+                clearTimeout(timer);
+                resolve(data);
+              });
+            }),
+        );
+
+        await request
+          .post("/api/donations")
+          .send({ projectId: "project-fan", donorAddress, amountXLM: "42", transactionHash })
+          .expect(201);
+
+        const payloads = await Promise.all(received);
+        for (const payload of payloads) {
+          expect(payload).toMatchObject({
+            projectId: "project-fan",
+            donorAddress,
+            amountXLM: "42",
+            transactionHash,
+          });
+        }
+      } finally {
+        clients.forEach((socket) => socket.disconnect());
+      }
+    },
+    3000,
+  );
+
+  test(
+    "emits exactly one donation_event per recorded donation",
+    async () => {
+      const donorAddress = makePublicKey("G");
+      const transactionHash = makeTxHash("b");
+      successfulXlmDonation({
+        id: "once-1",
+        project_id: "project-once",
+        donor_address: donorAddress,
+        amount_xlm: "10",
+        amount: "10",
+        currency: "XLM",
+        message: null,
+        transaction_hash: transactionHash,
+        created_at: new Date().toISOString(),
+      });
+
+      const socket = await connectClient();
+      try {
+        let count = 0;
+        socket.on("donation_event", () => {
+          count += 1;
+        });
+
+        await request
+          .post("/api/donations")
+          .send({ projectId: "project-once", donorAddress, amountXLM: "10", transactionHash })
+          .expect(201);
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        expect(count).toBe(1);
+      } finally {
+        socket.disconnect();
+      }
+    },
+    3000,
+  );
+
+  test(
+    "does not re-broadcast a duplicate transaction hash (idempotent replay)",
+    async () => {
+      const donorAddress = makePublicKey("H");
+      const transactionHash = makeTxHash("c");
+      // Project exists, but the tx hash is already recorded → early return, no INSERT/emit.
+      createMockClient(
+        queryResult([{ id: "project-dupe" }]),
+        queryResult([
+          {
+            id: "existing-donation",
+            project_id: "project-dupe",
+            donor_address: donorAddress,
+            amount_xlm: "15",
+            amount: "15",
+            currency: "XLM",
+            message: null,
+            transaction_hash: transactionHash,
+            created_at: new Date().toISOString(),
+          },
+        ]),
+      );
+
+      const socket = await connectClient();
+      try {
+        let emitted = false;
+        socket.on("donation_event", () => {
+          emitted = true;
+        });
+
+        const res = await request
+          .post("/api/donations")
+          .send({ projectId: "project-dupe", donorAddress, amountXLM: "15", transactionHash });
+
+        expect(res.status).toBe(200);
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        expect(emitted).toBe(false);
+      } finally {
+        socket.disconnect();
+      }
+    },
+    3000,
+  );
+
+  test.each([
+    ["an invalid donor key", { projectId: "p", donorAddress: "not-a-key", amountXLM: "10", transactionHash: makeTxHash("d") }],
+    ["an invalid transaction hash", { projectId: "p", donorAddress: makePublicKey("I"), amountXLM: "10", transactionHash: "xyz" }],
+  ])(
+    "rejects %s with 400 and emits nothing",
+    async (_label, body) => {
+      createMockClient(); // validation throws before any query runs
+
+      const socket = await connectClient();
+      try {
+        let emitted = false;
+        socket.on("donation_event", () => {
+          emitted = true;
+        });
+
+        await request.post("/api/donations").send(body).expect(400);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(emitted).toBe(false);
+      } finally {
+        socket.disconnect();
+      }
+    },
+    3000,
+  );
+
+  test(
+    "rejects a non-positive amount with 400 and emits nothing",
+    async () => {
+      createMockClient(queryResult([{ id: "project-amt" }])); // project lookup, then amount check fails
+
+      const socket = await connectClient();
+      try {
+        let emitted = false;
+        socket.on("donation_event", () => {
+          emitted = true;
+        });
+
+        await request
+          .post("/api/donations")
+          .send({
+            projectId: "project-amt",
+            donorAddress: makePublicKey("J"),
+            amountXLM: "0",
+            transactionHash: makeTxHash("e"),
+          })
+          .expect(400);
+
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(emitted).toBe(false);
+      } finally {
+        socket.disconnect();
+      }
+    },
+    3000,
+  );
+
+  test(
+    "emits a single primary event even when matching offers add donation rows",
+    async () => {
+      const donorAddress = makePublicKey("K");
+      const matcherAddress = makePublicKey("M");
+      const transactionHash = makeTxHash("f");
+      createMockClient(
+        queryResult([{ id: "project-match" }]),           // SELECT project
+        queryResult([]),                                   // dedup check
+        queryResult(),                                     // BEGIN
+        queryResult([                                      // INSERT primary donation
+          {
+            id: "match-primary",
+            project_id: "project-match",
+            donor_address: donorAddress,
+            amount_xlm: "50",
+            amount: "50",
+            currency: "XLM",
+            message: null,
+            transaction_hash: transactionHash,
+            created_at: new Date().toISOString(),
+          },
+        ]),
+        queryResult([                                      // active matching offer
+          { id: "offer-1", matcher_address: matcherAddress, cap_xlm: "100", matched_xlm: "0", multiplier: 2 },
+        ]),
+        queryResult(),                                     // INSERT match donation
+        queryResult(),                                     // UPDATE donation_matches
+        queryResult(),                                     // UPDATE projects
+        queryResult([]),                                   // SELECT profile
+        queryResult([{ count: "1" }]),                     // COUNT(DISTINCT project_id)
+        queryResult(),                                     // INSERT profile
+        queryResult(),                                     // COMMIT
+      );
+
+      const socket = await connectClient();
+      try {
+        const events = [];
+        socket.on("donation_event", (data) => events.push(data));
+
+        await request
+          .post("/api/donations")
+          .send({ projectId: "project-match", donorAddress, amountXLM: "50", transactionHash })
+          .expect(201);
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({ projectId: "project-match", donorAddress });
+      } finally {
+        socket.disconnect();
+      }
+    },
+    3000,
+  );
+});


### PR DESCRIPTION
## Summary

The WebSocket broadcast test added in `donations.socket.test.js` proves the happy path — one client receives a `donation_event` after `POST /api/donations`. This PR extends that suite to cover the correctness guarantees a real-time donation feed depends on, all of which are currently untested branches in `recordDonation`.

## Added coverage

| Scenario | Guarantee |
|---|---|
| **Fan-out** | Every connected client receives the event (`io.emit` reaches all sockets) |
| **Exactly-once** | A successful donation emits the event exactly one time |
| **Idempotent replay** | A duplicate `transactionHash` returns `200` and does **not** re-broadcast |
| **Invalid donor key** | Responds `400`, emits nothing |
| **Invalid tx hash** | Responds `400`, emits nothing |
| **Non-positive amount** | Responds `400`, emits nothing |
| **Matching offers** | Match logic inserts extra donation rows but still emits a single primary event |

The idempotency and validation cases matter most: without them a replayed on-chain transaction or a malformed request could push a phantom donation into every connected client's feed.

## Implementation notes

- Reuses the existing `socket.io-client` + `supertest` harness already in the file.
- Mocked `pool` query sequences mirror `recordDonation`'s actual query order, including the matching-offer branch.
- Clients connect before the POST is issued so assertions never race the socket handshake.

## Testing

```
npx jest src/routes/donations.socket.test.js
# 10 passed (3 existing + 7 new)
```

Closes #436
