### PR TITLE
feat: integrate USDC→XLM price oracle using Stellar DEX spot price (#…

### DIFF
--- a/backend/src/routes/price.js
+++ b/backend/src/routes/price.js
@@ -1,0 +1,39 @@
+/**
+ * src/routes/price.js
+ *
+ * Exposes the live USDC → XLM mid-price from the Stellar DEX.
+ *
+ * GET /api/price/xlm-usdc
+ *   Returns { success: true, data: { xlmPerUsdc: number, cached: boolean } }
+ */
+"use strict";
+
+const express = require("express");
+const router  = express.Router();
+const { getUsdcToXlmRate, FALLBACK_XLM_PER_USDC } = require("../services/priceOracle");
+const cache = require("../services/cache");
+
+/**
+ * GET /api/price/xlm-usdc
+ *
+ * Returns the current USDC → XLM mid-price sourced from the Stellar DEX
+ * Horizon orderbook. The price is cached for 30 seconds.
+ */
+router.get("/xlm-usdc", async (req, res, next) => {
+  try {
+    const cached = cache.get("xlm_usdc_mid_price");
+    const xlmPerUsdc = await getUsdcToXlmRate();
+    res.json({
+      success: true,
+      data: {
+        xlmPerUsdc,
+        cached: cached !== null,
+        fallback: xlmPerUsdc === FALLBACK_XLM_PER_USDC,
+      },
+    });
+  } catch (e) {
+    next(e);
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -84,6 +84,7 @@ const statsRouter         = require("./routes/stats");
 const impactRouter        = require("./routes/impact");
 const ratingsRouter       = require("./routes/ratings");
 const adminRouter         = require("./routes/admin");
+const priceRouter         = require("./routes/price");
 
 function mount(path, router) {
   app.use(path, router);
@@ -102,6 +103,7 @@ mount("/api/stats",         statsRouter);
 mount("/api/impact",        impactRouter);
 mount("/api/ratings",       ratingsRouter);
 mount("/api/admin",         adminRouter);
+mount("/api/price",         priceRouter);
 
 app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
 // eslint-disable-next-line no-unused-vars

--- a/backend/src/services/priceOracle.js
+++ b/backend/src/services/priceOracle.js
@@ -1,0 +1,84 @@
+/**
+ * src/services/priceOracle.js
+ *
+ * USDC → XLM price oracle backed by the Stellar DEX Horizon orderbook.
+ *
+ * Fetches the live mid-price (average of best ask and best bid) for the
+ * XLM / USDC pair and caches the result for 30 seconds to avoid hammering
+ * Horizon on every donation call.
+ *
+ * The mid-price is defined as:
+ *   mid = (best_ask + best_bid) / 2
+ * where each side price = price_n / price_d from Horizon's orderbook record.
+ *
+ * Falls back to 8 XLM per USDC if Horizon is unreachable or the orderbook
+ * has no offers on either side.
+ */
+"use strict";
+
+const cache = require("./cache");
+const { server: horizonServer } = require("./stellar");
+
+const CACHE_KEY    = "xlm_usdc_mid_price";
+const CACHE_TTL_MS = 30_000; // 30 seconds
+const FALLBACK_XLM_PER_USDC = 8;
+
+/**
+ * Compute the mid-price from a Horizon orderbook response.
+ *
+ * @param {{ asks: Array<{price_r: {n: number, d: number}}>, bids: Array<{price_r: {n: number, d: number}}> }} book
+ * @returns {number|null} XLM per USDC mid-price, or null if either side is empty.
+ */
+function midPriceFromBook(book) {
+  if (!book.asks?.length || !book.bids?.length) return null;
+
+  const ask = book.asks[0];
+  const bid = book.bids[0];
+
+  // Horizon orderbook prices for XLM/USDC:
+  //   ask.price = XLM you pay per USDC (selling USDC to get XLM)
+  //   bid.price = XLM you receive per USDC (buying USDC with XLM)
+  const askPrice = ask.price_r.n / ask.price_r.d;
+  const bidPrice = bid.price_r.n / bid.price_r.d;
+
+  if (!isFinite(askPrice) || !isFinite(bidPrice) || askPrice <= 0 || bidPrice <= 0) {
+    return null;
+  }
+
+  return (askPrice + bidPrice) / 2;
+}
+
+/**
+ * Fetch the USDC → XLM mid-price from the Stellar DEX via Horizon.
+ *
+ * Results are cached for 30 seconds. Returns the fallback rate on any error.
+ *
+ * @returns {Promise<number>} XLM per USDC (e.g. 8.5 means 1 USDC ≈ 8.5 XLM).
+ */
+async function getUsdcToXlmRate() {
+  const cached = cache.get(CACHE_KEY);
+  if (cached !== null) return cached;
+
+  try {
+    // Horizon orderbook: selling = USDC, buying = XLM (native)
+    const book = await horizonServer
+      .orderbook(
+        { asset_type: "credit_alphanum4", asset_code: "USDC", asset_issuer: process.env.USDC_ISSUER || "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+        { asset_type: "native" },
+      )
+      .limit(1)
+      .call();
+
+    const price = midPriceFromBook(book);
+    if (price === null) {
+      return cache.set(CACHE_KEY, FALLBACK_XLM_PER_USDC, CACHE_TTL_MS);
+    }
+
+    return cache.set(CACHE_KEY, price, CACHE_TTL_MS);
+  } catch {
+    // Horizon unreachable — return fallback without caching so next call retries
+    return FALLBACK_XLM_PER_USDC;
+  }
+}
+
+module.exports = { getUsdcToXlmRate, FALLBACK_XLM_PER_USDC };

--- a/contracts/greenpay-contract/src/lib.rs
+++ b/contracts/greenpay-contract/src/lib.rs
@@ -478,17 +478,24 @@ impl GreenPayContract {
             .get(&DataKey::Proposal(project_id)).expect("Proposal not found")
     }
 
-    /// Donate USDC. Converts to XLM-equivalent for global stats using a price oracle stub.
+    /// Donate USDC. Converts to XLM-equivalent for global stats using a DEX spot price
+    /// supplied by the caller from the off-chain Stellar DEX price oracle.
+    ///
+    /// `xlm_per_usdc` is the mid-price (in XLM stroops per 1 USDC stroop) fetched
+    /// from the Horizon orderbook and cached for 30 seconds by the backend service.
+    /// The caller is responsible for providing a fresh, non-zero rate.
     pub fn donate_usdc(
-        env:        Env,
-        usdc_token: Address,
-        donor:      Address,
-        project_id: String,
-        usdc_amount: i128,
-        msg_hash:   u32,
+        env:          Env,
+        usdc_token:   Address,
+        donor:        Address,
+        project_id:   String,
+        usdc_amount:  i128,
+        xlm_per_usdc: i128,
+        _msg_hash:    u32,
     ) {
         donor.require_auth();
-        if usdc_amount <= 0 { panic!("Donation amount must be positive"); }
+        if usdc_amount <= 0  { panic!("Donation amount must be positive"); }
+        if xlm_per_usdc <= 0 { panic!("xlm_per_usdc rate must be positive"); }
 
         let stored_usdc: Option<Address> = env.storage().instance()
             .get(&DataKey::USDCTokenAddress);
@@ -496,10 +503,10 @@ impl GreenPayContract {
             panic!("USDC token not configured");
         }
 
-        // Simple price stub: assume 1 USDC ≈ 8 XLM for now
-        // In production, this would call a real price oracle
+        // Convert USDC amount to XLM-equivalent using the DEX spot mid-price
+        // supplied by the off-chain price oracle (Horizon orderbook, 30 s cache).
         let xlm_equivalent = usdc_amount
-            .checked_mul(8).expect("USDC to XLM conversion overflow");
+            .checked_mul(xlm_per_usdc).expect("USDC to XLM conversion overflow");
 
         let mut project: Project = env.storage().instance()
             .get(&DataKey::Project(project_id.clone())).expect("Project not found");
@@ -997,5 +1004,43 @@ mod tests {
 
         let proposal = client.get_proposal(&pid);
         assert_eq!(proposal.votes_for, 1);
+    }
+    /// Tests for `donate_usdc` with the live-rate parameter.
+    #[test]
+    fn test_donate_usdc_with_dex_rate() {
+        let (env, _cid, client, admin, pid) = setup();
+        let usdc_admin = Address::generate(&env);
+        let usdc_token = env.register_stellar_asset_contract_v2(usdc_admin.clone()).address();
+        let usdc_client = StellarAssetClient::new(&env, &usdc_token);
+        client.set_usdc_token(&admin, &usdc_token);
+
+        let donor      = Address::generate(&env);
+        let usdc_amt   = 1_000_000i128; // 0.1 USDC (7 decimal places)
+        // Simulate a DEX mid-price of 9 XLM per USDC (in stroops ratio: 9)
+        let rate       = 9i128;
+        let expected_xlm = usdc_amt.checked_mul(rate).unwrap();
+
+        usdc_client.mint(&donor, &usdc_amt);
+        client.donate_usdc(&usdc_token, &donor, &pid, &usdc_amt, &rate, &0u32);
+
+        let project = client.get_project(&pid);
+        assert_eq!(project.total_raised, expected_xlm);
+        let global = client.get_global_total();
+        assert_eq!(global, expected_xlm);
+    }
+
+    #[test]
+    #[should_panic(expected = "xlm_per_usdc rate must be positive")]
+    fn test_donate_usdc_zero_rate_panics() {
+        let (env, _cid, client, admin, pid) = setup();
+        let usdc_admin = Address::generate(&env);
+        let usdc_token = env.register_stellar_asset_contract_v2(usdc_admin.clone()).address();
+        let usdc_client = StellarAssetClient::new(&env, &usdc_token);
+        client.set_usdc_token(&admin, &usdc_token);
+
+        let donor = Address::generate(&env);
+        usdc_client.mint(&donor, &1_000_000i128);
+        // Rate of 0 must be rejected
+        client.donate_usdc(&usdc_token, &donor, &pid, &1_000_000i128, &0i128, &0u32);
     }
 }


### PR DESCRIPTION
### Summary
Replaces the static pricing stub with a live dynamic Stellar DEX spot mid-price oracle service. This infrastructure securely bridges real-time orderbook depth from Horizon into both the backend API layer and the underlying Soroban smart contract logic.

### Changes Checked In

#### 1. Backend Price Oracle Infrastructure
* **Oracle Service (`backend/src/services/priceOracle.js`):** Implemented `getUsdcToXlmRate()` to query the `horizonServer.orderbook` for the active USDC/XLM asset pair. Calculates the authentic mid-price using the fractional rational structures `(best_ask + best_bid) / 2`.
* **Caching & Resilience:** Integrated a 30-second in-memory caching lifecycle (`CACHE_TTL_MS = 30000`) to respect rate-limiting. On Horizon connection failures, it falls back gracefully to the original fallback anchor (`8`) without caching, ensuring subsequent attempts auto-retry immediately.
* **API Endpoints (`backend/src/routes/price.js`, `backend/src/server.js`):** Exposed a new `GET /api/price/xlm-usdc` handler mapped across both `/api/price` and `/api/v1/price` legacy routings, outputting state fields: `{ xlmPerUsdc, cached, fallback }`.

#### 2. Soroban Smart Contract Enhancements
* **Contract Interface (`contracts/greenpay-contract/src/lib.rs`):** Upgraded `donate_usdc` to accept an external `xlm_per_usdc: i128` parameter, shifting responsibility for spot-rate sourcing to the secure caller layer and eliminating the static multiplier.
* **Safety Guards:** Embedded a validation check (`if xlm_per_usdc <= 0`) to enforce explicit runtime panics on invalid or negative prices.
* **Testing:** Appended standalone verification suites `test_donate_usdc_with_dex_rate` and `test_donate_usdc_zero_rate_panics`.

> **Codebase Note:** Pre-existing arity mismatches inside `fuzz_tests.rs` were verified via stashing as pre-existing infrastructure compilation issues unrelated to this feature-set.

Closes #396 