### PR TITLE
Test/leaderboard only verified filter

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,40 +1,52 @@
-# test(leaderboard): add `onlyVerified` filter tests
+# test(leaderboard): cover `?onlyVerified=true` filter with Donor A / Donor B fixtures
 
 ## Summary
 
-Adds a new `GET /api/leaderboard — onlyVerified filter` test suite to `backend/src/routes/leaderboard.test.js` covering the `?onlyVerified=true` query parameter.
+The `GET /api/leaderboard` route supports an `?onlyVerified=true` query parameter that filters out donors who have ever donated to an unverified project. This behaviour had no test coverage, leaving a gap where a regression could go undetected. This PR adds a dedicated test suite with two donor fixtures — one who donated only to verified projects (Donor A) and one who donated to both verified and unverified projects (Donor B) — and asserts that only Donor A appears when the filter is active.
 
-## What changed
+## Type
 
-**`backend/src/routes/leaderboard.test.js`**
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor
+- [x] **Testing**
+- [ ] Smart contract change
 
-Added a new `describe` block with two donor fixtures and four tests:
+## Related Issue
 
-| Fixture | Donations |
-|---------|-----------|
-| Donor A (`GDDD…`) | Verified projects only |
-| Donor B (`GEEE…`) | Both verified **and** unverified projects |
+Closes #
 
-| # | Test | Assertion |
-|---|------|-----------|
-| 1 | `returns only Donor A when onlyVerified=true` | Response has exactly one entry; its `publicKey` matches Donor A |
-| 2 | `does not include Donor B in the results when onlyVerified=true` | Donor B's public key is absent from all response entries |
-| 3 | `sends a SQL query containing the verified-only filter` | The SQL string passed to `pool.query` contains both `verified = false` (exclusion subquery) and `verified = true` (inclusion subquery) |
-| 4 | `does not apply the verified filter when onlyVerified is absent` | Both donors appear in results; SQL lacks the verified filter |
+## Testing
 
-## How to test
+- [x] Tested locally on Testnet
+- [x] No TypeScript / Rust errors
+- [ ] Docs updated if needed
+
+### Tests added
+
+```
+GET /api/leaderboard — onlyVerified filter
+  ✓ returns only Donor A when onlyVerified=true (Donor B donated to unverified projects)
+  ✓ does not include Donor B in the results when onlyVerified=true
+  ✓ sends a SQL query containing the verified-only filter when onlyVerified=true
+  ✓ does not apply the verified filter when onlyVerified is absent
+```
+
+| Fixture | Donations | Appears in `?onlyVerified=true` response |
+|---------|-----------|------------------------------------------|
+| **Donor A** (`GDDD…`) | Verified projects only | ✅ |
+| **Donor B** (`GEEE…`) | Verified **and** unverified projects | ❌ |
+
+Run locally with:
 
 ```bash
 cd backend
 npm test -- --testPathPattern=leaderboard --no-coverage
 ```
 
-All 16 tests pass (8 pre-existing + 4 new `onlyVerified` + 4 pre-existing limit tests).
+**Result: 16/16 tests pass** (8 pre-existing + 4 new)
 
-## Checklist
+## Screenshots (if UI change)
 
-- [x] Tests cover the happy path (Donor A returned)
-- [x] Tests cover the exclusion case (Donor B absent)
-- [x] Tests verify the SQL filter is applied (or not applied) correctly
-- [x] No production code changed
-- [x] All existing tests continue to pass
+N/A — backend test-only change, no UI affected.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,30 +1,40 @@
-feat: add context menu item to donate to project, fix inline address click flow via background service worker
+# test(leaderboard): add `onlyVerified` filter tests
 
 ## Summary
-This PR adds a right-click context menu item ("Donate to this GreenPay project") that appears dynamically when a user right-clicks on a page containing a GreenPay project ID (detected via URL or the new `<meta name="greenpay:project:id">` tag). Clicking the context menu item opens the extension popup, fetches the project details, and pre-fills the donation form automatically.
 
-Additionally, this PR fixes a dormant feature where clicking a highlighted inline Stellar address in the browser did not work because the background script to handle `openDonatePopup` was missing. Both features now share a robust background service worker.
+Adds a new `GET /api/leaderboard — onlyVerified filter` test suite to `backend/src/routes/leaderboard.test.js` covering the `?onlyVerified=true` query parameter.
 
-Key changes:
-- Added `greenpay:project:id` meta tag to `frontend/pages/projects/[id].tsx`.
-- Registered `background.ts` as a service worker in `manifest.json` and `manifest.firefox.json` with the `contextMenus` permission.
-- Updated `content-script.ts` to detect the project ID dynamically on load and via a `MutationObserver`/`popstate` to support Next.js SPA routing, notifying the background script of context changes.
-- Implemented `popup.ts` to consume the pending donation context from `chrome.storage.local` and auto-fill the destination `walletAddress` and project name.
+## What changed
 
-## Type
-- [x] Bug fix
-- [x] New feature
-- [ ] Documentation
-- [ ] Refactor
-- [ ] Smart contract change
+**`backend/src/routes/leaderboard.test.js`**
 
-## Related Issue
-Closes #492
+Added a new `describe` block with two donor fixtures and four tests:
 
-## Testing
-- [x] Tested locally on Testnet
-- [x] No TypeScript / Rust errors
-- [ ] Docs updated if needed
+| Fixture | Donations |
+|---------|-----------|
+| Donor A (`GDDD…`) | Verified projects only |
+| Donor B (`GEEE…`) | Both verified **and** unverified projects |
 
-## Screenshots (if UI change)
-<!-- Add screenshots here if applicable -->
+| # | Test | Assertion |
+|---|------|-----------|
+| 1 | `returns only Donor A when onlyVerified=true` | Response has exactly one entry; its `publicKey` matches Donor A |
+| 2 | `does not include Donor B in the results when onlyVerified=true` | Donor B's public key is absent from all response entries |
+| 3 | `sends a SQL query containing the verified-only filter` | The SQL string passed to `pool.query` contains both `verified = false` (exclusion subquery) and `verified = true` (inclusion subquery) |
+| 4 | `does not apply the verified filter when onlyVerified is absent` | Both donors appear in results; SQL lacks the verified filter |
+
+## How to test
+
+```bash
+cd backend
+npm test -- --testPathPattern=leaderboard --no-coverage
+```
+
+All 16 tests pass (8 pre-existing + 4 new `onlyVerified` + 4 pre-existing limit tests).
+
+## Checklist
+
+- [x] Tests cover the happy path (Donor A returned)
+- [x] Tests cover the exclusion case (Donor B absent)
+- [x] Tests verify the SQL filter is applied (or not applied) correctly
+- [x] No production code changed
+- [x] All existing tests continue to pass

--- a/backend/src/routes/leaderboard.test.js
+++ b/backend/src/routes/leaderboard.test.js
@@ -134,6 +134,84 @@ describe("GET /api/leaderboard — ranking sort order", () => {
   });
 });
 
+describe("GET /api/leaderboard — onlyVerified filter", () => {
+  let app;
+
+  // Donor A: donated exclusively to verified projects
+  const DONOR_A = {
+    public_key: "GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+    display_name: "Donor A",
+    badges: [],
+    total_donated_xlm: "200",
+    projects_supported: 2,
+  };
+
+  // Donor B: donated to both verified and unverified projects.
+  // When onlyVerified=true the DB WHERE clause excludes Donor B, so the
+  // mock simulates that by not including Donor B in the returned rows.
+  const DONOR_B = {
+    public_key: "GEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
+    display_name: "Donor B",
+    badges: [],
+    total_donated_xlm: "300",
+    projects_supported: 3,
+  };
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("returns only Donor A when onlyVerified=true (Donor B donated to unverified projects)", async () => {
+    // Simulate the DB filtering out Donor B because they donated to unverified projects
+    pool.query.mockResolvedValue({ rows: [DONOR_A] });
+
+    const res = await request(app)
+      .get("/api/leaderboard?onlyVerified=true")
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].publicKey).toBe(DONOR_A.public_key);
+    expect(res.body.data[0].displayName).toBe("Donor A");
+  });
+
+  test("does not include Donor B in the results when onlyVerified=true", async () => {
+    pool.query.mockResolvedValue({ rows: [DONOR_A] });
+
+    const res = await request(app)
+      .get("/api/leaderboard?onlyVerified=true")
+      .expect(200);
+
+    const keys = res.body.data.map((e) => e.publicKey);
+    expect(keys).not.toContain(DONOR_B.public_key);
+  });
+
+  test("sends a SQL query containing the verified-only filter when onlyVerified=true", async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+
+    await request(app).get("/api/leaderboard?onlyVerified=true").expect(200);
+
+    const [sql] = pool.query.mock.calls[0];
+    // The route adds a WHERE clause that excludes donors with unverified donations
+    expect(sql).toMatch(/verified\s*=\s*false/i);
+    // …and requires at least one verified donation
+    expect(sql).toMatch(/verified\s*=\s*true/i);
+  });
+
+  test("does not apply the verified filter when onlyVerified is absent", async () => {
+    pool.query.mockResolvedValue({ rows: [DONOR_A, DONOR_B] });
+
+    const res = await request(app).get("/api/leaderboard").expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+
+    const [sql] = pool.query.mock.calls[0];
+    expect(sql).not.toMatch(/verified\s*=\s*false/i);
+  });
+});
+
 describe("GET /api/leaderboard — limit handling", () => {
   let app;
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? -->
Adds test coverage for the ?onlyVerified=true query parameter on GET /api/leaderboard. Introduces two donor fixtures — Donor A (verified projects only) and Donor B (verified and unverified projects) — and asserts that only Donor A is returned when the filter is active, that Donor B is excluded, that the correct SQL subqueries are injected into the query, and that no filter is applied when the param is absent.



## Type
- [ ] Bug fix
- [ ] New feature
- [] Documentation
- [ ] Refactor
- [x] Testing
- [ ] Smart contract change

## Related Issue
Closes #

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed


