### PR TITLE
test: add digestQueue.runDigest test for zero active projects

### DIFF
--- a/backend/src/services/digestQueue.test.js
+++ b/backend/src/services/digestQueue.test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+jest.mock("pg-boss", () => {
+  const mockBoss = {
+    on: jest.fn(),
+    start: jest.fn(),
+    schedule: jest.fn(),
+    work: jest.fn(),
+  };
+  return function PgBoss() { return mockBoss; };
+}, { virtual: true });
+jest.mock("../db/pool", () => ({ query: jest.fn() }));
+jest.mock("../logger", () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }));
+
+const pool = require("../db/pool");
+const logger = require("../logger");
+const { runDigest } = require("./digestQueue");
+
+global.fetch = jest.fn();
+
+describe("runDigest", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("no active projects with subscribers sends no emails", async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+
+    await runDigest();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "digest_run_complete", sent: 0 }),
+      expect.any(String),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
### **testing: add test for digestQueue.runDigest with no active projects sends no emails**

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #754 

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
<img width="466" height="216" alt="image" src="https://github.com/user-attachments/assets/fd8a8fea-3226-4f44-a3e8-1f8b2cb91d5f" />
