### PR TITLE
feat(webhooks): add webhook management UI in admin panel

### DIFF
--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -10,7 +10,7 @@ const QRCode = require("qrcode");
 const pool = require("../db/pool");
 const { logAdminAction } = require("../services/audit");
 const { adminKeyRequired } = require("../middleware/auth");
-const { mapProjectRow, mapProjectMilestoneRow } = require("../services/store");
+const { mapProjectRow, mapProjectMilestoneRow, updateWebhook } = require("../services/store");
 const {
   getOnChainProject,
   CONTRACT_ID,
@@ -1256,6 +1256,109 @@ router.get("/:id/badge-holders", async (req, res, next) => {
     }));
 
     res.json({ success: true, data: badgeHolders });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * PATCH /api/projects/:id/webhook
+ * Update the webhook URL and secret for a project. Auto-generates a secret
+ * when one is not provided. Returns the updated webhook config.
+ */
+router.patch("/:id/webhook", async (req, res, next) => {
+  try {
+    const { webhookUrl, webhookSecret } = req.body || {};
+
+    if (webhookUrl !== null && webhookUrl !== undefined && webhookUrl !== "") {
+      try {
+        new URL(webhookUrl);
+      } catch {
+        return res.status(400).json({ error: "Invalid webhook URL" });
+      }
+    }
+
+    const projectResult = await pool.query(
+      "SELECT id FROM projects WHERE id = $1",
+      [req.params.id],
+    );
+    if (!projectResult.rows[0]) {
+      return res.status(404).json({ error: "Project not found" });
+    }
+
+    const url = webhookUrl || null;
+    let secret = webhookSecret || null;
+    if (url && !secret) {
+      secret = crypto.randomBytes(32).toString("hex");
+    }
+
+    const updated = await updateWebhook(req.params.id, url, secret);
+    res.json({ success: true, data: updated });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * POST /api/projects/:id/webhook/test
+ * Sends a test event to the project's configured webhook URL.
+ * Returns the HTTP status code from the remote endpoint.
+ */
+router.post("/:id/webhook/test", async (req, res, next) => {
+  try {
+    const projectResult = await pool.query(
+      "SELECT id, webhook_url, webhook_secret FROM projects WHERE id = $1",
+      [req.params.id],
+    );
+    const project = projectResult.rows[0];
+    if (!project) {
+      return res.status(404).json({ error: "Project not found" });
+    }
+    if (!project.webhook_url || !project.webhook_secret) {
+      return res.status(400).json({ error: "No webhook configured for this project" });
+    }
+
+    const payload = {
+      event: "webhook.test",
+      projectId: req.params.id,
+      message: "This is a test webhook delivery from GreenPay.",
+      timestamp: new Date().toISOString(),
+    };
+
+    const body = JSON.stringify(payload);
+    const urlObj = new URL(project.webhook_url);
+    const lib = urlObj.protocol === "https:" ? require("https") : require("http");
+
+    const statusCode = await new Promise((resolve, reject) => {
+      const options = {
+        hostname: urlObj.hostname,
+        port: urlObj.port || (urlObj.protocol === "https:" ? 443 : 80),
+        path: urlObj.pathname + urlObj.search,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+          "User-Agent": "GreenPay-Webhook/1.0",
+        },
+        timeout: 10000,
+      };
+
+      const req = lib.request(options, (response) => {
+        response.on("data", () => {});
+        response.on("end", () => resolve(response.statusCode));
+      });
+
+      req.on("error", (err) => reject(err));
+      req.on("timeout", () => {
+        req.destroy();
+        reject(new Error("Request timed out"));
+      });
+
+      req.write(body);
+      req.end();
+    });
+
+    res.json({ success: true, statusCode });
   } catch (e) {
     next(e);
   }

--- a/backend/src/services/store.js
+++ b/backend/src/services/store.js
@@ -311,6 +311,33 @@ function mapProjectRatingRow(row) {
  */
 // exported as `mapProjectRatingRow`
 
+/**
+ * Update the webhook URL and secret for a project.
+ *
+ * @param {string} projectId - Project UUID.
+ * @param {string|null} webhookUrl - The webhook URL to set (or null to clear).
+ * @param {string|null} webhookSecret - The HMAC secret for signing payloads.
+ * @returns {Promise<{webhookUrl: string|null, webhookSecret: string|null}>} Updated webhook config.
+ */
+async function updateWebhook(projectId, webhookUrl, webhookSecret) {
+  const pool = require("../db/pool");
+  const result = await pool.query(
+    `UPDATE projects
+     SET webhook_url = $1,
+         webhook_secret = $2,
+         updated_at = NOW()
+     WHERE id = $3
+     RETURNING webhook_url, webhook_secret`,
+    [webhookUrl || null, webhookSecret || null, projectId],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  return {
+    webhookUrl: row.webhook_url || null,
+    webhookSecret: row.webhook_secret || null,
+  };
+}
+
 module.exports = {
   seedProjects,
   seedProjectUpdates,
@@ -324,4 +351,5 @@ module.exports = {
   mapJobRow,
   mapProjectMilestoneRow,
   mapProjectRatingRow,
+  updateWebhook,
 };

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -677,6 +677,33 @@ export async function submitProject(payload: SubmitProjectPayload): Promise<Subm
   return data.data;
 }
 
+// ── Webhooks ─────────────────────────────────────────────────────────────────
+
+export interface WebhookConfig {
+  webhookUrl: string | null;
+  webhookSecret: string | null;
+}
+
+export async function updateProjectWebhook(
+  projectId: string,
+  payload: { webhookUrl?: string | null; webhookSecret?: string | null },
+): Promise<WebhookConfig> {
+  const { data } = await api.patch<{ success: boolean; data: WebhookConfig }>(
+    `/api/projects/${projectId}/webhook`,
+    payload,
+  );
+  return data.data;
+}
+
+export async function testProjectWebhook(
+  projectId: string,
+): Promise<{ success: boolean; statusCode: number }> {
+  const { data } = await api.post<{ success: boolean; statusCode: number }>(
+    `/api/projects/${projectId}/webhook/test`,
+  );
+  return data;
+}
+
 // ── Verification Requests (/apply) ───────────────────────────────────────────
 export interface VerificationDocument {
   name: string;

--- a/frontend/pages/admin/[projectId].tsx
+++ b/frontend/pages/admin/[projectId].tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import WalletConnect from "@/components/WalletConnect";
-import { createProjectUpdate, fetchProject, fetchProjectDonations, updateProjectStatus, registerProjectOnChain, confirmProjectRegistration, fetchProjectMatches, csrfFetch } from "@/lib/api";
+import { createProjectUpdate, fetchProject, fetchProjectDonations, updateProjectStatus, registerProjectOnChain, confirmProjectRegistration, fetchProjectMatches, csrfFetch, updateProjectWebhook, testProjectWebhook } from "@/lib/api";
 import { buildMilestoneTransaction, submitTransaction } from "@/lib/stellar";
 import { formatCO2, formatXLM, shortenAddress, timeAgo } from "@/utils/format";
 import type { ClimateProject, Donation } from "@/utils/types";
@@ -63,6 +63,13 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
   const [widgetCurrency, setWidgetCurrency] = useState<"XLM" | "USDC">("XLM");
   const [copied, setCopied] = useState(false);
 
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [webhookSecret, setWebhookSecret] = useState("");
+  const [webhookState, setWebhookState] = useState<"idle" | "saving" | "success" | "error">("idle");
+  const [webhookMessage, setWebhookMessage] = useState<string | null>(null);
+  const [testState, setTestState] = useState<"idle" | "testing" | "success" | "error">("idle");
+  const [testMessage, setTestMessage] = useState<string | null>(null);
+
   const widgetEmbedCode = useMemo(() => {
     const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
     const params = new URLSearchParams({
@@ -96,6 +103,48 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
     }
   };
 
+  const saveWebhook = async () => {
+    if (!project) return;
+    setWebhookState("saving");
+    setWebhookMessage(null);
+    try {
+      const updated = await updateProjectWebhook(project.id, {
+        webhookUrl: webhookUrl.trim() || null,
+        webhookSecret: webhookSecret.trim() || null,
+      });
+      setWebhookUrl(updated.webhookUrl || "");
+      setWebhookSecret(updated.webhookSecret || "");
+      setProject({ ...project, webhookUrl: updated.webhookUrl, webhookSecret: updated.webhookSecret });
+      setWebhookMessage("Webhook configuration saved.");
+      setWebhookState("success");
+      setTimeout(() => setWebhookState("idle"), 3000);
+    } catch (e: any) {
+      setWebhookMessage(e.message || "Failed to save webhook configuration");
+      setWebhookState("error");
+    }
+  };
+
+  const generateSecret = () => {
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
+    setWebhookSecret(Array.from(array, (b) => b.toString(16).padStart(2, "0")).join(""));
+  };
+
+  const sendTestWebhook = async () => {
+    if (!project) return;
+    setTestState("testing");
+    setTestMessage(null);
+    try {
+      const result = await testProjectWebhook(project.id);
+      setTestMessage(`Test event sent. Status: ${result.statusCode}`);
+      setTestState("success");
+      setTimeout(() => setTestState("idle"), 4000);
+    } catch (e: any) {
+      setTestMessage(e.message || "Failed to send test event");
+      setTestState("error");
+    }
+  };
+
   useEffect(() => {
     if (!projectId || typeof projectId !== "string") return;
     setLoading(true);
@@ -112,6 +161,8 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
         setDonations(d);
         setMilestones(m.data || []);
         setMatches(mt);
+        setWebhookUrl(p.webhookUrl || "");
+        setWebhookSecret(p.webhookSecret || "");
       })
       .catch((e: unknown) => setError((e as Error).message || "Failed to load project"))
       .finally(() => setLoading(false));
@@ -791,6 +842,76 @@ export default function ProjectAdmin({ publicKey, onConnect }: AdminProps) {
               {copied ? "✓ Copied!" : "Copy Embed Code"}
             </button>
           </div>
+        </div>
+      </div>
+
+      {/* Webhooks */}
+      <div className="card mt-6">
+        <h2 className="font-display text-xl font-bold text-forest-900 mb-2">Webhooks</h2>
+        <p className="text-sm text-[#5a7a5a] dark:text-[#8aaa8a] font-body mb-4">
+          Configure a webhook URL to receive signed POST notifications when milestones are reached.
+        </p>
+
+        {webhookMessage && (
+          <div className={`p-3 rounded-xl text-sm font-body mb-4 ${webhookState === "success" ? "bg-green-50 border border-green-200 text-green-700" : "bg-red-50 border border-red-200 text-red-600"}`}>
+            {webhookMessage}
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-bold text-forest-800 uppercase tracking-widest mb-1 ml-1 opacity-50">
+              Webhook URL
+            </label>
+            <input
+              value={webhookUrl}
+              onChange={(e) => setWebhookUrl(e.target.value)}
+              className="input-field"
+              placeholder="https://example.com/webhook"
+              type="url"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-bold text-forest-800 uppercase tracking-widest mb-1 ml-1 opacity-50">
+              Signing Secret
+            </label>
+            <div className="flex gap-2">
+              <input
+                value={webhookSecret}
+                onChange={(e) => setWebhookSecret(e.target.value)}
+                className="input-field flex-1 font-mono text-xs"
+                placeholder="Auto-generated if left empty"
+                type="text"
+              />
+              <button
+                onClick={generateSecret}
+                className="px-4 py-2 rounded-xl text-sm font-semibold border border-forest-200 bg-forest-50 hover:bg-forest-100 transition-all whitespace-nowrap"
+              >
+                Generate
+              </button>
+            </div>
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={saveWebhook}
+              disabled={webhookState === "saving"}
+              className="btn-primary flex-1 disabled:opacity-50"
+            >
+              {webhookState === "saving" ? "Saving…" : "Save Webhook"}
+            </button>
+            <button
+              onClick={sendTestWebhook}
+              disabled={testState === "testing" || !webhookUrl.trim()}
+              className="flex-1 bg-forest-100 hover:bg-forest-200 text-forest-900 font-semibold px-6 py-3 rounded-xl transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {testState === "testing" ? "Sending…" : "Send Test Event"}
+            </button>
+          </div>
+          {testMessage && (
+            <div className={`p-3 rounded-xl text-sm font-body ${testState === "success" ? "bg-green-50 border border-green-200 text-green-700" : "bg-red-50 border border-red-200 text-red-600"}`}>
+              {testMessage}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/utils/types.ts
+++ b/frontend/utils/types.ts
@@ -66,6 +66,8 @@ export interface ClimateProject {
   // passed to the fetch; defaults to false when omitted.
   followCount?: number;
   isFollowing?: boolean;
+  webhookUrl?: string | null;
+  webhookSecret?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a webhook management section to the project admin page where project owners can configure, test, and manage webhooks.

## Changes

### Backend
- **`store.js`** - Added `updateWebhook()` method to persist webhook URL and secret
- **`projects.js`** - Added `PATCH /:id/webhook` (validate URL, auto-generate HMAC secret, save) and `POST /:id/webhook/test` (send test event, return status code)

### Frontend
- **`admin/[projectId].tsx`** - New "Webhooks" card section with URL input, secret input + Generate button, Save button, Send Test Event button, and status display
- **`lib/api.ts`** - Added `updateProjectWebhook()` and `testProjectWebhook()` API methods
- **`utils/types.ts`** - Added `webhookUrl` and `webhookSecret` fields to `ClimateProject`

## UI Features

- Enter webhook URL
- Auto-generate or manually enter HMAC-SHA256 secret
- Save webhook configuration
- Send test event to verify delivery
- View test result status code

Fixes #710