### PR TITLE
fix(contract): add two-step admin key rotation #418

### DIFF
--- a/contracts/greenpay-contract/README.md
+++ b/contracts/greenpay-contract/README.md
@@ -11,6 +11,8 @@ Every donation is recorded permanently on the Stellar blockchain. Anyone can que
 | Function | Who calls it | Description |
 |----------|-------------|-------------|
 | `initialize(admin)` | Deployer | One-time setup |
+| `propose_new_admin(admin, new_admin)` | Admin | Start a two-step admin rotation |
+| `accept_admin(new_admin)` | Pending admin | Accept the proposed admin role |
 | `register_project(admin, id, name, wallet, co2_per_xlm)` | Admin | Register a verified project |
 | `deactivate_project(admin, id)` | Admin | Stop new donations to a project |
 | `donate(token, donor, project_id, amount, msg_hash)` | Donor | Send XLM + record donation |
@@ -20,6 +22,15 @@ Every donation is recorded permanently on the Stellar blockchain. Anyone can que
 | `get_global_total()` | Anyone | Total XLM raised platform-wide |
 | `get_global_co2()` | Anyone | Total CO₂ offset in grams |
 | `get_donation_count()` | Anyone | Total donations recorded |
+
+## Admin Rotation
+
+Admin rotation is a two-step flow to avoid accidental lockout:
+
+1. Current admin calls `propose_new_admin(admin, new_admin)`
+2. Proposed admin calls `accept_admin(new_admin)`
+
+The current admin remains unchanged until the second step succeeds.
 
 ## Badge Tiers
 

--- a/contracts/greenpay-contract/UPGRADE.md
+++ b/contracts/greenpay-contract/UPGRADE.md
@@ -17,6 +17,7 @@ The current persisted keys are:
 - `DataKey::HasDonated(String, Address)`
 - `DataKey::Proposal(String)`
 - `DataKey::HasVoted(String, Address)`
+- `DataKey::PendingAdmin`
 
 Do not rename or remove these variants, change their argument order, or reorder/remove fields from stored structs such as `Project`, `DonorStats`, `ImpactNFT`, or `VoteProposal` without adding an explicit migration path. New fields should be handled through a new storage version or a new key namespace so existing v1 values remain decodable.
 

--- a/contracts/greenpay-contract/src/lib.rs
+++ b/contracts/greenpay-contract/src/lib.rs
@@ -175,6 +175,7 @@ pub enum DataKey {
     USDCTokenAddress,
     // Price oracle for USDC → XLM conversion
     OracleAddress,
+    PendingAdmin,
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -659,6 +660,55 @@ impl GreenPayContract {
             .instance()
             .get(&DataKey::Admin)
             .expect("Not initialized")
+    }
+
+    /// Propose a new admin. The current admin keeps control until the
+    /// proposed address explicitly accepts the role.
+    pub fn propose_new_admin(env: Env, admin: Address, new_admin: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if stored_admin != admin {
+            panic!("Only admin can propose a new admin");
+        }
+        if new_admin == stored_admin {
+            panic!("New admin must differ from current admin");
+        }
+
+        env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+        env.events()
+            .publish((symbol_short!("adm_prop"), admin), new_admin);
+    }
+
+    /// Accept a pending admin proposal and finalize the admin rotation.
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+        let pending_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .expect("No pending admin proposal");
+        if pending_admin != new_admin {
+            panic!("Only pending admin can accept admin role");
+        }
+
+        let previous_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.events()
+            .publish((symbol_short!("adm_acpt"), previous_admin), new_admin);
+    }
+
+    /// Read the current pending admin proposal, if any.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::PendingAdmin)
     }
 
     // ─── Placeholders ─────────────────────────────────────────────────────────
@@ -1225,6 +1275,72 @@ mod tests {
         assert_eq!(client.get_project_count(), 0);
         assert_eq!(client.get_donation_count(), 0);
         assert_eq!(client.get_global_total(), 0);
+    }
+
+    #[test]
+    fn test_admin_rotation_requires_proposal_and_acceptance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, GreenPayContract);
+        let client = GreenPayContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.propose_new_admin(&admin, &new_admin);
+
+        assert_eq!(client.get_admin(), admin);
+        assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+        client.accept_admin(&new_admin);
+
+        assert_eq!(client.get_admin(), new_admin);
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Only pending admin can accept admin role")]
+    fn test_accept_admin_requires_pending_admin_match() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, GreenPayContract);
+        let client = GreenPayContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let pending_admin = Address::generate(&env);
+        let wrong_admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.propose_new_admin(&admin, &pending_admin);
+        client.accept_admin(&wrong_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "No pending admin proposal")]
+    fn test_accept_admin_without_proposal_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, GreenPayContract);
+        let client = GreenPayContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.accept_admin(&new_admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Only admin can propose a new admin")]
+    fn test_only_current_admin_can_propose_new_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, GreenPayContract);
+        let client = GreenPayContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.propose_new_admin(&attacker, &new_admin);
     }
 
         #[test]


### PR DESCRIPTION
## Overview

This PR implements a two-step admin key rotation flow for the GreenPay Soroban contract so the current admin cannot accidentally lock the contract by setting an invalid address in a single step.

## Related Issue

Closes #418

## Changes

### Smart Contract Admin Rotation

* **[MODIFY]** `contracts/greenpay-contract/src/lib.rs`
  * Adds `DataKey::PendingAdmin` to store a pending admin proposal.
  * Adds `propose_new_admin(env, admin, new_admin)` so only the current admin can propose a replacement.
  * Adds `accept_admin(env, new_admin)` so only the proposed address can finalize the transfer.
  * Adds `get_pending_admin(env)` to inspect the pending admin state.
  * Emits events for proposal and acceptance.

### Tests

* **[ADD]** Admin-rotation regression coverage in `contracts/greenpay-contract/src/lib.rs`
  * Happy-path proposal and acceptance.
  * Reject acceptance by a non-pending address.
  * Reject acceptance when no proposal exists.
  * Reject proposals from non-admin callers.

### Documentation

* **[MODIFY]** `contracts/greenpay-contract/README.md`
  * Documents the new two-step admin rotation flow.

* **[MODIFY]** `contracts/greenpay-contract/UPGRADE.md`
  * Records `DataKey::PendingAdmin` in storage compatibility notes.

## Verification Results

```
git show -1 --format=fuller --stat
Author:    Timmytaps-1 <307744333+Timmytaps-1@users.noreply.github.com>
Committer: Timmytaps-1 <307744333+Timmytaps-1@users.noreply.github.com>

Runtime validation:
- Added focused admin rotation tests covering success and failure paths.
- Local cargo-based test execution was not available in this environment because Rust tooling is not installed on PATH.
```

| Acceptance Criteria | Status |
| --- | --- |
| Add `propose_new_admin(env, admin, new_admin)` | ✅ Implemented |
| Add `accept_admin(env, new_admin)` | ✅ Implemented |
| Prevent accidental lockout from one-step admin replacement | ✅ Admin remains unchanged until pending admin accepts |
| Verify admin-rotation behavior | ✅ Code-path coverage added for success and failure cases; local cargo execution unavailable in this environment |