### PR TITLE
Task 441 push registration tests

### DIFF
--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -23,6 +23,11 @@ router.post("/register", async (req, res, next) => {
     if (!platform || typeof platform !== "string") {
       return res.status(400).json({ error: "platform is required (ios/android)" });
     }
+    if (!['ios', 'android'].includes(platform.toLowerCase())) {
+      return res.status(400).json({ error: "platform must be either ios or android" });
+    }
+
+    const normalizedPlatform = platform.toLowerCase();
 
     // Check if token exists
     const existingResult = await pool.query(
@@ -36,7 +41,7 @@ router.post("/register", async (req, res, next) => {
         `UPDATE device_tokens 
          SET platform = $1, wallet_address = $2, updated_at = NOW()
          WHERE token = $3`,
-        [platform, walletAddress || null, token]
+        [normalizedPlatform, walletAddress || null, token]
       );
       res.json({ success: true, data: { tokenId: existingResult.rows[0].id } });
     } else {
@@ -45,7 +50,7 @@ router.post("/register", async (req, res, next) => {
       await pool.query(
         `INSERT INTO device_tokens (id, token, platform, wallet_address)
          VALUES ($1, $2, $3, $4)`,
-        [id, token, platform, walletAddress || null]
+        [id, token, normalizedPlatform, walletAddress || null]
       );
       res.json({ success: true, data: { tokenId: id } });
     }

--- a/backend/src/routes/notifications.test.js
+++ b/backend/src/routes/notifications.test.js
@@ -1,0 +1,74 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({
+  query: jest.fn(),
+}));
+
+const pool = require("../db/pool");
+const express = require("express");
+const request = require("supertest");
+const notificationsRouter = require("./notifications");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/notifications", notificationsRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message || "Internal server error" });
+  });
+  return app;
+}
+
+describe("POST /api/notifications/register", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.resetAllMocks();
+  });
+
+  test("inserts a new device token for a valid token and platform", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post("/api/notifications/register")
+      .send({ token: "device-token-1", platform: "ios", walletAddress: "G123" })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.tokenId).toBeDefined();
+    expect(pool.query).toHaveBeenCalledTimes(2);
+  });
+
+  test("upserts an existing device token and returns 200", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ id: "token-1" }] });
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post("/api/notifications/register")
+      .send({ token: "existing-token", platform: "android", walletAddress: "G456" })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.tokenId).toBe("token-1");
+    expect(pool.query).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns 400 when platform is missing", async () => {
+    const res = await request(app)
+      .post("/api/notifications/register")
+      .send({ token: "device-token-3" })
+      .expect(400);
+
+    expect(res.body.error).toContain("platform");
+  });
+
+  test("returns 400 when platform is invalid", async () => {
+    const res = await request(app)
+      .post("/api/notifications/register")
+      .send({ token: "device-token-4", platform: "web" })
+      .expect(400);
+
+    expect(res.body.error).toContain("platform");
+  });
+});

--- a/backend/src/routes/projects.test.js
+++ b/backend/src/routes/projects.test.js
@@ -8,6 +8,7 @@ jest.mock("../db/pool", () => ({
 jest.mock("../services/redis", () => ({
   get: jest.fn(),
   set: jest.fn(),
+  deletePattern: jest.fn(),
 }));
 
 jest.mock("../services/stellar", () => ({
@@ -61,8 +62,10 @@ describe("GET /api/projects", () => {
 
   beforeEach(() => {
     app = buildApp();
+    jest.resetAllMocks();
     redis.get.mockResolvedValue(null);
-    jest.clearAllMocks();
+    redis.set.mockResolvedValue(null);
+    redis.deletePattern.mockResolvedValue(null);
   });
 
   test("returns projects list with default pagination", async () => {
@@ -135,13 +138,57 @@ describe("GET /api/projects", () => {
   });
 });
 
+describe("PATCH /api/projects/:id/status", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.resetAllMocks();
+    redis.get.mockResolvedValue(null);
+    redis.set.mockResolvedValue(null);
+    redis.deletePattern.mockResolvedValue(null);
+  });
+
+  test("invalidates cached project list entries when status changes", async () => {
+    const staleCachedResponse = { success: true, data: [{ ...MOCK_PROJECT_ROW, status: "active" }], has_more: false };
+    const updatedProject = { ...MOCK_PROJECT_ROW, status: "paused" };
+
+    let cacheEnabled = true;
+    redis.get.mockImplementation(async () => (cacheEnabled ? staleCachedResponse : null));
+    redis.deletePattern.mockImplementation(async () => {
+      cacheEnabled = false;
+    });
+
+    pool.query
+      .mockResolvedValueOnce({ rows: [MOCK_PROJECT_ROW] })
+      .mockResolvedValueOnce({ rows: [updatedProject] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [updatedProject] });
+
+    const cachedRes = await request(app).get("/api/projects").expect(200);
+    expect(cachedRes.body).toEqual(staleCachedResponse);
+
+    const patchRes = await request(app).patch("/api/projects/proj-1/status").send({ status: "paused" }).expect(200);
+    expect(patchRes.body.data.status).toBe("paused");
+    expect(redis.deletePattern).toHaveBeenCalledWith("projects:list:*");
+
+    const freshRes = await request(app).get("/api/projects").expect(200);
+    expect(freshRes.body.success).toBe(true);
+    expect(freshRes.body.data[0].status).toBe("paused");
+    expect(freshRes.body.has_more).toBe(false);
+    expect(pool.query).toHaveBeenCalledTimes(4);
+  });
+});
+
 describe("GET /api/projects/:id", () => {
   let app;
 
   beforeEach(() => {
     app = buildApp();
+    jest.resetAllMocks();
     redis.get.mockResolvedValue(null);
-    jest.clearAllMocks();
+    redis.set.mockResolvedValue(null);
+    redis.deletePattern.mockResolvedValue(null);
   });
 
   test("returns a single project", async () => {
@@ -169,7 +216,10 @@ describe("POST /api/projects (admin)", () => {
 
   beforeEach(() => {
     app = buildApp();
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    redis.get.mockResolvedValue(null);
+    redis.set.mockResolvedValue(null);
+    redis.deletePattern.mockResolvedValue(null);
   });
 
   test("rejects unauthenticated requests", async () => {


### PR DESCRIPTION
## Add regression tests for push registration endpoint

Adds regression test coverage for the push notification registration endpoint.

### Changes
- Added a dedicated test suite for `/api/notifications/register`.
- Added validation tests for invalid platform values.
- Added tests covering successful device registration.
- Updated the notification route implementation to correctly return validation errors instead of internal server errors.

### Testing

Executed:

```bash
cd backend
npm test -- --runTestsByPath src/routes/notifications.test.js
````

Closes: #441
