### PR TITLE
feat: add Content-Disposition header to GET /api/uploads/:key (#696)

### DIFF
--- a/backend/src/routes/uploads.js
+++ b/backend/src/routes/uploads.js
@@ -11,6 +11,8 @@
  *
  * GET /api/uploads/:key
  *   - Serves files written by the local backend from backend/uploads/<key>.
+ *   - Sets Content-Disposition: attachment so browsers prompt a download
+ *     instead of rendering PDFs/images inline (issue #696).
  *   - Other backends simply point callers at absolute URLs, so this
  *     static-serve route returns 404 by design for non-local backends.
  */
@@ -85,6 +87,34 @@ router.post("/", uploadRateLimiter, (req, res, next) => {
 });
 
 /**
+ * Derive a safe Content-Disposition header value from a storage key.
+ *
+ * Keys are built by storage.js as "<24-char hex>-<sanitized-original-name>",
+ * e.g. "a1b2c3d4e5f6a1b2c3d4e5f6-report_2026.pdf".
+ * We strip the hex prefix to recover the original filename, then emit both
+ * an ASCII quoted-string fallback (for older UAs) and an RFC 5987
+ * percent-encoded filename* parameter (for full Unicode support).
+ *
+ * @param {string} key - URL-decoded storage key from req.params.key.
+ * @returns {string} Complete Content-Disposition header value.
+ */
+function buildContentDisposition(key) {
+  const match = key.match(/^[0-9a-f]{24}-(.+)$/i);
+  const filename = match ? match[1] : key;
+
+  // ASCII fallback: replace anything outside printable ASCII and RFC 6266
+  // forbidden chars (double-quote, backslash) with underscores.
+  const asciiFilename = filename
+    .replace(/[^\x20-\x7E]/g, "_")
+    .replace(/["\\]/g, "_");
+
+  // RFC 5987 value for full Unicode filenames.
+  const encodedFilename = encodeURIComponent(filename).replace(/'/g, "%27");
+
+  return `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodedFilename}`;
+}
+
+/**
  * Serve files persisted by the "local" backend. S3/IPFS callers
  * should use the URLs returned at upload time — this route only exists
  * for the local fallback to make documents reachable from the browser.
@@ -105,6 +135,8 @@ router.get("/:key", (req, res) => {
   if (!fs.existsSync(fullPath)) {
     return res.status(404).json({ error: "File not found" });
   }
+  // Issue #696 — prompt download instead of inline rendering.
+  res.setHeader("Content-Disposition", buildContentDisposition(key));
   res.sendFile(fullPath);
 });
 

--- a/backend/src/routes/uploads.test.js
+++ b/backend/src/routes/uploads.test.js
@@ -1,0 +1,144 @@
+"use strict";
+
+/**
+ * Tests for GET /api/uploads/:key — Content-Disposition header (issue #696)
+ *
+ * We mock the fs, path, and storage modules so no real filesystem access
+ * is needed and the tests run deterministically in CI.
+ */
+
+jest.mock("../services/storage", () => ({
+  uploadFile: jest.fn(),
+  backendName: jest.fn(() => "local"),
+  UPLOAD_DIR: "/fake/uploads",
+}));
+
+jest.mock("../middleware/rateLimiter", () => ({
+  createRateLimiter: jest.fn(() => (_req, _res, next) => next()),
+}));
+
+// Intercept fs.existsSync so we never touch the real filesystem.
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
+  existsSync: jest.fn(() => true),
+}));
+
+const request = require("supertest");
+const express = require("express");
+const path = require("path");
+
+// path.join and path.sep must behave normally — only UPLOAD_DIR is faked.
+// We reload the router after mocks are in place.
+const uploadsRouter = require("./uploads");
+const { backendName } = require("../services/storage");
+const fs = require("fs");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/uploads", uploadsRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a realistic storage key the way storage.js does:
+ *   crypto.randomBytes(12).toString("hex") + "-" + sanitized-name
+ * We use a fixed 24-char hex prefix for predictable assertions.
+ */
+const HEX_PREFIX = "a1b2c3d4e5f6a1b2c3d4e5f6";
+const key = (name) => `${HEX_PREFIX}-${name}`;
+
+// ---------------------------------------------------------------------------
+// Content-Disposition — happy path
+// ---------------------------------------------------------------------------
+
+describe("GET /api/uploads/:key — Content-Disposition header (issue #696)", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    backendName.mockReturnValue("local");
+    fs.existsSync.mockReturnValue(true);
+  });
+
+  test("sets Content-Disposition: attachment for a PDF key", async () => {
+    const res = await request(app).get(`/api/uploads/${key("report_2026.pdf")}`);
+    expect(res.headers["content-disposition"]).toMatch(/^attachment/);
+  });
+
+  test("includes the original filename in the header", async () => {
+    const res = await request(app).get(`/api/uploads/${key("invoice.pdf")}`);
+    expect(res.headers["content-disposition"]).toContain("invoice.pdf");
+  });
+
+  test("includes both filename= and filename*= params for broad UA support", async () => {
+    const res = await request(app).get(`/api/uploads/${key("photo.png")}`);
+    const header = res.headers["content-disposition"];
+    expect(header).toMatch(/filename="/);
+    expect(header).toMatch(/filename\*=UTF-8''/);
+  });
+
+  test("strips the hex prefix so the download name is clean", async () => {
+    const res = await request(app).get(`/api/uploads/${key("data_export.csv")}`);
+    const header = res.headers["content-disposition"];
+    // The hex prefix must NOT appear in the filename value.
+    expect(header).not.toContain(HEX_PREFIX);
+    expect(header).toContain("data_export.csv");
+  });
+
+  test("falls back to the raw key as filename when prefix pattern is absent", async () => {
+    // A key with no hex prefix (legacy or manually crafted).
+    const res = await request(app).get("/api/uploads/myfile.txt");
+    const header = res.headers["content-disposition"];
+    expect(header).toMatch(/^attachment/);
+    expect(header).toContain("myfile.txt");
+  });
+
+  test("percent-encodes non-ASCII characters in filename*", async () => {
+    // Simulate a sanitized name that still contains non-ASCII bytes.
+    const encodedKey = encodeURIComponent(key("repor\u00e9.pdf"));
+    const res = await request(app).get(`/api/uploads/${encodedKey}`);
+    const header = res.headers["content-disposition"];
+    expect(header).toMatch(/filename\*=UTF-8''/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Existing behaviour must be preserved
+// ---------------------------------------------------------------------------
+
+describe("GET /api/uploads/:key — existing guard behaviour", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    backendName.mockReturnValue("local");
+    fs.existsSync.mockReturnValue(true);
+  });
+
+  test("returns 404 when the storage backend is not local", async () => {
+    backendName.mockReturnValue("s3");
+    const res = await request(app).get(`/api/uploads/${key("file.pdf")}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/disabled/i);
+  });
+
+  test("returns 400 for a key containing path-traversal sequences", async () => {
+    const res = await request(app).get("/api/uploads/..%2F..%2Fetc%2Fpasswd");
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 when the file does not exist on disk", async () => {
+    fs.existsSync.mockReturnValue(false);
+    const res = await request(app).get(`/api/uploads/${key("missing.pdf")}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+});


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #696 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
closes #696 
