### PR TITLE
fix: add isFollowing to GET /api/projects/:id when walletAddress passed #705

### DIFF
--- a/backend/src/db/migrations/001_initial_schema.js
+++ b/backend/src/db/migrations/001_initial_schema.js
@@ -157,11 +157,21 @@ module.exports = {
       CREATE TABLE IF NOT EXISTS project_follows (
         id UUID PRIMARY KEY,
         project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-        device_token_id UUID NOT NULL REFERENCES device_tokens(id) ON DELETE CASCADE,
+        device_token_id UUID REFERENCES device_tokens(id) ON DELETE CASCADE,
         wallet_address TEXT,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         UNIQUE(project_id, device_token_id)
       )
+    `);
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS project_follows_project_wallet_uidx
+        ON project_follows (project_id, wallet_address)
+        WHERE device_token_id IS NULL AND wallet_address IS NOT NULL
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS project_follows_wallet_lookup_idx
+        ON project_follows (project_id, wallet_address)
+        WHERE wallet_address IS NOT NULL
     `);
   },
 

--- a/backend/src/db/migrations/003_wallet_project_follows.js
+++ b/backend/src/db/migrations/003_wallet_project_follows.js
@@ -1,0 +1,49 @@
+"use strict";
+
+/**
+ * Allow wallet-address follows alongside device-token (push) follows on
+ * project_follows. Web Follow buttons use (project_id, wallet_address) with
+ * device_token_id NULL; mobile push continues to use device_token_id.
+ */
+module.exports = {
+  name: "003_wallet_project_follows",
+
+  async up(client) {
+    await client.query(`
+      ALTER TABLE project_follows
+        ALTER COLUMN device_token_id DROP NOT NULL
+    `);
+
+    // One wallet-only follow row per (project, wallet). Device-token rows may
+    // also store wallet_address for push targeting and are excluded here.
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS project_follows_project_wallet_uidx
+        ON project_follows (project_id, wallet_address)
+        WHERE device_token_id IS NULL AND wallet_address IS NOT NULL
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS project_follows_wallet_lookup_idx
+        ON project_follows (project_id, wallet_address)
+        WHERE wallet_address IS NOT NULL
+    `);
+  },
+
+  async down(client) {
+    await client.query(
+      `DROP INDEX IF EXISTS project_follows_wallet_lookup_idx`,
+    );
+    await client.query(
+      `DROP INDEX IF EXISTS project_follows_project_wallet_uidx`,
+    );
+
+    // Remove wallet-only rows before restoring NOT NULL on device_token_id.
+    await client.query(
+      `DELETE FROM project_follows WHERE device_token_id IS NULL`,
+    );
+    await client.query(`
+      ALTER TABLE project_follows
+        ALTER COLUMN device_token_id SET NOT NULL
+    `);
+  },
+};

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -170,17 +170,24 @@ CREATE TABLE IF NOT EXISTS device_tokens (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- project_follows: many-to-many join between projects and device_tokens.
--- A device "follows" a project to receive push notifications.
--- UNIQUE(project_id, device_token_id) prevents duplicate follows.
+-- project_follows: project follow relationships for push devices and/or wallets.
+-- - Mobile push: device_token_id set (UNIQUE with project_id); wallet_address optional.
+-- - Web Follow button: device_token_id NULL, wallet_address required; uniqueness
+--   enforced by partial unique index (see migration 003_wallet_project_follows).
 CREATE TABLE IF NOT EXISTS project_follows (
   id UUID PRIMARY KEY,
   project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-  device_token_id UUID NOT NULL REFERENCES device_tokens(id) ON DELETE CASCADE,
+  device_token_id UUID REFERENCES device_tokens(id) ON DELETE CASCADE,
   wallet_address TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE(project_id, device_token_id)
 );
+CREATE UNIQUE INDEX IF NOT EXISTS project_follows_project_wallet_uidx
+  ON project_follows (project_id, wallet_address)
+  WHERE device_token_id IS NULL AND wallet_address IS NOT NULL;
+CREATE INDEX IF NOT EXISTS project_follows_wallet_lookup_idx
+  ON project_follows (project_id, wallet_address)
+  WHERE wallet_address IS NOT NULL;
 
 -- Verification requests submitted via the /apply form on the frontend.
 -- Each row represents an organisation asking the GreenPay admin team to

--- a/backend/src/routes/projects.isFollowing.test.js
+++ b/backend/src/routes/projects.isFollowing.test.js
@@ -1,0 +1,222 @@
+"use strict";
+
+jest.mock("uuid", () => ({
+  v4: jest.fn(() => "11111111-2222-3333-4444-555555555555"),
+}));
+
+jest.mock("../db/pool", () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+jest.mock("../services/redis", () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  deletePattern: jest.fn(),
+}));
+
+jest.mock("../services/stellar", () => ({
+  getOnChainProject: jest.fn(),
+  getProjectDonationEvents: jest.fn(),
+  CONTRACT_ID: "test-contract",
+  server: { getTransaction: jest.fn() },
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+}));
+
+jest.mock("../services/summaryQueue", () => ({
+  enqueueAISummary: jest.fn(),
+}));
+
+const pool = require("../db/pool");
+const redis = require("../services/redis");
+const { getOnChainProject } = require("../services/stellar");
+const express = require("express");
+const request = require("supertest");
+const projectsRouter = require("./projects");
+
+process.env.ADMIN_API_KEY = "test-admin-key";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/projects", projectsRouter);
+  app.use((err, _req, res, _next) => {
+    res
+      .status(err.status || 500)
+      .json({ error: err.message || "Internal server error" });
+  });
+  return app;
+}
+
+const MOCK_PROJECT_ROW = {
+  id: "proj-1",
+  name: "Test Project",
+  description: "A test climate project",
+  category: "Reforestation",
+  location: "Brazil",
+  wallet_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  goal_xlm: "10000",
+  raised_xlm: "5000",
+  donor_count: 42,
+  co2_offset_kg: 50000,
+  status: "active",
+  verified: true,
+  on_chain_verified: false,
+  tags: ["reforestation", "amazon"],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const FOLLOWER_WALLET =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+/** Queue the DB mocks required by GET /api/projects/:id after the project row. */
+function mockProjectDetailQueries({
+  followCount = 0,
+  isFollowing = false,
+} = {}) {
+  pool.query.mockResolvedValueOnce({ rows: [] }); // campaigns
+  pool.query.mockResolvedValueOnce({
+    rows: [{ avg_rating: null, count: 0 }],
+  }); // ratings
+  pool.query.mockResolvedValueOnce({ rows: [{ count: 0 }] }); // subscribers
+  pool.query.mockResolvedValueOnce({ rows: [] }); // milestones
+  pool.query.mockResolvedValueOnce({
+    rows: [{ follow_count: followCount, is_following: isFollowing }],
+  }); // follow stats
+  getOnChainProject.mockResolvedValue(null);
+}
+
+describe("GET /api/projects/:id isFollowing (issue #705)", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.resetAllMocks();
+    redis.get.mockResolvedValue(null);
+    redis.set.mockResolvedValue(null);
+    redis.deletePattern.mockResolvedValue(null);
+  });
+
+  test("returns isFollowing:false and followCount when walletAddress omitted", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_PROJECT_ROW] });
+    mockProjectDetailQueries({ followCount: 3, isFollowing: false });
+
+    const res = await request(app).get("/api/projects/proj-1").expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.isFollowing).toBe(false);
+    expect(res.body.data.followCount).toBe(3);
+
+    const followCall = pool.query.mock.calls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("is_following"),
+    );
+    expect(followCall).toBeTruthy();
+    expect(followCall[1][1]).toBeNull();
+  });
+
+  test("returns isFollowing:true when walletAddress follows the project", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_PROJECT_ROW] });
+    mockProjectDetailQueries({ followCount: 1, isFollowing: true });
+
+    const res = await request(app)
+      .get(`/api/projects/proj-1?walletAddress=${FOLLOWER_WALLET}`)
+      .expect(200);
+
+    expect(res.body.data.isFollowing).toBe(true);
+    expect(res.body.data.followCount).toBe(1);
+
+    const followCall = pool.query.mock.calls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("project_follows"),
+    );
+    expect(followCall[0]).toMatch(/EXISTS/);
+    expect(followCall[1]).toEqual(["proj-1", FOLLOWER_WALLET]);
+  });
+
+  test("returns isFollowing:false when walletAddress does not follow", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_PROJECT_ROW] });
+    mockProjectDetailQueries({ followCount: 2, isFollowing: false });
+
+    const res = await request(app)
+      .get(`/api/projects/proj-1?walletAddress=${FOLLOWER_WALLET}`)
+      .expect(200);
+
+    expect(res.body.data.isFollowing).toBe(false);
+    expect(res.body.data.followCount).toBe(2);
+  });
+
+  test("does not short-circuit with 304 when walletAddress is provided", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [MOCK_PROJECT_ROW] });
+    mockProjectDetailQueries({ followCount: 0, isFollowing: false });
+
+    const etag = `"${require("crypto")
+      .createHash("md5")
+      .update(String(MOCK_PROJECT_ROW.updated_at))
+      .digest("hex")}"`;
+
+    const res = await request(app)
+      .get(`/api/projects/proj-1?walletAddress=${FOLLOWER_WALLET}`)
+      .set("If-None-Match", etag)
+      .expect(200);
+
+    expect(res.body.data).toHaveProperty("isFollowing");
+  });
+});
+
+describe("POST/DELETE /api/projects/:id/follow", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.resetAllMocks();
+  });
+
+  test("POST /follow inserts a wallet follow and returns isFollowing:true", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ id: "proj-1" }] }) // project exists
+      .mockResolvedValueOnce({ rows: [] }) // insert
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] }); // count
+
+    const res = await request(app)
+      .post("/api/projects/proj-1/follow")
+      .send({ walletAddress: FOLLOWER_WALLET })
+      .expect(200);
+
+    expect(res.body.data).toEqual({ isFollowing: true, followCount: 1 });
+    expect(pool.query.mock.calls[1][0]).toMatch(/INSERT INTO project_follows/);
+    expect(pool.query.mock.calls[1][1][2]).toBe(FOLLOWER_WALLET);
+  });
+
+  test("POST /follows alias works the same as /follow", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ id: "proj-1" }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] });
+
+    const res = await request(app)
+      .post("/api/projects/proj-1/follows")
+      .send({ walletAddress: FOLLOWER_WALLET })
+      .expect(200);
+
+    expect(res.body.data.isFollowing).toBe(true);
+  });
+
+  test("DELETE /follow removes the wallet follow", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ id: "proj-1" }] })
+      .mockResolvedValueOnce({ rows: [] }) // delete
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] });
+
+    const res = await request(app)
+      .delete("/api/projects/proj-1/follow")
+      .send({ walletAddress: FOLLOWER_WALLET })
+      .expect(200);
+
+    expect(res.body.data).toEqual({ isFollowing: false, followCount: 0 });
+    expect(pool.query.mock.calls[1][0]).toMatch(/DELETE FROM project_follows/);
+  });
+
+  test("POST /follow rejects missing walletAddress", async () => {
+    await request(app).post("/api/projects/proj-1/follow").send({}).expect(400);
+  });
+});

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -45,16 +45,6 @@ const VALID_CATEGORIES = [
 ];
 const STELLAR_PUBLIC_KEY_RE = /^G[A-Z0-9]{55}$/;
 
-const createProjectSchema = z.object({
-  name: sanitizedStringField({ required: true, minLength: 3, maxLength: 120, message: "must not contain HTML" }),
-  description: sanitizedStringField({ required: true, minLength: 10, maxLength: 5000, message: "must not contain HTML" }),
-  location: sanitizedStringField({ required: true, minLength: 2, maxLength: 200, message: "must not contain HTML" }),
-  category: z.enum(VALID_CATEGORIES),
-  wallet_address: z.string().min(1, "wallet_address is required"),
-  goal_xlm: z.union([z.string(), z.number()]).optional(),
-  tags: z.array(z.string()).optional().default([]),
-});
-
 /**
  * GET /api/projects/featured
  * Returns the project with the highest donorCount (active projects only).
@@ -793,13 +783,25 @@ router.get("/:id", async (req, res, next) => {
     if (!projectResult.rows[0])
       return res.status(404).json({ error: "Project not found" });
 
+    const { walletAddress } = req.query;
+    const hasWalletQuery =
+      typeof walletAddress === "string" && walletAddress.trim().length > 0;
+    const normalizedWallet = hasWalletQuery ? walletAddress.trim() : null;
+
     const updatedAt = projectResult.rows[0].updated_at;
     const etag = `"${crypto.createHash("md5").update(String(updatedAt)).digest("hex")}"`;
     const lastModified = new Date(updatedAt).toUTCString();
-    res.set("ETag", etag);
-    res.set("Last-Modified", lastModified);
-    if (req.headers["if-none-match"] === etag) {
-      return res.status(304).end();
+    // Personalized ?walletAddress= responses must not be cached via ETag —
+    // isFollowing can change without projects.updated_at changing, and Express
+    // would otherwise auto-304 on res.json() when If-None-Match matches.
+    if (hasWalletQuery) {
+      res.set("Cache-Control", "private, no-store");
+    } else {
+      res.set("ETag", etag);
+      res.set("Last-Modified", lastModified);
+      if (req.headers["if-none-match"] === etag) {
+        return res.status(304).end();
+      }
     }
 
     const campaigns = await fetchCampaignsForProject(req.params.id);
@@ -823,23 +825,33 @@ router.get("/:id", async (req, res, next) => {
       [req.params.id],
     );
 
-    // Fetch follower count and, when ?walletAddress=G... is provided, whether
-    // that wallet is currently following this project.
-    const followCountResult = await pool.query(
-      "SELECT COUNT(*) AS count FROM project_follows WHERE project_id = $1",
-      [req.params.id],
+    // Follower count + optional isFollowing from wallet-only project_follows rows.
+    // When ?walletAddress=G... is passed, include whether that wallet follows.
+    // Device-token (push) rows are excluded so web Follow state stays consistent
+    // with POST/DELETE /follow.
+    const followStatsResult = await pool.query(
+      `SELECT
+         (
+           SELECT COUNT(*)::int
+           FROM project_follows pf
+           WHERE pf.project_id = $1
+             AND pf.device_token_id IS NULL
+             AND pf.wallet_address IS NOT NULL
+         ) AS follow_count,
+         EXISTS (
+           SELECT 1
+           FROM project_follows pf
+           WHERE pf.project_id = $1
+             AND pf.device_token_id IS NULL
+             AND pf.wallet_address = $2
+         ) AS is_following`,
+      [req.params.id, normalizedWallet],
     );
-    const followCount = parseInt(followCountResult.rows[0].count, 10) || 0;
-
-    let isFollowing = false;
-    const { walletAddress } = req.query;
-    if (walletAddress && typeof walletAddress === "string") {
-      const followResult = await pool.query(
-        "SELECT 1 FROM project_follows WHERE project_id = $1 AND wallet_address = $2",
-        [req.params.id, walletAddress],
-      );
-      isFollowing = followResult.rowCount > 0;
-    }
+    const followCount =
+      parseInt(followStatsResult.rows[0]?.follow_count, 10) || 0;
+    const isFollowing = hasWalletQuery
+      ? Boolean(followStatsResult.rows[0]?.is_following)
+      : false;
 
     const stroopsToXlm = (stroops) => {
       if (stroops === null || stroops === undefined) return "0.0000000";
@@ -886,14 +898,19 @@ router.get("/:id", async (req, res, next) => {
 
 /**
  * POST /api/projects/:id/follow
+ * POST /api/projects/:id/follows  (alias used by mobile)
  * Follow a project. Body: { walletAddress: "G..." }
  * Idempotent — re-following a project that is already followed is a no-op.
  */
-router.post("/:id/follow", async (req, res, next) => {
+async function followProjectHandler(req, res, next) {
   try {
     const { walletAddress } = req.body || {};
     if (!walletAddress || typeof walletAddress !== "string") {
       return res.status(400).json({ error: "walletAddress is required" });
+    }
+    const normalizedWallet = walletAddress.trim();
+    if (!STELLAR_PUBLIC_KEY_RE.test(normalizedWallet)) {
+      return res.status(400).json({ error: "walletAddress must be a valid Stellar address" });
     }
 
     const projectResult = await pool.query("SELECT id FROM projects WHERE id = $1", [req.params.id]);
@@ -901,16 +918,22 @@ router.post("/:id/follow", async (req, res, next) => {
       return res.status(404).json({ error: "Project not found" });
     }
 
-    // INSERT … ON CONFLICT DO NOTHING makes this idempotent.
+    // Wallet-only follow row (device_token_id NULL). Partial unique index makes this idempotent.
     await pool.query(
-      `INSERT INTO project_follows (project_id, wallet_address, created_at)
-       VALUES ($1, $2, NOW())
-       ON CONFLICT (project_id, wallet_address) DO NOTHING`,
-      [req.params.id, walletAddress],
+      `INSERT INTO project_follows (id, project_id, device_token_id, wallet_address, created_at)
+       VALUES ($1, $2, NULL, $3, NOW())
+       ON CONFLICT (project_id, wallet_address)
+         WHERE device_token_id IS NULL AND wallet_address IS NOT NULL
+       DO NOTHING`,
+      [uuid(), req.params.id, normalizedWallet],
     );
 
     const countResult = await pool.query(
-      "SELECT COUNT(*) AS count FROM project_follows WHERE project_id = $1",
+      `SELECT COUNT(*)::int AS count
+       FROM project_follows
+       WHERE project_id = $1
+         AND device_token_id IS NULL
+         AND wallet_address IS NOT NULL`,
       [req.params.id],
     );
 
@@ -924,32 +947,46 @@ router.post("/:id/follow", async (req, res, next) => {
   } catch (e) {
     next(e);
   }
-});
+}
+
+router.post("/:id/follow", followProjectHandler);
+router.post("/:id/follows", followProjectHandler);
 
 /**
  * DELETE /api/projects/:id/follow
+ * DELETE /api/projects/:id/follows  (alias used by mobile)
  * Unfollow a project. Body: { walletAddress: "G..." }
  * Idempotent — unfollowing a project not currently followed is a no-op.
  */
-router.delete("/:id/follow", async (req, res, next) => {
+async function unfollowProjectHandler(req, res, next) {
   try {
     const { walletAddress } = req.body || {};
     if (!walletAddress || typeof walletAddress !== "string") {
       return res.status(400).json({ error: "walletAddress is required" });
     }
+    const normalizedWallet = walletAddress.trim();
 
     const projectResult = await pool.query("SELECT id FROM projects WHERE id = $1", [req.params.id]);
     if (!projectResult.rows[0]) {
       return res.status(404).json({ error: "Project not found" });
     }
 
+    // Remove wallet-only follow rows. Device-token push follows are managed via
+    // /api/notifications/unfollow and are left intact.
     await pool.query(
-      "DELETE FROM project_follows WHERE project_id = $1 AND wallet_address = $2",
-      [req.params.id, walletAddress],
+      `DELETE FROM project_follows
+       WHERE project_id = $1
+         AND wallet_address = $2
+         AND device_token_id IS NULL`,
+      [req.params.id, normalizedWallet],
     );
 
     const countResult = await pool.query(
-      "SELECT COUNT(*) AS count FROM project_follows WHERE project_id = $1",
+      `SELECT COUNT(*)::int AS count
+       FROM project_follows
+       WHERE project_id = $1
+         AND device_token_id IS NULL
+         AND wallet_address IS NOT NULL`,
       [req.params.id],
     );
 
@@ -963,7 +1000,10 @@ router.delete("/:id/follow", async (req, res, next) => {
   } catch (e) {
     next(e);
   }
-});
+}
+
+router.delete("/:id/follow", unfollowProjectHandler);
+router.delete("/:id/follows", unfollowProjectHandler);
 
 /**
  * POST /api/projects/:id/generate-summary

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -131,13 +131,51 @@ export async function fetchProjects(params?: {
  * Fetch a single project by its id.
  *
  * @param id - Project id.
+ * @param walletAddress - Optional connected wallet; when provided, the backend
+ *   returns `isFollowing` for Follow button state on initial load (issue #705).
  * @returns The project.
  * @throws If the request fails (including 404s for missing projects).
  */
-export async function fetchProject(id: string) {
+export async function fetchProject(id: string, walletAddress?: string) {
+  const params = walletAddress ? { walletAddress } : undefined;
   const { data } = await api.get<{ success: boolean; data: ClimateProject }>(
     `/api/projects/${id}`,
     { params },
+  );
+  return data.data;
+}
+
+export interface FollowResponse {
+  isFollowing: boolean;
+  followCount: number;
+}
+
+/**
+ * Follow a project. Returns the updated isFollowing flag and follower count.
+ * Idempotent — safe to call even if already following.
+ */
+export async function followProject(
+  projectId: string,
+  walletAddress: string,
+): Promise<FollowResponse> {
+  const { data } = await api.post<{ success: boolean; data: FollowResponse }>(
+    `/api/projects/${projectId}/follow`,
+    { walletAddress },
+  );
+  return data.data;
+}
+
+/**
+ * Unfollow a project. Returns the updated isFollowing flag and follower count.
+ * Idempotent — safe to call even if not currently following.
+ */
+export async function unfollowProject(
+  projectId: string,
+  walletAddress: string,
+): Promise<FollowResponse> {
+  const { data } = await api.delete<{ success: boolean; data: FollowResponse }>(
+    `/api/projects/${projectId}/follow`,
+    { data: { walletAddress } },
   );
   return data.data;
 }

--- a/frontend/pages/projects/[id].tsx
+++ b/frontend/pages/projects/[id].tsx
@@ -14,7 +14,7 @@ import CircularProgress from "@/components/CircularProgress";
 import MonthlyGivingSetup from "@/components/MonthlyGivingSetup";
 import DescriptionAccordion from "@/components/DescriptionAccordion";
 import WalletAddressQRCode from "@/components/WalletAddressQRCode";
-import { fetchProject, fetchProjectUpdates, subscribeToProject, fetchSubscriberCount, createProjectCampaign, fetchProjectMatches, generateProjectSummary, toggleUpdateLike } from "@/lib/api";
+import { fetchProject, fetchProjectUpdates, subscribeToProject, fetchSubscriberCount, createProjectCampaign, fetchProjectMatches, generateProjectSummary, toggleUpdateLike, followProject, unfollowProject } from "@/lib/api";
 import { useI18n } from "@/lib/i18n";
 import { formatXLM, formatCO2, progressPercent, timeAgo, statusClass, statusLabel, CATEGORY_ICONS, copyToClipboard, shortenAddress } from "@/utils/format";
 import { accountUrl, fetchProjectDiscussion, type ProjectDiscussionMessage } from "@/lib/stellar";
@@ -111,7 +111,7 @@ export default function ProjectDetail({
       })
       .catch(() => router.push("/projects"))
       .finally(() => setLoading(false));
-  }, [id]);
+  }, [id, publicKey]);
 
   useEffect(() => {
     if (!project) return;


### PR DESCRIPTION
## Overview

This PR restores and hardens the **`isFollowing` flag** on `GET /api/projects/:id` when `?walletAddress=G...` is provided, so the Follow button can render the correct state on page load without an extra round-trip.

## Related Issue

Closes #705

## Changes

### 🔁 Project follow state on load

* **[MODIFY]** `backend/src/routes/projects.js`
  * `GET /api/projects/:id` queries `project_follows` (EXISTS + follower count) and returns `isFollowing` / `followCount` when `?walletAddress=` is passed.
  * Personalized wallet responses use `Cache-Control: private, no-store` (no stale ETag 304).
  * `POST`/`DELETE` `/follow` (+ `/follows` alias) insert/delete wallet-only follow rows correctly.
  * Removes a broken unused `createProjectSchema` block that prevented the router from loading.

* **[ADD]** `backend/src/db/migrations/003_wallet_project_follows.js`
  * Makes `device_token_id` nullable and adds a partial unique index for wallet-only follows alongside push-device follows.

* **[MODIFY]** `backend/src/db/schema.sql`, `backend/src/db/migrations/001_initial_schema.js`
  * Align schema docs/definitions with wallet + device follow coexistence.

* **[MODIFY]** `frontend/lib/api.ts`
  * `fetchProject(id, walletAddress?)` forwards the query param.
  * Restores `followProject` / `unfollowProject` helpers.

* **[MODIFY]** `frontend/pages/projects/[id].tsx`
  * Seeds Follow button from `isFollowing` and refetches when the connected wallet changes.

* **[ADD]** `backend/src/routes/projects.isFollowing.test.js`
  * Coverage for `isFollowing` true/false, no-304 with wallet, follow/unfollow, and `/follows` alias.

## Verification Results

```
cd backend && npm test -- --testPathPatterns=projects.isFollowing --no-coverage
✅ 8/8 passed

Checks covered:
✅ isFollowing:false when walletAddress omitted
✅ isFollowing:true when wallet follows the project
✅ isFollowing:false when wallet does not follow
✅ No ETag 304 short-circuit when walletAddress is provided
✅ POST /follow + /follows alias return isFollowing:true
✅ DELETE /follow returns isFollowing:false
```

| Acceptance Criteria | Status |
| --- | --- |
| `?walletAddress=G...` joins/queries `project_follows` for follow state | ✅ EXISTS lookup on wallet-only follow rows |
| Response includes `isFollowing: true/false` | ✅ Returned on GET project detail |
| Follow button can seed state on page load | ✅ `fetchProject` passes wallet; page seeds from response |
| Wallet follows work with existing device-token schema | ✅ Migration + partial unique index |