### PR TITLE
#390 feature: add on-chain badge minting UI on donor profile page (v1…FIXED

### DIFF
--- a/frontend/lib/__tests__/mintImpactNft.test.ts
+++ b/frontend/lib/__tests__/mintImpactNft.test.ts
@@ -1,0 +1,39 @@
+/**
+ * lib/__tests__/mintImpactNft.test.ts
+ *
+ * Unit tests for the Claim Impact NFT helpers (issue: "Add a Claim NFT button
+ * on the donor profile page"). These verify the off-chain → on-chain badge
+ * tier mapping that the `mint_impact_nft(donor, tier)` Soroban call depends on.
+ */
+import { xdr, nativeToScVal } from "@stellar/stellar-sdk";
+import { CONTRACT_BADGE_SYMBOL } from "@/lib/stellar";
+
+describe("CONTRACT_BADGE_SYMBOL", () => {
+  it("maps every frontend BadgeTier to its on-chain enum variant name", () => {
+    // Mirrors the contract's `BadgeTier` enum:
+    // None | Seedling | Tree | Forest | EarthGuardian
+    expect(CONTRACT_BADGE_SYMBOL).toEqual({
+      seedling: "Seedling",
+      tree: "Tree",
+      forest: "Forest",
+      earth: "EarthGuardian",
+    });
+  });
+
+  it("produces a Soroban unit-variant enum ScVal (Vec of one Symbol)", () => {
+    // Soroban serialises a data-less enum variant as a Vec containing a single
+    // Symbol. This is exactly what `buildMintImpactNftTransaction` sends as the
+    // `tier` argument, so the contract can match `BadgeTier::Seedling` etc.
+    for (const [tier, variant] of Object.entries(CONTRACT_BADGE_SYMBOL)) {
+      const scVal = xdr.ScVal.scvVec([
+        nativeToScVal(variant, { type: "symbol" }),
+      ]);
+      expect(scVal.switch().name).toBe("scvVec");
+      const inner = scVal.vec()![0];
+      expect(inner.switch().name).toBe("scvSymbol");
+      expect(inner.sym().toString()).toBe(variant);
+      // sanity: tier key is lowercase, variant is PascalCase
+      expect(tier).toBe(tier.toLowerCase());
+    }
+  });
+});

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -1,7 +1,7 @@
 /**
  * lib/stellar.ts — Stellar SDK helpers for GreenPay
  */
-import { Horizon, Networks, Asset, Operation, TransactionBuilder, Transaction, Memo, rpc, Contract, scValToNative, Address, nativeToScVal, Account } from "@stellar/stellar-sdk";
+import { Horizon, Networks, Asset, Operation, TransactionBuilder, Transaction, Memo, rpc, Contract, scValToNative, Address, nativeToScVal, Account, xdr } from "@stellar/stellar-sdk";
 
 export const NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet") as "testnet" | "mainnet";
 const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -130,6 +130,143 @@ export async function buildContractDonationTransaction({
   } else {
     throw formatSimulationFailure(simulated);
   }
+}
+
+/**
+ * Maps the frontend `BadgeTier` strings (lowercase, used across the UI and the
+ * off-chain API) to the on-chain `BadgeTier` enum variant names used by the
+ * GreenPay Soroban contract (`Seedling | Tree | Forest | EarthGuardian`).
+ */
+export const CONTRACT_BADGE_SYMBOL: Record<string, string> = {
+  seedling: "Seedling",
+  tree: "Tree",
+  forest: "Forest",
+  earth: "EarthGuardian",
+};
+
+/**
+ * Builds the Soroban ScVal for a `BadgeTier` unit-variant enum value.
+ * Soroban serialises a unit (data-less) enum variant as a Vec containing a
+ * single Symbol with the variant's name.
+ */
+function badgeTierToScVal(tier: string) {
+  const variant = CONTRACT_BADGE_SYMBOL[tier];
+  if (!variant) {
+    throw new Error(`Unknown badge tier "${tier}". Cannot mint Impact NFT.`);
+  }
+  return xdr.ScVal.scvVec([nativeToScVal(variant, { type: "symbol" })]);
+}
+
+/**
+ * Builds a Soroban transaction that calls `mint_impact_nft(donor, tier)` on the
+ * GreenPay contract. The `donor` account authorises and pays for the mint, and
+ * `tier` must match the donor's current on-chain badge tier (enforced by the
+ * contract). Pass the lowercase frontend tier string (e.g. "seedling").
+ */
+export async function buildMintImpactNftTransaction({
+  contractId,
+  donor,
+  tier,
+}: {
+  contractId: string;
+  donor: string;
+  tier: string;
+}) {
+  if (!contractId.trim()) {
+    throw new Error(
+      "GreenPay contract is not configured (set NEXT_PUBLIC_CONTRACT_ID).",
+    );
+  }
+  const source = await server.loadAccount(donor);
+  const contract = new Contract(contractId);
+  const donorAddr = new Address(donor);
+
+  const tx = new TransactionBuilder(source, {
+    fee: "1000000",
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call("mint_impact_nft", donorAddr.toScVal(), badgeTierToScVal(tier)),
+    )
+    .setTimeout(60)
+    .build();
+
+  const simulated = await rpcServer.simulateTransaction(tx);
+  if (rpc.Api.isSimulationSuccess(simulated)) {
+    return rpc.assembleTransaction(tx, simulated).build();
+  }
+  throw formatMintSimulationFailure(simulated);
+}
+
+/** Maps Soroban `mint_impact_nft` simulation errors to user-facing messages. */
+export function formatMintSimulationFailure(simulated: unknown): Error {
+  const raw = JSON.stringify(simulated);
+  if (raw.includes("NFT already minted for this tier")) {
+    return new Error("You have already claimed the Impact NFT for this tier.");
+  }
+  if (raw.includes("No badge tier reached yet")) {
+    return new Error("No badge tier reached yet — donate more to unlock an Impact NFT.");
+  }
+  if (raw.includes("Tier does not match donor's current badge")) {
+    return new Error("This tier no longer matches your on-chain badge. Refresh and try again.");
+  }
+  if (raw.includes("Cannot mint NFT for None tier")) {
+    return new Error("There is no badge tier to claim yet.");
+  }
+  if (/underfunded|insufficient/i.test(raw) && /balance|fee|Fund/i.test(raw)) {
+    return new Error(
+      "Insufficient XLM to pay Soroban fees. Add test XLM to this account and try again.",
+    );
+  }
+  if (raw.includes("HostError") || raw.includes("VmValidation")) {
+    return new Error(
+      "The contract rejected this mint. Check the network (testnet/mainnet) and contract ID.",
+    );
+  }
+  return new Error(
+    "Could not simulate mint_impact_nft. Verify NEXT_PUBLIC_CONTRACT_ID and that your badge tier is recorded on-chain.",
+  );
+}
+
+/**
+ * Submits a signed Soroban contract transaction via the Soroban RPC server and
+ * polls until it is applied. Returns the transaction hash and the ledger it was
+ * included in (the "mint ledger" for an NFT mint). Unlike {@link submitTransaction}
+ * (which targets Horizon and is unsuitable for contract invocations), this uses
+ * the RPC `sendTransaction` / `getTransaction` flow.
+ */
+export async function submitSorobanTransaction(
+  signedXDR: string,
+  { timeoutMs = 30000, intervalMs = 1500 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<{ hash: string; ledger: number }> {
+  const tx = new Transaction(signedXDR, NETWORK_PASSPHRASE);
+  const sent = await rpcServer.sendTransaction(tx);
+
+  if (sent.status === "ERROR") {
+    throw new Error(
+      `Transaction submission failed: ${JSON.stringify(sent.errorResult ?? sent)}`,
+    );
+  }
+
+  const hash = sent.hash;
+  const deadline = Date.now() + timeoutMs;
+
+  // Poll the RPC until the transaction is applied (SUCCESS) or fails.
+  while (Date.now() < deadline) {
+    const result = await rpcServer.getTransaction(hash);
+    if (result.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+      return { hash, ledger: result.ledger };
+    }
+    if (result.status === rpc.Api.GetTransactionStatus.FAILED) {
+      throw new Error("Transaction failed on-chain. The mint was not completed.");
+    }
+    // NOT_FOUND — still pending; wait and retry.
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(
+    "Timed out waiting for the mint transaction to confirm. Check the explorer with the transaction hash.",
+  );
 }
 
 /**

--- a/frontend/pages/donors/[publicKey].tsx
+++ b/frontend/pages/donors/[publicKey].tsx
@@ -10,6 +10,17 @@ import { useRouter } from "next/router";
 import { useEffect, useState, useCallback } from "react";
 import { fetchProfile, fetchDonorHistory } from "@/lib/api";
 import type { DonorProfile, Donation, BadgeTier } from "@/utils/types";
+import {
+  buildMintImpactNftTransaction,
+  submitSorobanTransaction,
+  explorerUrl,
+  CONTRACT_ID,
+} from "@/lib/stellar";
+import {
+  connectWallet,
+  getConnectedPublicKey,
+  signTransactionWithWallet,
+} from "@/lib/wallet";
 
 // ── Badge helpers ─────────────────────────────────────────────────────────────
 
@@ -226,6 +237,229 @@ function ShareButton({ url }: { url: string }) {
   );
 }
 
+// ── Claim NFT card ────────────────────────────────────────────────────────────
+
+/** Order of badge tiers, lowest → highest, used to pick the donor's top tier. */
+const TIER_ORDER: BadgeTier[] = ["seedling", "tree", "forest", "earth"];
+
+/**
+ * Returns the highest badge tier the donor has earned, or null if none.
+ * The issue asks us to "check current badge tier"; the current tier is the
+ * highest one reflected by the profile (which mirrors the on-chain badge).
+ */
+function highestTier(badges: { tier: BadgeTier }[]): BadgeTier | null {
+  let best: BadgeTier | null = null;
+  let bestIdx = -1;
+  for (const b of badges) {
+    const idx = TIER_ORDER.indexOf(b.tier);
+    if (idx > bestIdx) {
+      bestIdx = idx;
+      best = b.tier;
+    }
+  }
+  return best;
+}
+
+type ClaimStep =
+  | "idle"
+  | "checking"
+  | "building"
+  | "signing"
+  | "submitting"
+  | "success"
+  | "error";
+
+interface MintedNft {
+  tier: BadgeTier;
+  ledger: number;
+  hash: string;
+}
+
+function ClaimNftCard({ profile }: { profile: DonorProfile }) {
+  const [connectedKey, setConnectedKey] = useState<string | null>(null);
+  const [step, setStep] = useState<ClaimStep>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [minted, setMinted] = useState<MintedNft | null>(null);
+
+  // The tier the donor is eligible to claim (their current/highest badge).
+  const tier = highestTier(profile.badges);
+
+  // On mount, see if a wallet is already authorised so we can match it to the
+  // profile owner (the contract's `mint_impact_nft` requires the donor to sign).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const pk = await getConnectedPublicKey();
+      if (!cancelled) setConnectedKey(pk);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const isOwner = Boolean(connectedKey && connectedKey === profile.publicKey);
+  const busy =
+    step === "checking" ||
+    step === "building" ||
+    step === "signing" ||
+    step === "submitting";
+
+  const handleConnect = useCallback(async () => {
+    setError(null);
+    const { publicKey, error: e } = await connectWallet();
+    if (e) {
+      setError(e);
+      return;
+    }
+    setConnectedKey(publicKey);
+  }, []);
+
+  const handleClaim = useCallback(async () => {
+    setError(null);
+    setMinted(null);
+
+    if (!CONTRACT_ID) {
+      setError("Impact NFT contract is not configured (set NEXT_PUBLIC_CONTRACT_ID).");
+      setStep("error");
+      return;
+    }
+    if (!connectedKey || connectedKey !== profile.publicKey) {
+      setError("Connect the wallet that owns this profile to claim its NFT.");
+      setStep("error");
+      return;
+    }
+
+    try {
+      // 1. Re-check the current badge tier from the API right before minting.
+      setStep("checking");
+      const fresh = await fetchProfile(profile.publicKey);
+      const currentTier = highestTier(fresh.badges);
+      if (!currentTier) {
+        throw new Error("No badge tier reached yet — donate more to unlock an Impact NFT.");
+      }
+
+      // 2. Build the Soroban mint_impact_nft(donor, tier) transaction.
+      setStep("building");
+      const tx = await buildMintImpactNftTransaction({
+        contractId: CONTRACT_ID,
+        donor: profile.publicKey,
+        tier: currentTier,
+      });
+
+      // 3. Prompt Freighter to sign.
+      setStep("signing");
+      const { signedXDR, error: signErr } = await signTransactionWithWallet(
+        tx.toXDR(),
+      );
+      if (signErr || !signedXDR) {
+        throw new Error(signErr || "Wallet did not return a signed transaction.");
+      }
+
+      // 4. Submit via Soroban RPC and wait for the mint ledger.
+      setStep("submitting");
+      const { hash, ledger } = await submitSorobanTransaction(signedXDR);
+
+      setMinted({ tier: currentTier, ledger, hash });
+      setStep("success");
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : "Something went wrong. Please try again.";
+      setError(msg);
+      setStep("error");
+    }
+  }, [connectedKey, profile.publicKey]);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  // Successfully minted: show the NFT with its tier name and mint ledger.
+  if (minted) {
+    const meta = BADGE_META[minted.tier];
+    return (
+      <div className={`card border ${meta.border} ${meta.bg}`}>
+        <h2 className="label mb-3">Impact NFT Minted 🎉</h2>
+        <div className="flex items-center gap-4">
+          <div
+            className={`w-16 h-16 rounded-2xl flex items-center justify-center text-4xl border ${meta.border} bg-white/70 select-none`}
+          >
+            {meta.emoji}
+          </div>
+          <div className="min-w-0">
+            <p className={`font-display text-lg font-semibold ${meta.color}`}>
+              {meta.label} Impact NFT
+            </p>
+            <p className="text-xs text-[#5a7a5a] font-body">
+              Minted at ledger{" "}
+              <span className="font-semibold text-[#227239]">
+                #{minted.ledger.toLocaleString()}
+              </span>
+            </p>
+            <a
+              href={explorerUrl(minted.hash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-forest-600 hover:underline font-body break-all"
+            >
+              View transaction ↗
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // No badge tier yet — nothing to claim.
+  if (!tier) return null;
+
+  const meta = BADGE_META[tier];
+
+  return (
+    <div className="card">
+      <h2 className="label mb-1">Claim your Impact NFT</h2>
+      <p className="text-sm text-[#5a7a5a] font-body mb-4">
+        Mint an on-chain{" "}
+        <span className={`font-semibold ${meta.color}`}>
+          {meta.emoji} {meta.label}
+        </span>{" "}
+        Impact NFT for your contributions.
+      </p>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 p-3 rounded-xl bg-red-50 border border-red-200 text-red-600 text-sm font-body"
+        >
+          {error}
+        </div>
+      )}
+
+      {!connectedKey ? (
+        <button onClick={handleConnect} className="btn-primary text-sm">
+          🔗 Connect Freighter to claim
+        </button>
+      ) : !isOwner ? (
+        <p className="text-xs text-[#8aaa8a] font-body">
+          Connect the wallet that owns this profile ({shortenKey(profile.publicKey)})
+          to claim its Impact NFT.
+        </p>
+      ) : (
+        <button
+          onClick={handleClaim}
+          disabled={busy}
+          className="btn-primary text-sm flex items-center gap-2 disabled:opacity-60"
+          aria-busy={busy}
+        >
+          {step === "checking" && "Checking tier…"}
+          {step === "building" && "Building transaction…"}
+          {step === "signing" && "Confirm in Freighter…"}
+          {step === "submitting" && "Minting on-chain…"}
+          {(step === "idle" || step === "error" || step === "success") &&
+            `Claim ${meta.label} NFT`}
+        </button>
+      )}
+    </div>
+  );
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function DonorProfilePage() {
@@ -367,6 +601,9 @@ export default function DonorProfilePage() {
               </div>
             </div>
           )}
+
+          {/* ── Claim Impact NFT ────────────────────────────────────────── */}
+          <ClaimNftCard profile={profile} />
 
           {/* ── Donation history ────────────────────────────────────────── */}
           <div className="card">


### PR DESCRIPTION

## Summary

Adds a **Claim NFT** button to the donor profile page (`/donors/:publicKey`). When clicked, it:

1. Calls `GET /api/profiles/:publicKey` (via `fetchProfile`) to read the donor's current/highest badge tier.
2. Builds a Soroban transaction calling `mint_impact_nft(donor, tier)` on the GreenPay contract (with correct off-chain→on-chain tier mapping and unit-variant enum ScVal encoding).
3. Prompts **Freighter** to sign (`signTransactionWithWallet`).
4. On success, submits via Soroban RPC, polls for confirmation, and **displays the minted NFT with its tier name and mint ledger** (plus an explorer link).

The button is owner-gated (only enabled when the connected wallet matches the profile owner, as the contract requires `donor.require_auth()`), simulates before signing, and maps contract panics to friendly messages ("already claimed", "no badge yet", insufficient fees, etc.).

**Files changed**
- `frontend/pages/donors/[publicKey].tsx` — new `ClaimNftCard` component (button + flow + minted-NFT display)
- `frontend/lib/stellar.ts` — `CONTRACT_BADGE_SYMBOL`, `buildMintImpactNftTransaction()`, `formatMintSimulationFailure()`, `submitSorobanTransaction()`
- `frontend/lib/__tests__/mintImpactNft.test.ts` — new unit tests (tier mapping + enum ScVal encoding)

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change


## Testing

- [ ] Tested locally on Testnet <!-- requires a deployed NEXT_PUBLIC_CONTRACT_ID + Freighter; couldn't run in CI sandbox -->
- [x] No TypeScript / Rust errors — `npx tsc --noEmit` → 0 errors; `npx next build` → success (17 routes); `npx jest` → 8/8 tests, 4/4 snapshots pass
- [ ] Docs updated if needed <!-- no docs change needed -->

CLOSE #390 
