### PR TITLE
feat: add admin digest preview endpoint

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const pool = require("../db/pool");
 const { signToken, adminRequired } = require("../middleware/auth");
 const { createRateLimiter } = require("../middleware/rateLimiter");
+const { buildDigestHtml, buildDigestText } = require("../services/digestQueue");
 
 const loginLimiter = createRateLimiter(10, 15);
 
@@ -143,6 +144,106 @@ router.get("/audit-log", adminRequired, async (req, res, next) => {
     });
   } catch (e) {
     next(e);
+  }
+});
+
+/**
+ * Render a monthly digest email body for admin review without sending it.
+ *
+ * @route POST /api/admin/digest/preview
+ * @param {import('express').Request} req - Express request with projectId and month.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express error middleware.
+ * @returns {Promise<void>} Sends the HTML digest body as text/html.
+ */
+router.post("/digest/preview", adminRequired, async (req, res, next) => {
+  try {
+    const { projectId, month } = req.body || {};
+
+    if (!projectId || typeof projectId !== "string") {
+      return res.status(400).json({ error: "projectId is required" });
+    }
+
+    if (!month || typeof month !== "string") {
+      return res.status(400).json({ error: "month is required in YYYY-MM format" });
+    }
+
+    const monthMatch = /^\d{4}-(0[1-9]|1[0-2])$/.exec(month);
+    if (!monthMatch) {
+      return res.status(400).json({ error: "month must be in YYYY-MM format" });
+    }
+
+    const [year, monthIndex] = month.split("-").map(Number);
+    const monthStart = new Date(Date.UTC(year, monthIndex - 1, 1));
+    const monthEnd = new Date(Date.UTC(year, monthIndex, 1));
+    const monthLabel = monthStart.toLocaleString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
+
+    const projectResult = await pool.query(
+      "SELECT id, name, co2_offset_kg FROM projects WHERE id = $1",
+      [projectId],
+    );
+
+    if (!projectResult.rows.length) {
+      return res.status(404).json({ error: "Project not found" });
+    }
+
+    const project = projectResult.rows[0];
+
+    const statsResult = await pool.query(
+      `SELECT
+         COALESCE(SUM(CASE WHEN currency = 'XLM' THEN amount_xlm ELSE 0 END), 0) AS raised_xlm
+       FROM donations
+       WHERE project_id = $1
+         AND created_at >= $2
+         AND created_at < $3`,
+      [project.id, monthStart.toISOString(), monthEnd.toISOString()],
+    );
+
+    const raisedXLM = parseFloat(statsResult.rows[0].raised_xlm || "0").toFixed(2);
+
+    const lifetimeTotResult = await pool.query(
+      "SELECT COALESCE(SUM(amount_xlm), 0) AS total FROM donations WHERE project_id = $1 AND currency = 'XLM'",
+      [project.id],
+    );
+    const lifetimeXLM = parseFloat(lifetimeTotResult.rows[0].total || "0");
+    const co2Total = parseInt(project.co2_offset_kg, 10) || 0;
+    const co2OffsetKg = lifetimeXLM > 0
+      ? Math.round((parseFloat(raisedXLM) / lifetimeXLM) * co2Total)
+      : 0;
+
+    const milestonesResult = await pool.query(
+      `SELECT title, percentage FROM project_milestones
+       WHERE project_id = $1
+         AND reached_at >= $2
+         AND reached_at < $3
+       ORDER BY percentage ASC`,
+      [project.id, monthStart.toISOString(), monthEnd.toISOString()],
+    );
+
+    const updatesResult = await pool.query(
+      `SELECT title, body FROM project_updates
+       WHERE project_id = $1
+         AND created_at >= $2
+         AND created_at < $3
+       ORDER BY created_at DESC
+       LIMIT 5`,
+      [project.id, monthStart.toISOString(), monthEnd.toISOString()],
+    );
+
+    const projectUrl = `${process.env.APP_URL || "http://localhost:3000"}/projects/${project.id}`;
+    const html = buildDigestHtml({
+      project,
+      stats: { raisedXLM, co2OffsetKg },
+      milestones: milestonesResult.rows,
+      updates: updatesResult.rows,
+      projectUrl,
+      monthLabel,
+    });
+
+    res.type("text/html");
+    return res.send(html);
+  } catch (e) {
+    return next(e);
   }
 });
 

--- a/backend/src/routes/admin.test.js
+++ b/backend/src/routes/admin.test.js
@@ -1,7 +1,12 @@
 "use strict";
 const express = require("express");
 const request = require("supertest");
+const pool = require("../db/pool");
 const { signToken, adminRequired, adminKeyRequired } = require("../middleware/auth");
+
+jest.mock("../db/pool", () => ({
+  query: jest.fn(),
+}));
 
 jest.mock("../middleware/rateLimiter", () => ({
   createRateLimiter: () => (req, res, next) => next(),
@@ -84,6 +89,51 @@ describe("POST /api/admin/refresh", () => {
     expect(res.body.success).toBe(true);
     expect(res.body.data.token).toBeDefined();
     expect(res.body.data.expiresIn).toBe(3600);
+  });
+});
+
+describe("POST /api/admin/digest/preview", () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("returns the rendered HTML digest body for an admin preview request", async () => {
+    const loginRes = await request(app).post("/api/admin/login").send({ username: "admin", password: "testpass" });
+    const token = loginRes.body.data.token;
+
+    pool.query.mockImplementation(async (query, params) => {
+      if (query.includes("FROM projects")) {
+        return { rows: [{ id: "project-123", name: "Solar Haven", co2_offset_kg: 300 }] };
+      }
+      if (query.includes("FROM donations")) {
+        return { rows: [{ raised_xlm: "120.50", donation_count: 2 }] };
+      }
+      if (query.includes("FROM project_milestones")) {
+        return { rows: [{ title: "Carbon neutral", percentage: 75 }] };
+      }
+      if (query.includes("FROM project_updates")) {
+        return { rows: [{ title: "Launch update", body: "The new solar array is live." }] };
+      }
+      if (query.includes("FROM project_subscriptions")) {
+        return { rows: [{ email: "admin@example.com" }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/admin/digest/preview")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ projectId: "project-123", month: "2026-07" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/html");
+    expect(res.text).toContain("Monthly Impact Digest");
+    expect(res.text).toContain("Solar Haven");
+    expect(res.text).toContain("120.50 XLM");
+    expect(res.text).toContain("Carbon neutral");
   });
 });
 

--- a/backend/src/services/digestQueue.js
+++ b/backend/src/services/digestQueue.js
@@ -299,4 +299,9 @@ async function start() {
   logger.info({ event: "digest_scheduled", cron: cronSchedule }, `[digestQueue] Monthly digest scheduled: ${cronSchedule}`);
 }
 
-module.exports = { start, runDigest };
+module.exports = {
+  start,
+  runDigest,
+  buildDigestHtml,
+  buildDigestText,
+};


### PR DESCRIPTION
# Implements admin-only monthly digest email preview support for testing and review.

## What changed
- Added `POST /api/admin/digest/preview`
- Authenticated admins can request a digest preview for a specific `projectId` and `month`
- The endpoint renders the HTML digest body and returns it as `text/html`
- No email is sent during preview generation
- Reused the existing digest HTML builder to keep formatting consistent with the real monthly digest flow
- Added regression coverage in the admin route test suite

## Why
This allows admins to review the digest layout and content in the dashboard before sending the actual monthly email, without triggering any delivery behavior.

## Testing
- Verified with targeted backend Jest coverage:
  - `npm test -- --runInBand src/routes/admin.test.js`

Closes: #713