### PR TITLE
feat(jobs): add GET /api/jobs/stats endpoint with Redis caching

### DIFF
--- a/backend/src/routes/jobs-stats.test.js
+++ b/backend/src/routes/jobs-stats.test.js
@@ -1,0 +1,108 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({ query: jest.fn() }));
+jest.mock("../services/redis", () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+const request = require("supertest");
+const express = require("express");
+const pool = require("../db/pool");
+const redis = require("../services/redis");
+const jobsRouter = require("./jobs");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/jobs", jobsRouter);
+  app.use((err, _req, res, _next) => {
+    void _next;
+    res.status(err.status || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+describe("GET /api/jobs/stats", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("returns aggregate escrow marketplace metrics and caches them in Redis for 60 seconds", async () => {
+    redis.get.mockResolvedValue(null);
+    pool.query.mockResolvedValue({
+      rows: [
+        {
+          totalJobsInEscrow: 12,
+          totalJobsCompleted: 45,
+          totalEscrowXLM: "12500.0000000",
+          totalReleasedXLM: "8200.0000000",
+        },
+      ],
+    });
+
+    const res = await request(app).get("/api/jobs/stats").expect(200);
+
+    expect(res.body).toEqual({
+      totalJobsInEscrow: 12,
+      totalJobsCompleted: 45,
+      totalEscrowXLM: "12500.0000000",
+      totalReleasedXLM: "8200.0000000",
+    });
+    expect(redis.set).toHaveBeenCalledWith("jobs:stats", res.body, 60);
+  });
+
+  test("serves cached stats without querying Postgres", async () => {
+    const cached = {
+      totalJobsInEscrow: 5,
+      totalJobsCompleted: 10,
+      totalEscrowXLM: "1000.0000000",
+      totalReleasedXLM: "500.0000000",
+    };
+    redis.get.mockResolvedValue(cached);
+
+    const res = await request(app).get("/api/jobs/stats").expect(200);
+
+    expect(res.body).toEqual(cached);
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  test("returns zeroed values when the jobs table is empty", async () => {
+    redis.get.mockResolvedValue(null);
+    pool.query.mockResolvedValue({
+      rows: [
+        {
+          totalJobsInEscrow: 0,
+          totalJobsCompleted: 0,
+          totalEscrowXLM: "0",
+          totalReleasedXLM: "0",
+        },
+      ],
+    });
+
+    const res = await request(app).get("/api/jobs/stats").expect(200);
+
+    expect(res.body).toEqual({
+      totalJobsInEscrow: 0,
+      totalJobsCompleted: 0,
+      totalEscrowXLM: "0.0000000",
+      totalReleasedXLM: "0.0000000",
+    });
+  });
+
+  test("does not clash with GET /api/jobs/:id", async () => {
+    pool.query.mockResolvedValue({
+      rows: [{ id: "abc-123", title: "Test Job" }],
+    });
+
+    const res = await request(app).get("/api/jobs/abc-123").expect(200);
+
+    // It should resolve to the :id route, not /stats
+    expect(res.body).toHaveProperty("data");
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/backend/src/routes/jobs.js
+++ b/backend/src/routes/jobs.js
@@ -6,7 +6,11 @@
 const express = require("express");
 const router = express.Router();
 const pool = require("../db/pool");
+const redis = require("../services/redis");
 const { mapJobRow } = require("../services/store");
+
+const JOBS_STATS_CACHE_KEY = "jobs:stats";
+const JOBS_STATS_CACHE_TTL_SECONDS = 60;
 
 function validateTxHash(h) {
   if (!h || !/^[a-fA-F0-9]{64}$/.test(h)) {
@@ -84,6 +88,39 @@ router.patch("/:id/release", async (req, res, next) => {
   }
 });
 
+// GET /api/jobs/stats — aggregated escrow marketplace metrics
+router.get("/stats", async (req, res, next) => {
+  try {
+    const cached = await redis.get(JOBS_STATS_CACHE_KEY);
+    if (cached) {
+      return res.json(cached);
+    }
+
+    const result = await pool.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE status = 'in_escrow')::int AS "totalJobsInEscrow",
+        COUNT(*) FILTER (WHERE status = 'completed')::int  AS "totalJobsCompleted",
+        COALESCE(SUM(amount_escrow_xlm) FILTER (WHERE status = 'in_escrow'), 0)::text AS "totalEscrowXLM",
+        COALESCE(SUM(amount_escrow_xlm) FILTER (WHERE status = 'completed'), 0)::text  AS "totalReleasedXLM"
+      FROM jobs
+    `);
+
+    const row = result.rows[0];
+    const stats = {
+      totalJobsInEscrow: Number.parseInt(row.totalJobsInEscrow, 10) || 0,
+      totalJobsCompleted: Number.parseInt(row.totalJobsCompleted, 10) || 0,
+      totalEscrowXLM: Number.parseFloat(row.totalEscrowXLM || "0").toFixed(7),
+      totalReleasedXLM: Number.parseFloat(row.totalReleasedXLM || "0").toFixed(7),
+    };
+
+    await redis.set(JOBS_STATS_CACHE_KEY, stats, JOBS_STATS_CACHE_TTL_SECONDS);
+
+    res.json(stats);
+  } catch (e) {
+    next(e);
+  }
+});
+
 router.get("/:id", async (req, res, next) => {
   try {
     const result = await pool.query("SELECT * FROM jobs WHERE id = $1", [
@@ -99,3 +136,5 @@ router.get("/:id", async (req, res, next) => {
 });
 
 module.exports = router;
+module.exports.JOBS_STATS_CACHE_KEY = JOBS_STATS_CACHE_KEY;
+module.exports.JOBS_STATS_CACHE_TTL_SECONDS = JOBS_STATS_CACHE_TTL_SECONDS;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,7 +4,14 @@
 "use strict";
 
 require("dotenv").config();
+const express = require("express");
+const helmet = require("helmet");
+const cookieParser = require("cookie-parser");
+const csurf = require("csurf");
+const rateLimit = require("express-rate-limit");
 const Sentry = require("@sentry/node");
+const requestLogger = require("./middleware/requestLogger");
+const logger = require("./logger");
 const Tracing = require("@sentry/tracing");
 
 Sentry.init({
@@ -83,6 +90,24 @@ function csrfTokenHandler(req, res) {
 }
 app.get("/api/csrf-token", csrfTokenHandler);
 app.get("/api/v1/csrf-token", csrfTokenHandler);
+
+// ── API Routes ──────────────────────────────────────────────────────────────
+app.use("/api/jobs", require("./routes/jobs"));
+app.use("/api/stats", require("./routes/stats"));
+app.use("/api/projects", require("./routes/projects"));
+app.use("/api/donations", require("./routes/donations"));
+app.use("/api/profiles", require("./routes/profiles"));
+app.use("/api/admin", require("./routes/admin"));
+app.use("/api/health", require("./routes/health"));
+app.use("/api/readiness", require("./routes/readiness"));
+app.use("/api/impact", require("./routes/impact"));
+app.use("/api/leaderboard", require("./routes/leaderboard"));
+app.use("/api/ratings", require("./routes/ratings"));
+app.use("/api/updates", require("./routes/updates"));
+app.use("/api/uploads", require("./routes/uploads"));
+app.use("/api/notifications", require("./routes/notifications"));
+app.use("/api/subscriptions", require("./routes/subscriptions"));
+app.use("/api/verification-requests", require("./routes/verification"));
 
 app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
 // Sentry error handler — capture and send exceptions to Sentry

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -400,6 +400,17 @@ components:
         updatedAt:
           type: string
           format: date-time
+    JobStats:
+      type: object
+      properties:
+        totalJobsInEscrow:
+          type: integer
+        totalJobsCompleted:
+          type: integer
+        totalEscrowXLM:
+          type: string
+        totalReleasedXLM:
+          type: string
     StatsGlobal:
       type: object
       properties:
@@ -1610,6 +1621,18 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Job'
+  /api/jobs/stats:
+    get:
+      tags: [Jobs]
+      summary: Get escrow marketplace aggregate metrics
+      description: Returns total jobs in escrow, completed jobs, and aggregate XLM amounts. Cached for 60 seconds.
+      responses:
+        '200':
+          description: Aggregate job statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobStats'
   /api/jobs/{id}/release:
     patch:
       tags: [Jobs]

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -273,6 +273,18 @@ components:
           type: string
           format: date-time
 
+    JobStats:
+      type: object
+      properties:
+        totalJobsInEscrow:
+          type: integer
+        totalJobsCompleted:
+          type: integer
+        totalEscrowXLM:
+          type: string
+        totalReleasedXLM:
+          type: string
+
     Rating:
       type: object
       properties:
@@ -1521,6 +1533,20 @@ paths:
                         type: array
                         items:
                           $ref: '#/components/schemas/Job'
+
+  /api/jobs/stats:
+    get:
+      tags: [Jobs]
+      summary: Get escrow marketplace aggregate metrics
+      operationId: getJobStats
+      description: Returns total jobs in escrow, completed jobs, and aggregate XLM amounts. Cached for 60 seconds.
+      responses:
+        '200':
+          description: Aggregate job statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobStats'
 
   /api/jobs/{id}:
     get:


### PR DESCRIPTION
## Summary

Adds a new `GET /api/jobs/stats` endpoint that returns aggregate escrow marketplace metrics (jobs in escrow, completed jobs, total XLM escrowed, total XLM released). Results are cached in Redis for 60 seconds, matching the exact caching pattern established by the existing `GET /api/stats/global` endpoint. Also fixes the `server.js` entrypoint which was missing critical `require` statements and all route mountings.

Closes #687

## Type

- [x] New feature
- [x] Bug fix (server.js was broken - missing requires and route mounting)

## Changes

### 1. New Endpoint: `GET /api/jobs/stats` (`backend/src/routes/jobs.js`)

Returns:
```json
{
  "totalJobsInEscrow": 12,
  "totalJobsCompleted": 45,
  "totalEscrowXLM": "12500.0000000",
  "totalReleasedXLM": "8200.0000000"
}
```

- Uses a single SQL query with PostgreSQL `FILTER (WHERE ...)` clauses for efficiency
- `COALESCE(SUM(...), 0)` ensures sensible defaults when the `jobs` table is empty
- XLM amounts formatted to 7 decimal places with `toFixed(7)`, consistent with `/api/stats/global`
- Redis cache key: `jobs:stats`, TTL: 60s
- Route placed before `/:id` to avoid param collision

### 2. New Test File (`backend/src/routes/jobs-stats.test.js`)

4 tests, all passing:
- Cache miss -> DB query -> cache set
- Cache hit (serves from Redis, no Postgres call)
- Empty table returns zeroed values
- Route non-collision with `/:id`

### 3. Server Fixes (`backend/src/server.js`)

- Added 8 missing `require` statements (express, helmet, cookie-parser, csurf, express-rate-limit, requestLogger, logger - plus pre-existing Tracing)
- Added route mounting for all 16 API modules (was entirely missing)

### 4. API Documentation

- Added `JobStats` schema and `/api/jobs/stats` path to both `docs/api/openapi.yaml` and `docs/openapi.yml`

## Testing

- [x] All 4 new tests pass
- [x] Existing `stats.test.js` tests (2) still pass
- [x] Test file has zero ESLint errors
- [ ] Manual verification with live Redis recommended

## Screenshots

N/A - backend API endpoint