### PR TITLE
feat: add Widget Builder panel to admin page with embed customisation

### DIFF
--- a/frontend/pages/admin/[projectId].tsx
+++ b/frontend/pages/admin/[projectId].tsx
@@ -58,6 +58,44 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
 
   const [matches, setMatches] = useState<any[]>([]);
 
+  const [widgetAccent, setWidgetAccent] = useState("#059669");
+  const [widgetButtonText, setWidgetButtonText] = useState("Donate on GreenPay");
+  const [widgetCurrency, setWidgetCurrency] = useState<"XLM" | "USDC">("XLM");
+  const [copied, setCopied] = useState(false);
+
+  const widgetEmbedCode = useMemo(() => {
+    const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
+    const params = new URLSearchParams({
+      accent: widgetAccent,
+      buttonText: widgetButtonText,
+      currency: widgetCurrency,
+    });
+    return `<iframe src="${baseUrl}/widget/${projectId}?${params}" width="360" height="420" frameborder="0" style="border:none;overflow:hidden" sandbox="allow-scripts allow-same-origin"></iframe>`;
+  }, [widgetAccent, widgetButtonText, widgetCurrency, projectId]);
+
+  const PRESET_COLORS = [
+    "#059669", "#10b981", "#34d399", "#6ee7b7",
+    "#2563eb", "#7c3aed", "#db2777", "#dc2626",
+    "#ea580c", "#d97706", "#65a30d", "#0891b2",
+  ];
+
+  const copyEmbed = async () => {
+    try {
+      await navigator.clipboard.writeText(widgetEmbedCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = widgetEmbedCode;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
   useEffect(() => {
     if (!projectId || typeof projectId !== "string") return;
     setLoading(true);
@@ -650,6 +688,110 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
             ))}
           </div>
         )}
+      </div>
+
+      {/* Widget Builder */}
+      <div className="card mt-6">
+        <h2 className="font-display text-xl font-bold text-forest-900 mb-2">Widget Builder</h2>
+        <p className="text-sm text-[#5a7a5a] font-body mb-4">
+          Customise the embeddable widget for this project and copy the embed code to paste on external sites.
+        </p>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Controls */}
+          <div className="space-y-5">
+            {/* Accent colour */}
+            <div>
+              <label className="block text-xs font-bold text-forest-800 uppercase tracking-widest mb-2 ml-1 opacity-50">
+                Accent Colour
+              </label>
+              <div className="flex items-center gap-2 mb-2">
+                {PRESET_COLORS.map((c) => (
+                  <button
+                    key={c}
+                    onClick={() => setWidgetAccent(c)}
+                    className={`w-7 h-7 rounded-full border-2 transition-all ${widgetAccent === c ? "border-forest-900 scale-110" : "border-transparent"}`}
+                    style={{ backgroundColor: c }}
+                    aria-label={`Select colour ${c}`}
+                  />
+                ))}
+              </div>
+              <div className="flex items-center gap-3">
+                <input
+                  type="color"
+                  value={widgetAccent}
+                  onChange={(e) => setWidgetAccent(e.target.value)}
+                  className="w-10 h-10 rounded cursor-pointer border border-forest-200 p-0.5"
+                />
+                <span className="text-xs font-mono text-[#5a7a5a]">{widgetAccent}</span>
+              </div>
+            </div>
+
+            {/* Button text */}
+            <div>
+              <label className="block text-xs font-bold text-forest-800 uppercase tracking-widest mb-1 ml-1 opacity-50">
+                Button Text
+              </label>
+              <input
+                value={widgetButtonText}
+                onChange={(e) => setWidgetButtonText(e.target.value)}
+                className="input-field"
+                placeholder="Donate on GreenPay"
+                maxLength={60}
+              />
+            </div>
+
+            {/* Currency */}
+            <div>
+              <label className="block text-xs font-bold text-forest-800 uppercase tracking-widest mb-2 ml-1 opacity-50">
+                Currency Displayed
+              </label>
+              <div className="flex gap-2">
+                {(["XLM", "USDC"] as const).map((c) => (
+                  <button
+                    key={c}
+                    onClick={() => setWidgetCurrency(c)}
+                    className={`px-5 py-2 rounded-xl text-sm font-semibold border transition-all ${
+                      widgetCurrency === c
+                        ? "bg-forest-600 text-white border-forest-600"
+                        : "bg-white text-[#5a7a5a] border-forest-200 hover:bg-forest-50"
+                    }`}
+                  >
+                    {c}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Live preview hint */}
+            <div className="p-3 rounded-xl bg-forest-50 border border-forest-100">
+              <p className="text-xs text-[#5a7a5a] font-body">
+                <span className="font-semibold">Tip:</span> The widget will display {widgetCurrency} amounts with the accent colour shown above.
+              </p>
+            </div>
+          </div>
+
+          {/* Embed code */}
+          <div className="space-y-3">
+            <label className="block text-xs font-bold text-forest-800 uppercase tracking-widest ml-1 opacity-50">
+              Embed Code
+            </label>
+            <textarea
+              readOnly
+              value={widgetEmbedCode}
+              className="input-field font-mono text-xs min-h-[100px] resize-none bg-forest-50/50"
+              onClick={(e) => (e.target as HTMLTextAreaElement).select()}
+            />
+            <button
+              onClick={copyEmbed}
+              className={`btn-primary w-full text-sm py-2.5 transition-all ${
+                copied ? "bg-emerald-600 hover:bg-emerald-700" : ""
+              }`}
+            >
+              {copied ? "✓ Copied!" : "Copy Embed Code"}
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/pages/widget/[projectId].tsx
+++ b/frontend/pages/widget/[projectId].tsx
@@ -9,12 +9,23 @@ import { fetchProject } from "@/lib/api";
 import { formatXLM, formatCO2, progressPercent } from "@/utils/format";
 import type { ClimateProject } from "@/utils/types";
 
+type Currency = "XLM" | "USDC";
+
+function hexToRgb(hex: string): string {
+  const clean = hex.replace("#", "");
+  const num = parseInt(clean, 16);
+  return `${(num >> 16) & 255}, ${(num >> 8) & 255}, ${num & 255}`;
+}
+
 export default function WidgetPage() {
   const router = useRouter();
   const { projectId } = router.query;
   const [project, setProject] = useState<ClimateProject | null>(null);
   const [loading, setLoading] = useState(true);
   const theme = (router.query.theme as "light" | "dark") || "light";
+  const accent = (router.query.accent as string) || "#059669";
+  const buttonText = (router.query.buttonText as string) || "Donate on GreenPay";
+  const currency = (router.query.currency as Currency) || "XLM";
 
   useEffect(() => {
     if (!projectId) return;
@@ -27,7 +38,7 @@ export default function WidgetPage() {
   if (loading) {
     return (
       <div className={`min-h-screen flex items-center justify-center ${theme === "dark" ? "bg-gray-900" : "bg-white"}`}>
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-forest-600" />
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2" style={{ borderBottomColor: accent }} />
       </div>
     );
   }
@@ -47,17 +58,25 @@ export default function WidgetPage() {
   const textClass = theme === "dark" ? "text-gray-100" : "text-gray-900";
   const secondaryClass = theme === "dark" ? "text-gray-400" : "text-gray-600";
   const borderClass = theme === "dark" ? "border-gray-700" : "border-gray-200";
-  const buttonClass = theme === "dark"
-    ? "bg-forest-600 hover:bg-forest-700 text-white"
-    : "bg-forest-500 hover:bg-forest-600 text-white";
+
+  const formatAmount = (xlm: string) => {
+    if (currency === "USDC") {
+      const val = parseFloat(xlm);
+      return `$${val.toFixed(2)}`;
+    }
+    return formatXLM(xlm);
+  };
 
   return (
     <div className={`min-h-screen ${bgClass} p-4 flex items-center justify-center`}>
       <div className={`w-full max-w-sm rounded-xl border ${borderClass} overflow-hidden shadow-lg`}>
         {/* Header */}
-        <div className="bg-gradient-to-r from-forest-500 to-emerald-500 p-4 text-white">
+        <div
+          className="p-4 text-white"
+          style={{ background: `linear-gradient(to right, ${accent}, ${accent}dd)` }}
+        >
           <h3 className="font-display text-lg font-bold truncate">{project.name}</h3>
-          <p className={`text-sm opacity-90 truncate`}>{project.category}</p>
+          <p className="text-sm opacity-90 truncate">{project.category}</p>
         </div>
 
         {/* Content */}
@@ -66,27 +85,36 @@ export default function WidgetPage() {
           <div>
             <div className="flex justify-between items-baseline mb-2">
               <p className={`text-sm font-semibold ${textClass}`}>
-                {formatXLM(project.raisedXLM)} raised
+                {formatAmount(project.raisedXLM)} raised
               </p>
               <p className={`text-xs ${secondaryClass}`}>
-                {pct}% of {formatXLM(project.goalXLM)}
+                {pct}% of {formatAmount(project.goalXLM)}
               </p>
             </div>
-            <div className={`h-2 rounded-full bg-gray-200 overflow-hidden`}>
+            <div className="h-2 rounded-full bg-gray-200 overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-forest-500 to-emerald-500 transition-all"
-                style={{ width: `${Math.min(pct, 100)}%` }}
+                className="h-full transition-all"
+                style={{
+                  width: `${Math.min(pct, 100)}%`,
+                  background: `linear-gradient(to right, ${accent}, ${accent}dd)`,
+                }}
               />
             </div>
           </div>
 
           {/* Stats grid */}
           <div className="grid grid-cols-2 gap-3">
-            <div className={`p-2 rounded bg-opacity-10 bg-forest-600`}>
+            <div
+              className="p-2 rounded"
+              style={{ backgroundColor: `rgba(${hexToRgb(accent)}, 0.1)` }}
+            >
               <p className={`text-xs ${secondaryClass} font-semibold`}>Donors</p>
               <p className={`text-lg font-bold ${textClass}`}>{project.donorCount}</p>
             </div>
-            <div className={`p-2 rounded bg-opacity-10 bg-emerald-600`}>
+            <div
+              className="p-2 rounded"
+              style={{ backgroundColor: `rgba(${hexToRgb(accent)}, 0.08)` }}
+            >
               <p className={`text-xs ${secondaryClass} font-semibold`}>CO₂ Offset</p>
               <p className={`text-lg font-bold ${textClass}`}>{formatCO2(project.co2OffsetKg)}</p>
             </div>
@@ -97,9 +125,12 @@ export default function WidgetPage() {
             href={`/projects/${project.id}?utm_source=widget`}
             target="_blank"
             rel="noopener noreferrer"
-            className={`block w-full py-3 rounded-lg font-semibold text-center transition-colors ${buttonClass}`}
+            className="block w-full py-3 rounded-lg font-semibold text-center transition-colors text-white"
+            style={{ backgroundColor: accent }}
+            onMouseEnter={(e) => { e.currentTarget.style.opacity = "0.9"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.opacity = "1"; }}
           >
-            Donate on GreenPay
+            {buttonText}
           </Link>
         </div>
 
@@ -109,7 +140,8 @@ export default function WidgetPage() {
             href="https://greenpay.app"
             target="_blank"
             rel="noopener noreferrer"
-            className={`text-xs ${secondaryClass} hover:text-forest-600 transition-colors`}
+            className={`text-xs ${secondaryClass} transition-colors`}
+            style={{ color: `rgba(${hexToRgb(accent)}, 0.6)` }}
           >
             Powered by GreenPay
           </a>


### PR DESCRIPTION
feat: add Widget Builder panel to admin page with embed customisation

The widget page at /widget/[projectId] was embeddable via iframe but had no
configuration UI. This commit adds a Widget Builder panel on the project admin
page allowing project owners to visually customise their embeddable widget.

Changes:
- frontend/pages/admin/[projectId].tsx:
  - Add Widget Builder card with 4 customisation controls:
    - Accent colour: 12 preset colour swatches + native colour picker
    - Button text: text input (max 60 chars, defaults to "Donate on GreenPay")
    - Currency toggle: XLM / USDC radio-style buttons
    - Generated iframe embed code with "Copy Embed Code" button
      (navigator.clipboard with execCommand fallback)
  - Embed URL uses window.location.origin for correct deployment-relative URLs
  - Shows visual feedback ("✓ Copied!") on successful copy

- frontend/pages/widget/[projectId].tsx:
  - Accept 3 new query parameters from the embed URL:
    - accent (hex colour) → customises header gradient, progress bar,
      button background, stat card tints, footer link colour
    - buttonText → overrides the CTA button label
    - currency (XLM/USDC) → toggles between formatXLM() and $X.XX display
  - Add hexToRgb utility for dynamic rgba background generation
  - Spinner and hover states now use the accent colour

Closes #411