### PR TITLE
Add tests for verification request status transition validation

### DIFF
--- a/backend/src/routes/verification.test.js
+++ b/backend/src/routes/verification.test.js
@@ -294,4 +294,39 @@ describe("PATCH /api/verification-requests/:id/status (admin)", () => {
       .send({ status: "shipped" });
     expect(res.status).toBe(400);
   });
+
+  test("transitions in_review \u2192 approved", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "in_review" }] })
+      .mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "approved" }] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .patch(`/api/verification-requests/${MOCK_DB_ROW.id}/status`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ status: "approved" });
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("approved");
+  });
+
+  test("rejects approved \u2192 rejected with 400 (no valid transitions out of approved)", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "approved" }] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .patch(`/api/verification-requests/${MOCK_DB_ROW.id}/status`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ status: "rejected" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Cannot transition/);
+  });
+
+  test("rejects a same-status transition (pending \u2192 pending) with 400", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "pending" }] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .patch(`/api/verification-requests/${MOCK_DB_ROW.id}/status`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ status: "pending" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Request is already in "pending" state');
+  });
 });


### PR DESCRIPTION
## What
Closes #751 — adds tests verifying that `PATCH /api/verification-requests/:id/status`
correctly enforces the `VALID_TRANSITIONS` state machine.

## Changes
- Extended the existing `describe("PATCH /api/verification-requests/:id/status
  (admin)", ...)` block in `backend/src/routes/verification.test.js` with 3
  new tests, covering the requirements from #751 not already tested:
  1. `pending → in_review` — already covered by an existing test
  2. `in_review → approved` — **new**: asserts 200 and the updated status
  3. `pending → approved` (invalid) — already covered by an existing test
  4. `approved → rejected` (no valid transitions out of `approved`) — **new**:
     asserts 400 with a "Cannot transition" error
  5. Same-status transition (`pending → pending`) — **new**: asserts 400 with
     the exact route message, `Request is already in "pending" state`

No changes were made to `verification.js` — the transition rules
(`VALID_TRANSITIONS`) and validation order are already correct; this PR is
test-only.

## Verification
Traced all 3 new tests against the actual route logic and mock sequencing
(SELECT → UPDATE for valid transitions; SELECT-only for rejected ones),
following the exact pattern of the pre-existing "pending → in_review" test
in the same file.

Note: this repo has a known, pre-existing, unrelated issue where any test
file that imports a route requiring `uuid` (including `verification.js`)
fails with `SyntaxError: Unexpected token 'export'`, because `uuid`'s
ESM-only build is `require()`'d without a Jest transform. This affects
`verification.test.js` on `main` already, independent of this PR, and is
out of scope for this test-only issue.