### PR TITLE
feat: add rate limiting to GET /api/leaderboard (#695)

### DIFF
--- a/backend/src/routes/leaderboard.js
+++ b/backend/src/routes/leaderboard.js
@@ -5,8 +5,12 @@
 const express = require("express");
 const router  = express.Router();
 const pool = require("../db/pool");
+const { createRateLimiter } = require("../middleware/rateLimiter");
 
-router.get("/", async (req, res, next) => {
+// 30 requests per minute per IP — prevents enumeration / data scraping (issue #695)
+const leaderboardLimiter = createRateLimiter(30, 1);
+
+router.get("/", leaderboardLimiter, async (req, res, next) => {
   try {
     const limit = Math.min(parseInt(req.query.limit, 10) || 20, 100);
     const period = req.query.period || "all";
@@ -97,7 +101,7 @@ router.get("/", async (req, res, next) => {
  * Query params:
  *   - months (int, max 24, default 12): how many past months to return
  */
-router.get("/history", async (req, res, next) => {
+router.get("/history", leaderboardLimiter, async (req, res, next) => {
   try {
     const months = Math.min(parseInt(req.query.months, 10) || 12, 24);
     const result = await pool.query(

--- a/backend/src/routes/leaderboard.test.js
+++ b/backend/src/routes/leaderboard.test.js
@@ -2,7 +2,14 @@
 
 jest.mock("../db/pool", () => ({ query: jest.fn() }));
 
+// Mock rate limiter so it doesn't interfere with most tests; individual
+// tests override this when they need to exercise rate-limit behaviour.
+jest.mock("../middleware/rateLimiter", () => ({
+  createRateLimiter: jest.fn(() => (_req, _res, next) => next()),
+}));
+
 const pool = require("../db/pool");
+const { createRateLimiter } = require("../middleware/rateLimiter");
 const request = require("supertest");
 const express = require("express");
 const leaderboardRouter = require("./leaderboard");
@@ -165,5 +172,41 @@ describe("GET /api/leaderboard — limit handling", () => {
     await request(app).get("/api/leaderboard?limit=abc").expect(200);
 
     expect(pool.query).toHaveBeenCalledWith(expect.any(String), [20]);
+  });
+});
+
+describe("GET /api/leaderboard — rate limiting", () => {
+  test("createRateLimiter is called with (30, 1) matching the donations-endpoint pattern", () => {
+    // The module was already required above; just verify the factory was invoked
+    // with the correct arguments (30 req/min per IP).
+    expect(createRateLimiter).toHaveBeenCalledWith(30, 1);
+  });
+
+  test("returns 429 when the rate limiter blocks the request", async () => {
+    // Temporarily override the mock to simulate a blocked request.
+    createRateLimiter.mockImplementationOnce(() => (_req, res) => {
+      res.set("Retry-After", "60");
+      return res.status(429).json({ message: "Too many requests — Try again later." });
+    });
+
+    // Re-require the router so it picks up the new mock implementation.
+    jest.resetModules();
+    jest.mock("../db/pool", () => ({ query: jest.fn() }));
+    jest.mock("../middleware/rateLimiter", () => ({
+      createRateLimiter: jest.fn(() => (_req, res) => {
+        res.set("Retry-After", "60");
+        return res.status(429).json({ message: "Too many requests — Try again later." });
+      }),
+    }));
+
+    const freshRouter = require("./leaderboard");
+    const app = express();
+    app.use(express.json());
+    app.use("/api/leaderboard", freshRouter);
+
+    const res = await request(app).get("/api/leaderboard");
+    expect(res.status).toBe(429);
+    expect(res.body.message).toMatch(/too many requests/i);
+    expect(res.headers["retry-after"]).toBe("60");
   });
 });


### PR DESCRIPTION
Apply createRateLimiter(30, 1) — 30 req/min per IP — to the GET /api/leaderboard and GET /api/leaderboard/history endpoints.

The leaderboard exposes all donor public keys and totals, making it trivial to scrape with no previous throttle in place. The 30 req/min limit matches the intent described in the issue and is consistent with the donations-endpoint pattern (which uses 10 req/min for writes).

The POST /snapshot admin endpoint is intentionally excluded: it already requires a secret header and is not publicly enumerable.

Tests: mock createRateLimiter to assert the factory is called with the correct arguments, and verify that a blocked request returns 429 with Retry-After header.

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

closes #695  
