### PR TITLE
Fix: Latest issues

### DIFF
--- a/backend/src/routes/profiles.js
+++ b/backend/src/routes/profiles.js
@@ -19,7 +19,31 @@ router.get("/:publicKey", async (req, res, next) => {
     validateKey(req.params.publicKey);
     const result = await pool.query("SELECT * FROM profiles WHERE public_key = $1", [req.params.publicKey]);
     if (!result.rows[0]) { const e = new Error("Profile not found"); e.status = 404; throw e; }
-    res.json({ success: true, data: mapProfileRow(result.rows[0]) });
+
+    const co2Result = await pool.query(
+      `SELECT COALESCE(
+        SUM(
+          CASE
+            WHEN p.raised_xlm > 0 THEN (d.amount_xlm * (p.co2_offset_kg::numeric / p.raised_xlm))
+            ELSE 0
+          END
+        ),
+        0
+      ) AS total_co2_offset_kg
+       FROM donations d
+       JOIN projects p ON p.id = d.project_id
+       WHERE d.donor_address = $1
+         AND (d.currency = 'XLM' OR d.currency IS NULL)`,
+      [req.params.publicKey],
+    );
+    const totalCo2OffsetKg = Math.round(
+      Number.parseFloat(co2Result.rows[0]?.total_co2_offset_kg || "0"),
+    );
+
+    res.json({
+      success: true,
+      data: { ...mapProfileRow(result.rows[0]), totalCo2OffsetKg },
+    });
   } catch (e) { next(e); }
 });
 

--- a/backend/src/routes/projects.test.js
+++ b/backend/src/routes/projects.test.js
@@ -180,3 +180,34 @@ describe("POST /api/projects (admin)", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("POST /api/projects/:id/generate-summary", () => {
+  let app;
+
+  const OWNER_ADDRESS = "GSEEDLING" + "A".repeat(47);
+  const OTHER_ADDRESS = "GDIFFERENT" + "B".repeat(46);
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("returns 403 when caller is not the project owner", async () => {
+    pool.query.mockResolvedValue({
+      rows: [{
+        id: "proj-1",
+        name: "Test Project",
+        category: "Reforestation",
+        description: "A test climate project",
+        wallet_address: OWNER_ADDRESS,
+      }],
+    });
+
+    const res = await request(app)
+      .post("/api/projects/proj-1/generate-summary")
+      .send({ adminAddress: OTHER_ADDRESS });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Only the project owner can generate a summary");
+  });
+});

--- a/contracts/greenpay-contract/src/lib.rs
+++ b/contracts/greenpay-contract/src/lib.rs
@@ -27,7 +27,7 @@ mod fuzz_tests;
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
-    token, Address, Env, symbol_short, Symbol, String, BytesN,
+    token, Address, Env, symbol_short, Symbol, String, BytesN, Vec,
 };
 
 // ─── Badge tiers (on-chain) ───────────────────────────────────────────────────
@@ -101,6 +101,7 @@ pub struct VoteProposal {
 pub enum DataKey {
     Admin,
     Project(String),
+    ProjectIds,
     ProjectCount,
     DonorStats(Address),
     ImpactNFT(Address, BadgeTier),
@@ -131,6 +132,10 @@ const VOTING_WINDOW_LEDGERS: u32 = 120_960;
 // pressure and prevents proposals from sitting open indefinitely.
 const MIN_VOTING_WINDOW_LEDGERS: u32 = 720;     // 1 hour @ 5s/ledger
 const MAX_VOTING_WINDOW_LEDGERS: u32 = 518_400; // 30 days @ 5s/ledger
+
+// Upper bound on co2_per_xlm at registration — prevents donate-time CO₂ overflow
+// panics and misleading impact figures from misconfigured projects.
+const MAX_CO2_PER_XLM: u32 = 100_000;
 
 fn calculate_badge(total_stroops: i128) -> BadgeTier {
     let xlm = total_stroops / STROOP;
@@ -179,12 +184,20 @@ impl GreenPayContract {
         if env.storage().instance().has(&DataKey::Project(project_id.clone())) {
             panic!("Project already registered");
         }
+        if co2_per_xlm > MAX_CO2_PER_XLM {
+            panic!("CO2 per XLM exceeds maximum");
+        }
         let project = Project {
             id: project_id.clone(), name, wallet, co2_per_xlm,
             total_raised: 0, donor_count: 0, active: true,
             registered_at: env.ledger().sequence(),
         };
         env.storage().instance().set(&DataKey::Project(project_id.clone()), &project);
+        let mut project_ids: Vec<String> = env.storage().instance()
+            .get(&DataKey::ProjectIds)
+            .unwrap_or_else(|| Vec::new(&env));
+        project_ids.push_back(project_id.clone());
+        env.storage().instance().set(&DataKey::ProjectIds, &project_ids);
         let count: u32 = env.storage().instance().get(&DataKey::ProjectCount).unwrap_or(0);
         let next_count = count.checked_add(1).expect("ProjectCount overflow");
         env.storage().instance().set(&DataKey::ProjectCount, &next_count);
@@ -200,6 +213,27 @@ impl GreenPayContract {
             .get(&DataKey::Project(project_id.clone())).expect("Project not found");
         project.active = false;
         env.storage().instance().set(&DataKey::Project(project_id), &project);
+    }
+
+    /// Emergency circuit breaker — deactivates every registered project at once.
+    /// Callable only by admin when a critical vulnerability requires halting
+    /// all donation processing.
+    pub fn deactivate_all_projects(env: Env, admin: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance()
+            .get(&DataKey::Admin).expect("Not initialized");
+        if stored_admin != admin { panic!("Only admin can deactivate all projects"); }
+        let project_ids: Vec<String> = env.storage().instance()
+            .get(&DataKey::ProjectIds)
+            .unwrap_or_else(|| Vec::new(&env));
+        for i in 0..project_ids.len() {
+            let project_id = project_ids.get(i).unwrap();
+            let mut project: Project = env.storage().instance()
+                .get(&DataKey::Project(project_id.clone())).expect("Project not found");
+            project.active = false;
+            env.storage().instance().set(&DataKey::Project(project_id), &project);
+        }
+        env.events().publish((symbol_short!("deact_all"),), admin);
     }
 
     // ─── Donations ────────────────────────────────────────────────────────────
@@ -935,6 +969,43 @@ mod tests {
     fn test_create_proposal_rejects_too_long_duration() {
         let (_env, _cid, client, admin, pid) = setup();
         client.create_proposal(&admin, &pid, &(MAX_VOTING_WINDOW_LEDGERS + 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "CO2 per XLM exceeds maximum")]
+    fn test_register_project_rejects_excessive_co2_per_xlm() {
+        let (env, _cid, client, admin, _pid) = setup();
+        let pid2 = String::from_str(&env, "proj-002");
+        let wallet = Address::generate(&env);
+        client.register_project(
+            &admin,
+            &pid2,
+            &String::from_str(&env, "Bad Project"),
+            &wallet,
+            &(MAX_CO2_PER_XLM + 1),
+        );
+    }
+
+    #[test]
+    fn test_deactivate_all_projects() {
+        let (env, _cid, client, admin, pid1) = setup();
+        let pid2 = String::from_str(&env, "proj-002");
+        let wallet = Address::generate(&env);
+        client.register_project(
+            &admin,
+            &pid2,
+            &String::from_str(&env, "Second Project"),
+            &wallet,
+            &100u32,
+        );
+
+        assert!(client.get_project(&pid1).active);
+        assert!(client.get_project(&pid2).active);
+
+        client.deactivate_all_projects(&admin);
+
+        assert!(!client.get_project(&pid1).active);
+        assert!(!client.get_project(&pid2).active);
     }
 
     /// Test that voting is rejected after the deadline has passed (issue #209).


### PR DESCRIPTION
## Summary

- **#434** — Add integration test for `POST /api/projects/:id/generate-summary` verifying that a non-owner caller receives HTTP 403 with `"Only the project owner can generate a summary"`.
- **#426** — Add `MAX_CO2_PER_XLM` (100,000) constant and validate `co2_per_xlm` in `register_project` to prevent misconfigured rates that could cause CO₂ overflow panics at donate time.
- **#379** — Add `totalCo2OffsetKg` to `GET /api/profiles/:publicKey`, aggregating proportional CO₂ offset across all donor donations joined with project rates.
- **#425** — Add admin-only `deactivate_all_projects` emergency circuit breaker that deactivates every registered project at once, with on-chain `ProjectIds` index for enumeration.

Closes #434
Closes #426
Closes #379
Closes #425

## Test plan

- [ ] `POST /api/projects/:id/generate-summary` returns 403 when `adminAddress` does not match project `wallet_address`
- [ ] `register_project` rejects `co2_per_xlm > 100_000`
- [ ] `GET /api/profiles/:publicKey` includes `totalCo2OffsetKg` reflecting summed donation impact
- [ ] `deactivate_all_projects` sets `active = false` on all registered projects; donations to any project fail afterward