### PR TITLE
#767 documentation: document STORAGE_BACKEND configuration (local/s3/…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -50,5 +50,7 @@ S3_BUCKET=
 S3_PUBLIC_URL=
 
 # IPFS (only used when STORAGE_BACKEND=ipfs)
+# PINATA_JWT is required when pinning documents to IPFS via Pinata.
 IPFS_API_URL=
 IPFS_GATEWAY_URL=https://ipfs.io/ipfs
+PINATA_JWT=


### PR DESCRIPTION
## Summary
Adds the missing `PINATA_JWT` environment variable to the IPFS storage backend section of `backend/.env.example`. The file already documented `STORAGE_BACKEND` (local/s3/ipfs) along with the S3 and other IPFS variables (`IPFS_API_URL`, `IPFS_GATEWAY_URL`); this PR closes the remaining gap by adding `PINATA_JWT`, required when pinning documents to IPFS via Pinata, with an explanatory comment consistent with the file's existing documentation style.

## Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #767

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [x] Docs updated if needed

N/A — documentation-only change to an example env file; no code or contract logic touched, so no functional testing was performed.

## Screenshots (if UI change)
N/A — no UI affected.
