### PR TITLE
ci: Backup backend/uploads directory along with PostgreSQL database

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -62,6 +62,22 @@ jobs:
         run: |
           echo "::error::Database backup failed. Check the logs above."
           exit 1
+          
+      - name: Backup local uploads directory
+        run: |
+          if [ -d "backend/uploads" ]; then
+            tar -czf /tmp/uploads-backup.tar.gz backend/uploads
+          else
+            echo "backend/uploads directory not found. Skipping."
+            touch /tmp/uploads-backup.tar.gz
+          fi
+
+      - name: Upload uploads backup to Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: uploads-backup
+          path: /tmp/uploads-backup.tar.gz
+          retention-days: 30
       
       - name: Upload backup status
         if: always()


### PR DESCRIPTION
Closes #780 

Description:

What does this PR do?
This PR updates the existing database-backup.yml GitHub Actions workflow to include a backup of the backend/uploads/ directory alongside the PostgreSQL database dump.

Why is this necessary?
Currently, the backup workflow only creates a dump of the PostgreSQL database. However, since the application uses a local storage backend, the media and assets located in backend/uploads/ were not being backed up, which could lead to data loss of user-uploaded files in the event of a failure.

Implementation details
Added a step to check for the existence of the backend/uploads/ directory.
If it exists, the contents are compressed into a tarball (uploads-backup.tar.gz).
Added the actions/upload-artifact@v4 step to upload this tarball to GitHub Artifacts with a 30-day retention period.