### PR TITLE
feat: mobile Scan to Donate using device camera to read QR codes

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -35,6 +35,7 @@ export default function RootLayout() {
         <Stack.Screen name="profile/[address]" options={{ title: 'Donor Profile' }} />
         <Stack.Screen name="leaderboard" options={{ title: 'Leaderboard' }} />
         <Stack.Screen name="recurring" options={{ title: 'Monthly Giving' }} />
+        <Stack.Screen name="scan" options={{ title: 'Scan to Donate', headerShown: false }} />
       </Stack>
     </ThemeProvider>
   );

--- a/mobile/app/donate/[id].tsx
+++ b/mobile/app/donate/[id].tsx
@@ -22,9 +22,11 @@ interface ClimateProject {
 export default function DonateScreen() {
   const { colors } = useTheme();
   const router = useRouter();
-  const { id } = useLocalSearchParams();
+  const { id, wallet: scannedWallet } = useLocalSearchParams();
   const [projects, setProjects] = useState<ClimateProject[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(id as string | undefined);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(
+    id && id !== 'scan' ? (id as string) : undefined
+  );
   const [amount, setAmount] = useState('1');
   const [message, setMessage] = useState('');
   const [secretKey, setSecretKey] = useState('');
@@ -57,7 +59,16 @@ export default function DonateScreen() {
     }
   };
 
-  const selectedProject = projects.find((project) => project.id === selectedProjectId) || projects[0] || null;
+  // When arriving from the QR scanner, prefer the project whose wallet matches
+  // the scanned address; fall back to id-based or first project selection.
+  const scannedAddr = typeof scannedWallet === 'string' ? scannedWallet : null;
+  const selectedProject =
+    (scannedAddr
+      ? projects.find((p) => p.walletAddress === scannedAddr)
+      : undefined) ??
+    projects.find((project) => project.id === selectedProjectId) ??
+    projects[0] ??
+    null;
 
   const handleDonate = async () => {
     if (!selectedProject) {
@@ -192,6 +203,14 @@ export default function DonateScreen() {
       <View style={styles.header}>
         <Text style={styles.title}>Donate to {selectedProject?.name || 'a project'}</Text>
         <Text style={styles.subtitle}>Choose a project and donate XLM on testnet.</Text>
+        {scannedAddr && (
+          <View style={styles.scannedBanner}>
+            <Text style={styles.scannedBannerText}>
+              QR scanned: {scannedAddr.slice(0, 8)}…{scannedAddr.slice(-4)}
+              {selectedProject ? ` — matched to ${selectedProject.name}` : ' (no matching project found)'}
+            </Text>
+          </View>
+        )}
       </View>
 
       <View style={styles.selectorCard}>
@@ -310,6 +329,18 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 14,
     marginTop: 4,
+  },
+  scannedBanner: {
+    marginTop: 10,
+    backgroundColor: 'rgba(76,175,80,0.15)',
+    borderRadius: 8,
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#4caf50',
+  },
+  scannedBannerText: {
+    fontSize: 12,
+    color: '#1b5e20',
   },
   selectorCard: {
     margin: 16,

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -101,6 +101,7 @@ function ProjectCard({
 export default function HomeScreen() {
   const router = useRouter();
   const { colors } = useTheme();
+  const handleScan = () => router.push('/scan' as `${string}`);
   const [projects, setProjects] = useState<ClimateProject[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -139,7 +140,7 @@ export default function HomeScreen() {
       renderItem={() => <SkeletonCard colors={colors} />}
       contentContainerStyle={styles.listContent}
       scrollEnabled={false}
-      ListHeaderComponent={<Header colors={colors} />}
+      ListHeaderComponent={<Header colors={colors} onScan={handleScan} />}
     />
   );
 
@@ -164,7 +165,7 @@ export default function HomeScreen() {
           />
         )}
         contentContainerStyle={styles.listContent}
-        ListHeaderComponent={<Header colors={colors} />}
+        ListHeaderComponent={<Header colors={colors} onScan={handleScan} />}
         ListEmptyComponent={
           networkError ? (
             <View style={styles.errorContainer}>
@@ -196,11 +197,24 @@ export default function HomeScreen() {
   );
 }
 
-function Header({ colors }: { colors: ReturnType<typeof useTheme>['colors'] }) {
+function Header({
+  colors,
+  onScan,
+}: {
+  colors: ReturnType<typeof useTheme>['colors'];
+  onScan: () => void;
+}) {
   return (
     <View style={[styles.header, { backgroundColor: colors.primary }]}>
-      <Text style={[styles.title, { color: colors.headerText }]}>Stellar GreenPay</Text>
-      <Text style={[styles.subtitle, { color: colors.headerText }]}>Climate donations on Stellar</Text>
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={[styles.title, { color: colors.headerText }]}>Stellar GreenPay</Text>
+          <Text style={[styles.subtitle, { color: colors.headerText }]}>Climate donations on Stellar</Text>
+        </View>
+        <TouchableOpacity style={styles.scanButton} onPress={onScan} accessibilityLabel="Scan QR to donate">
+          <Text style={styles.scanButtonText}>📷 Scan</Text>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }
@@ -215,6 +229,22 @@ const styles = StyleSheet.create({
   header: {
     padding: 24,
     marginBottom: 8,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  scanButton: {
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+  },
+  scanButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 14,
   },
   title: {
     fontSize: 28,

--- a/mobile/app/scan.tsx
+++ b/mobile/app/scan.tsx
@@ -1,0 +1,260 @@
+/**
+ * app/scan.tsx
+ * Scan to Donate — reads a project wallet QR code and navigates to the donate
+ * screen with the scanned wallet address pre-populated as the destination.
+ *
+ * QR format expected: a Stellar public key (G…) or a deep-link of the form
+ *   greenpay://donate?wallet=G...&project=<projectId>
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Linking,
+  Platform,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+
+const STELLAR_KEY_RE = /^G[A-Z2-7]{55}$/;
+const DEEP_LINK_RE   = /greenpay:\/\/donate\?(.+)/;
+
+function parseScan(data: string): { wallet: string; projectId?: string } | null {
+  const deepMatch = data.match(DEEP_LINK_RE);
+  if (deepMatch) {
+    const params = new URLSearchParams(deepMatch[1]);
+    const wallet = params.get('wallet') ?? '';
+    if (STELLAR_KEY_RE.test(wallet)) {
+      return { wallet, projectId: params.get('project') ?? undefined };
+    }
+    return null;
+  }
+  if (STELLAR_KEY_RE.test(data.trim())) {
+    return { wallet: data.trim() };
+  }
+  return null;
+}
+
+export default function ScanScreen() {
+  const router = useRouter();
+  const [permission, requestPermission] = useCameraPermissions();
+  const [scanned, setScanned] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cooldown = useRef(false);
+
+  useEffect(() => {
+    if (!permission?.granted) {
+      requestPermission();
+    }
+  }, []);
+
+  const handleBarcode = ({ data }: { data: string }) => {
+    if (cooldown.current || scanned) return;
+    cooldown.current = true;
+
+    const parsed = parseScan(data);
+    if (!parsed) {
+      setError('QR code is not a valid GreenPay wallet address. Try again.');
+      setTimeout(() => {
+        setError(null);
+        cooldown.current = false;
+      }, 2000);
+      return;
+    }
+
+    setScanned(true);
+
+    // Build the donate route with the scanned wallet as a query param.
+    // The donate/[id] screen reads `wallet` from params to pre-fill the destination.
+    const target = parsed.projectId
+      ? `/donate/${parsed.projectId}?wallet=${encodeURIComponent(parsed.wallet)}`
+      : `/donate/scan?wallet=${encodeURIComponent(parsed.wallet)}`;
+
+    router.push(target as `${string}`);
+  };
+
+  if (!permission) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.message}>Requesting camera permission…</Text>
+      </View>
+    );
+  }
+
+  if (!permission.granted) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.message}>Camera access is required to scan QR codes.</Text>
+        <TouchableOpacity style={styles.button} onPress={requestPermission}>
+          <Text style={styles.buttonText}>Grant Permission</Text>
+        </TouchableOpacity>
+        {Platform.OS !== 'web' && (
+          <TouchableOpacity
+            style={[styles.button, styles.buttonSecondary]}
+            onPress={() => Linking.openSettings()}
+          >
+            <Text style={styles.buttonText}>Open Settings</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <CameraView
+        style={StyleSheet.absoluteFillObject}
+        facing="back"
+        onBarcodeScanned={scanned ? undefined : handleBarcode}
+        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+      />
+
+      {/* Viewfinder overlay */}
+      <View style={styles.overlay}>
+        <View style={styles.topOverlay} />
+        <View style={styles.middleRow}>
+          <View style={styles.sideOverlay} />
+          <View style={styles.viewfinder}>
+            <View style={[styles.corner, styles.topLeft]} />
+            <View style={[styles.corner, styles.topRight]} />
+            <View style={[styles.corner, styles.bottomLeft]} />
+            <View style={[styles.corner, styles.bottomRight]} />
+          </View>
+          <View style={styles.sideOverlay} />
+        </View>
+        <View style={styles.bottomOverlay}>
+          {error ? (
+            <Text style={styles.errorText}>{error}</Text>
+          ) : scanned ? (
+            <Text style={styles.successText}>QR scanned — opening donation screen…</Text>
+          ) : (
+            <Text style={styles.hint}>
+              Point the camera at a project wallet QR code
+            </Text>
+          )}
+
+          {scanned && (
+            <TouchableOpacity
+              style={[styles.button, { marginTop: 16 }]}
+              onPress={() => { setScanned(false); cooldown.current = false; }}
+            >
+              <Text style={styles.buttonText}>Scan Again</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const CORNER = 24;
+const BORDER = 3;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+    backgroundColor: '#f0f7f0',
+  },
+  message: {
+    fontSize: 16,
+    color: '#1a2e1a',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  button: {
+    backgroundColor: '#227239',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 10,
+    marginTop: 8,
+  },
+  buttonSecondary: {
+    backgroundColor: '#5a7a5a',
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    flexDirection: 'column',
+  },
+  topOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+  },
+  middleRow: {
+    flexDirection: 'row',
+    height: 260,
+  },
+  sideOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+  },
+  viewfinder: {
+    width: 260,
+    height: 260,
+  },
+  bottomOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    paddingTop: 20,
+    paddingHorizontal: 24,
+  },
+  hint: {
+    color: '#c8e6c9',
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  errorText: {
+    color: '#ff8a80',
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  successText: {
+    color: '#a5d6a7',
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  corner: {
+    position: 'absolute',
+    width: CORNER,
+    height: CORNER,
+    borderColor: '#4caf50',
+  },
+  topLeft: {
+    top: 0,
+    left: 0,
+    borderTopWidth: BORDER,
+    borderLeftWidth: BORDER,
+  },
+  topRight: {
+    top: 0,
+    right: 0,
+    borderTopWidth: BORDER,
+    borderRightWidth: BORDER,
+  },
+  bottomLeft: {
+    bottom: 0,
+    left: 0,
+    borderBottomWidth: BORDER,
+    borderLeftWidth: BORDER,
+  },
+  bottomRight: {
+    bottom: 0,
+    right: 0,
+    borderBottomWidth: BORDER,
+    borderRightWidth: BORDER,
+  },
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,6 +22,7 @@
     "expo-router": "~3.5.0",
     "expo-status-bar": "~1.12.0",
     "expo-notifications": "~0.28.0",
+    "expo-camera": "~15.0.0",
     "react": "18.2.0",
     "react-native": "0.74.1",
     "react-native-safe-area-context": "4.10.1",


### PR DESCRIPTION
## Summary

- **`mobile/app/scan.tsx`** — full-screen `CameraView`-based QR scanner (expo-camera). Accepts plain Stellar public keys (`G…`) and `greenpay://donate?wallet=G...&project=<id>` deep-links. Shows a framed viewfinder with corner markers, per-scan feedback text, and a "Scan Again" button after a successful read.
- **`mobile/app/_layout.tsx`** — registers the `scan` screen with `headerShown: false` for a full-screen camera experience.
- **`mobile/app/index.tsx`** — adds a `📷 Scan` button in the home screen header for quick access to the scanner.
- **`mobile/app/donate/[id].tsx`** — reads the `wallet` query param injected by the scanner; auto-selects the matching project; shows a green confirmation banner with the scanned address and matched project name.
- **`mobile/package.json`** — adds `expo-camera ~15.0.0`.

## Flow

1. User taps **📷 Scan** on the home screen
2. Camera opens in full screen; user points at a project wallet QR
3. On successful scan, app navigates to `/donate/<projectId>?wallet=<address>`
4. Donate screen shows the scanned wallet banner and pre-selects the matching project

Closes #408
