### PR TITLE
feat: add GET /api/donations/stream SSE endpoint for real-time donation feed

### DIFF
--- a/backend/src/routes/donations.js
+++ b/backend/src/routes/donations.js
@@ -12,6 +12,7 @@ const { createRateLimiter } = require("../middleware/rateLimiter");
 const { sanitizedStringField, validateBody } = require("../middleware/validation");
 const { computeBadges, mapDonationRow } = require("../services/store");
 const { server } = require("../services/stellar");
+const donationEvents = require("../services/donationEvents");
 const donationLimiter = createRateLimiter(10, 1); // 10 requests per minute
 
 const donationSchema = z.object({
@@ -56,8 +57,9 @@ async function recordDonation(req, res, next) {
 
     client = await pool.connect();
 
-    const projectResult = await client.query("SELECT id FROM projects WHERE id = $1", [projectId]);
+    const projectResult = await client.query("SELECT id, name FROM projects WHERE id = $1", [projectId]);
     if (!projectResult.rows[0]) { const e = new Error("Project not found"); e.status = 404; throw e; }
+    const projectName = projectResult.rows[0].name || "Unknown Project";
 
     // Determine numeric amount depending on currency
     const parsedAmount = parseFloat(currency === "XLM" ? amountXLM ?? amount : amount);
@@ -188,6 +190,29 @@ async function recordDonation(req, res, next) {
     }, "Donation recorded");
 
     const io = req.app?.get("io");
+
+    // Compute donor badge for the SSE payload
+    let donorBadge = "";
+    try {
+      const profileResult = await pool.query(
+        "SELECT total_donated_xlm FROM profiles WHERE public_key = $1",
+        [donorAddress],
+      );
+      const totalXLM = profileResult.rows[0]
+        ? parseFloat(profileResult.rows[0].total_donated_xlm || "0")
+        : parsedAmount;
+      const badges = computeBadges(totalXLM);
+      donorBadge = badges.length > 0 ? badges[0].tier.charAt(0).toUpperCase() + badges[0].tier.slice(1) : "";
+    } catch {
+      // Badge computation is best-effort; don't fail the request
+    }
+
+    const ssePayload = {
+      projectName,
+      amountXLM: String(parsedAmount),
+      donorBadge,
+    };
+
     if (io && typeof io.emit === "function") {
       io.emit("donation_event", {
         projectId,
@@ -198,10 +223,9 @@ async function recordDonation(req, res, next) {
       });
     }
 
-    const mappedDonation = mapDonationRow(donationResult.rows[0]);
-    donationEvents.emit("new_donation", mappedDonation);
+    donationEvents.emit("new_donation", ssePayload);
 
-    res.status(201).json({ success: true, data: mappedDonation });
+    res.status(201).json({ success: true, data: mapDonationRow(donationResult.rows[0]) });
   } catch (e) {
     if (inTransaction && client) await client.query("ROLLBACK");
     next(e);
@@ -222,19 +246,31 @@ async function recordDonation(req, res, next) {
  */
 router.post("/", donationLimiter, recordDonation);
 
-// GET /api/donations/stream
+/**
+ * Stream new donation events as Server-Sent Events.
+ *
+ * Clients receive JSON payloads matching the shape:
+ *   {"projectName":"…","amountXLM":"…","donorBadge":"…"}
+ *
+ * A heartbeat comment is sent every 15 s to keep the connection alive.
+ *
+ * @route GET /api/donations/stream
+ * @param {import('express').Request} req - Express request.
+ * @param {import('express').Response} res - Express response (SSE).
+ */
 router.get("/stream", (req, res) => {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
   res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
   res.flushHeaders();
 
   const keepAlive = setInterval(() => {
-    res.write(":\\n\\n");
+    res.write(":\n\n");
   }, 15000);
 
   const onNewDonation = (donation) => {
-    res.write(`data: ${JSON.stringify(donation)}\\n\\n`);
+    res.write(`data: ${JSON.stringify(donation)}\n\n`);
   };
 
   donationEvents.on("new_donation", onNewDonation);

--- a/backend/src/routes/donations.sse.test.js
+++ b/backend/src/routes/donations.sse.test.js
@@ -1,0 +1,361 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({ query: jest.fn(), connect: jest.fn() }));
+jest.mock("../middleware/rateLimiter", () => ({
+  createRateLimiter: () => (req, res, next) => next(),
+}));
+jest.mock("../services/stellar", () => ({
+  server: { getTransaction: jest.fn().mockResolvedValue({ successful: true }) },
+}));
+
+const http = require("http");
+const express = require("express");
+const supertest = require("supertest");
+const pool = require("../db/pool");
+const donationEvents = require("../services/donationEvents");
+
+function makePublicKey(char = "A") {
+  return `G${char.repeat(55)}`;
+}
+
+function makeTxHash(char = "a") {
+  return char.repeat(64);
+}
+
+function queryResult(rows = []) {
+  return { rows };
+}
+
+function createMockClient(...responses) {
+  const client = { query: jest.fn(), release: jest.fn() };
+  responses.forEach((r) => {
+    if (r instanceof Error) {
+      client.query.mockRejectedValueOnce(r);
+    } else {
+      client.query.mockResolvedValueOnce(r);
+    }
+  });
+  pool.connect.mockResolvedValue(client);
+  return client;
+}
+
+describe("GET /api/donations/stream", () => {
+  let httpServer;
+  let baseUrl;
+
+  beforeAll((done) => {
+    const app = express();
+    app.use(express.json());
+    httpServer = http.createServer(app);
+    app.use("/api/donations", require("./donations"));
+    httpServer.listen(0, () => {
+      baseUrl = `http://localhost:${httpServer.address().port}`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    donationEvents.removeAllListeners();
+    httpServer.close(done);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    donationEvents.removeAllListeners();
+  });
+
+  test("returns correct SSE headers", (done) => {
+    const req = http.get(`${baseUrl}/api/donations/stream`, (res) => {
+      expect(res.headers["content-type"]).toContain("text/event-stream");
+      expect(res.headers["cache-control"]).toBe("no-cache");
+      expect(res.headers["connection"]).toBe("keep-alive");
+      expect(res.headers["x-accel-buffering"]).toBe("no");
+      res.destroy();
+      done();
+    });
+    req.on("error", done);
+  });
+
+  test("receives a donation event with projectName, amountXLM, and donorBadge", (done) => {
+    const chunks = [];
+
+    const req = http.get(`${baseUrl}/api/donations/stream`, (res) => {
+      res.on("data", (chunk) => {
+        const text = chunk.toString();
+        chunks.push(text);
+
+        const fullText = chunks.join("");
+        if (fullText.includes("data:")) {
+          const match = fullText.match(/data: ({.*})\n\n/);
+          if (match) {
+            const payload = JSON.parse(match[1]);
+            try {
+              expect(payload).toHaveProperty("projectName");
+              expect(payload).toHaveProperty("amountXLM");
+              expect(payload).toHaveProperty("donorBadge");
+              expect(typeof payload.projectName).toBe("string");
+              expect(typeof payload.amountXLM).toBe("string");
+              res.destroy();
+              done();
+            } catch (err) {
+              res.destroy();
+              done(err);
+            }
+          }
+        }
+      });
+    });
+
+    req.on("error", done);
+
+    // Give the connection time to establish, then emit an event
+    setTimeout(() => {
+      donationEvents.emit("new_donation", {
+        projectName: "Amazon Reforestation",
+        amountXLM: "25.0",
+        donorBadge: "Seedling",
+      });
+    }, 50);
+  });
+
+  test("emits correctly formatted SSE data line", (done) => {
+    const chunks = [];
+
+    const req = http.get(`${baseUrl}/api/donations/stream`, (res) => {
+      res.on("data", (chunk) => {
+        chunks.push(chunk.toString());
+        const fullText = chunks.join("");
+        if (fullText.includes("data:")) {
+          try {
+            expect(fullText).toMatch(/data: \{.*\}\n\n/);
+            res.destroy();
+            done();
+          } catch (err) {
+            res.destroy();
+            done(err);
+          }
+        }
+      });
+    });
+
+    req.on("error", done);
+
+    setTimeout(() => {
+      donationEvents.emit("new_donation", {
+        projectName: "Ocean Cleanup",
+        amountXLM: "100.0",
+        donorBadge: "Tree",
+      });
+    }, 50);
+  });
+
+  test("receives multiple events in sequence", (done) => {
+    const events = [];
+    const expectedCount = 3;
+
+    const req = http.get(`${baseUrl}/api/donations/stream`, (res) => {
+      res.on("data", (chunk) => {
+        const text = chunk.toString();
+        const match = text.match(/data: ({.*})\n\n/);
+        if (match) {
+          events.push(JSON.parse(match[1]));
+          if (events.length === expectedCount) {
+            try {
+              expect(events[0].projectName).toBe("Project A");
+              expect(events[1].projectName).toBe("Project B");
+              expect(events[2].projectName).toBe("Project C");
+              expect(events[2].amountXLM).toBe("50.0");
+              res.destroy();
+              done();
+            } catch (err) {
+              res.destroy();
+              done(err);
+            }
+          }
+        }
+      });
+    });
+
+    req.on("error", done);
+
+    setTimeout(() => {
+      donationEvents.emit("new_donation", { projectName: "Project A", amountXLM: "10.0", donorBadge: "Seedling" });
+      donationEvents.emit("new_donation", { projectName: "Project B", amountXLM: "20.0", donorBadge: "Tree" });
+      donationEvents.emit("new_donation", { projectName: "Project C", amountXLM: "50.0", donorBadge: "Forest" });
+    }, 50);
+  });
+
+  test("cleans up listener on client disconnect", (done) => {
+    const req = http.get(`${baseUrl}/api/donations/stream`, (res) => {
+      const listenerCountBefore = donationEvents.listenerCount("new_donation");
+      expect(listenerCountBefore).toBeGreaterThanOrEqual(1);
+
+      res.destroy();
+
+      // Allow time for the close event to propagate
+      setTimeout(() => {
+        const listenerCountAfter = donationEvents.listenerCount("new_donation");
+        expect(listenerCountAfter).toBeLessThan(listenerCountBefore);
+        done();
+      }, 100);
+    });
+
+    req.on("error", done);
+  });
+});
+
+describe("POST /api/donations → SSE emission", () => {
+  let httpServer;
+  let request;
+  let baseUrl;
+
+  beforeAll((done) => {
+    const app = express();
+    app.use(express.json());
+    httpServer = http.createServer(app);
+    app.use("/api/donations", require("./donations"));
+    httpServer.listen(0, () => {
+      baseUrl = `http://localhost:${httpServer.address().port}`;
+      request = supertest(httpServer);
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    donationEvents.removeAllListeners();
+    httpServer.close(done);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    donationEvents.removeAllListeners();
+  });
+
+  test(
+    "POST /api/donations emits enriched SSE event with projectName and donorBadge",
+    (done) => {
+      const donorAddress = makePublicKey("W");
+      const transactionHash = makeTxHash("7");
+      const donationRow = {
+        id: "sse-donation-1",
+        project_id: "project-sse",
+        donor_address: donorAddress,
+        amount_xlm: "25",
+        amount: "25",
+        currency: "XLM",
+        message: null,
+        transaction_hash: transactionHash,
+        created_at: new Date().toISOString(),
+      };
+
+      createMockClient(
+        queryResult([{ id: "project-sse", name: "Amazon Reforestation" }]), // SELECT project
+        queryResult([]),                          // dedup check
+        queryResult(),                            // BEGIN
+        queryResult([donationRow]),               // INSERT donation
+        queryResult([]),                          // SELECT donation_matches (empty)
+        queryResult(),                            // UPDATE projects
+        queryResult([{ total_donated_xlm: "25" }]), // SELECT profile (badge = Seedling)
+        queryResult([{ count: "1" }]),            // COUNT(DISTINCT project_id)
+        queryResult(),                            // INSERT profile
+        queryResult(),                            // COMMIT
+      );
+
+      const deadline = setTimeout(() => {
+        done(new Error("SSE event was not received within 500 ms"));
+      }, 500);
+
+      donationEvents.on("new_donation", (data) => {
+        clearTimeout(deadline);
+        try {
+          expect(data.projectName).toBe("Amazon Reforestation");
+          expect(data.amountXLM).toBe("25");
+          expect(data.donorBadge).toBe("Seedling");
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+
+      request
+        .post("/api/donations")
+        .send({
+          projectId: "project-sse",
+          donorAddress,
+          amountXLM: "25",
+          transactionHash,
+        })
+        .end((err) => {
+          if (err) {
+            clearTimeout(deadline);
+            done(err);
+          }
+        });
+    },
+    2000,
+  );
+
+  test(
+    "SSE event for large donation emits correct badge tier",
+    (done) => {
+      const donorAddress = makePublicKey("V");
+      const transactionHash = makeTxHash("a");
+      const donationRow = {
+        id: "sse-donation-2",
+        project_id: "project-big",
+        donor_address: donorAddress,
+        amount_xlm: "500",
+        amount: "500",
+        currency: "XLM",
+        message: null,
+        transaction_hash: transactionHash,
+        created_at: new Date().toISOString(),
+      };
+
+      createMockClient(
+        queryResult([{ id: "project-big", name: "Amazon Reforestation" }]),
+        queryResult([]),
+        queryResult(),
+        queryResult([donationRow]),
+        queryResult([]),
+        queryResult(),
+        queryResult([{ total_donated_xlm: "500" }]), // Forest badge
+        queryResult([{ count: "1" }]),
+        queryResult(),
+        queryResult(),
+      );
+
+      const deadline = setTimeout(() => {
+        done(new Error("SSE event was not received within 500 ms"));
+      }, 500);
+
+      donationEvents.on("new_donation", (data) => {
+        clearTimeout(deadline);
+        try {
+          expect(data.projectName).toBe("Amazon Reforestation");
+          expect(data.amountXLM).toBe("500");
+          expect(data.donorBadge).toBe("Forest");
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+
+      request
+        .post("/api/donations")
+        .send({
+          projectId: "project-big",
+          donorAddress,
+          amountXLM: "500",
+          transactionHash,
+        })
+        .end((err) => {
+          if (err) {
+            clearTimeout(deadline);
+            done(err);
+          }
+        });
+    },
+    2000,
+  );
+});

--- a/backend/src/services/donationEvents.js
+++ b/backend/src/services/donationEvents.js
@@ -1,0 +1,20 @@
+/**
+ * Shared EventEmitter for donation events.
+ *
+ * Bridges WebSocket broadcasts and the SSE stream endpoint so that
+ * both the REST API route and the Horizon indexer can push donation
+ * events to connected SSE clients.
+ *
+ * @module services/donationEvents
+ */
+"use strict";
+
+const { EventEmitter } = require("events");
+
+const donationEvents = new EventEmitter();
+
+// Prevent Node from throwing when >10 listeners attach (SSE clients
+// can accumulate during traffic spikes).
+donationEvents.setMaxListeners(0);
+
+module.exports = donationEvents;

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -8,6 +8,7 @@ const pool = require("../db/pool");
 const { v4: uuid } = require("uuid");
 const { computeBadges } = require("./store");
 const { checkAndDeliverMilestones } = require("./webhook");
+const donationEvents = require("./donationEvents");
 const logger = require("../logger");
 
 let lastProcessedLedger = 0;
@@ -179,7 +180,26 @@ async function handleDonation(projectId, op) {
       });
     }
 
-    // 6. Check milestones asynchronously
+    // 6. Emit SSE event with enriched payload
+    let projectName = "Unknown Project";
+    let donorBadge = "";
+    try {
+      const projectResult = await client.query("SELECT name FROM projects WHERE id = $1", [projectId]);
+      if (projectResult.rows[0]) projectName = projectResult.rows[0].name;
+    } catch {
+      // best-effort
+    }
+    if (badges.length > 0) {
+      const tier = badges[0].tier;
+      donorBadge = tier.charAt(0).toUpperCase() + tier.slice(1);
+    }
+    donationEvents.emit("new_donation", {
+      projectName,
+      amountXLM: String(amountXLM),
+      donorBadge,
+    });
+
+    // 7. Check milestones asynchronously
     checkAndDeliverMilestones(projectId).catch(() => {});
   } catch (err) {
     if (inTransaction) await client.query("ROLLBACK");


### PR DESCRIPTION
## Summary

Implements the `GET /api/donations/stream` Server-Sent Events endpoint that streams new donation events in real time. This is the backend for the landing page live ticker, allowing the frontend to consume donation events from the backend instead of opening direct Horizon SSE connections.

## Motivation

The landing page live ticker currently streams directly from Stellar Horizon SSE. This has two drawbacks:

1. **No enriched data** -- Horizon only provides raw payment data (amounts, addresses). It cannot include human-readable project names or donor badge tiers.
2. **No centralization** -- Every client opens its own Horizon connection, which is wasteful and harder to monitor.

The new SSE endpoint bridges both donation sources (the REST API and the Horizon indexer) through a shared EventEmitter, so connected clients receive a single unified stream of enriched donation events.

## What Changed

### New file: `backend/src/services/donationEvents.js`

A shared `EventEmitter` instance that bridges WebSocket broadcasts and the SSE stream. Both the REST API route (`POST /api/donations`) and the Horizon indexer service import this module and emit `"new_donation"` events to it. SSE clients subscribe via `GET /api/donations/stream`.

### Fixed: `backend/src/routes/donations.js`

- **Imported the shared emitter** -- the existing code referenced `donationEvents` but never declared or imported it (would throw `ReferenceError` at runtime).
- **Fixed SSE data format** -- the keep-alive and data lines wrote literal `\\n\\n` (escaped backslashes) instead of actual newlines. Clients would never parse the stream correctly.
- **Enriched SSE payload** -- each event now includes:
  - `projectName` -- looked up from the `projects` table (was previously only `SELECT id`)
  - `amountXLM` -- the donation amount as a string
  - `donorBadge` -- computed from the donor's cumulative total using `computeBadges()` (Seedling / Tree / Forest / Earth)
- **Added `X-Accel-Buffering: no`** -- required for correct SSE behavior behind nginx reverse proxies.
- **Added JSDoc** to the SSE endpoint.
- **Badge computation is best-effort** -- wrapped in try/catch so a profile lookup failure never blocks the donation recording.

### Fixed: `backend/src/services/indexerService.js`

- **Emits to the shared emitter** after recording a Horizon-indexed donation, so donations detected by the indexer also appear in the SSE stream.
- Enriches the payload with `projectName` (queried from DB) and `donorBadge` (computed from the donor's updated profile).

### New file: `backend/src/routes/donations.sse.test.js`

7 tests covering:

| Test | Description |
|------|-------------|
| SSE headers | Verifies `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no` |
| Event shape | Receives a JSON event with `projectName`, `amountXLM`, and `donorBadge` fields |
| Data format | Verifies proper `data: {...}\n\n` SSE framing |
| Multiple events | Three sequential emissions all arrive in order |
| Listener cleanup | Listener count decreases after client disconnect |
| POST then SSE enrichment | `POST /api/donations` emits enriched event with project name and donor badge |
| Badge tier | Large donation (500 XLM) emits `"Forest"` badge |

## SSE Event Format

```
data: {"projectName":"Amazon Reforestation","amountXLM":"25.0","donorBadge":"Seedling"}
```

| Field | Type | Description |
|-------|------|-------------|
| `projectName` | `string` | Human-readable project name from the database |
| `amountXLM` | `string` | Donation amount in XLM (string for JSON precision) |
| `donorBadge` | `string` | Donor badge tier: `"Seedling"` (>=10), `"Tree"` (>=100), `"Forest"` (>=500), `"Earth"` (>=2000), or `""` if below all thresholds |

## How It Works

```
POST /api/donations --> recordDonation() --> donationEvents.emit("new_donation", payload)
                                                  |
Horizon indexer -----> handleDonation() --> donationEvents.emit("new_donation", payload)
                                                  |
GET /api/donations/stream -----> donationEvents.on("new_donation") --> SSE client
```

Both the REST API route and the Horizon indexer push to the same EventEmitter. The SSE endpoint subscribes and forwards each event to all connected clients.

## Files Changed

| File | Change |
|------|--------|
| `backend/src/services/donationEvents.js` | **New** -- shared EventEmitter singleton |
| `backend/src/routes/donations.js` | Import emitter, fix SSE format, enrich events, add JSDoc |
| `backend/src/services/indexerService.js` | Import emitter, emit enriched SSE events from indexer |
| `backend/src/routes/donations.sse.test.js` | **New** -- 7 SSE endpoint tests |

## Verification

- All 4 new/modified files pass `node --check` (syntax validation)
- SSE event format matches the issue spec exactly: `{"projectName":"...","amountXLM":"...","donorBadge":"..."}`
- Both donation sources (REST API and Horizon indexer) feed into the same SSE stream
- Listener cleanup on client disconnect prevents memory leaks
- Badge computation is best-effort and never blocks donation recording
- No conflicts with `main`

Closes #691
