### PR TITLE
Add pg-boss schema migration step to docker-compose.test.yml

### DIFF
--- a/backend/src/db/pgboss-migrate.js
+++ b/backend/src/db/pgboss-migrate.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const PgBoss = require("pg-boss");
+
+async function main() {
+  const connectionString =
+    process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/greenpay";
+
+  const boss = new PgBoss(connectionString);
+  await boss.start();
+  await boss.stop({ graceful: false });
+
+  console.log("[pgboss] Schema migrated successfully");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("[pgboss] Migration failed:", err.message);
+  process.exit(1);
+});

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,6 +21,18 @@ services:
       timeout: 5s
       retries: 10
 
+  pgboss-migrate:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: test
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/greenpay_test
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: node src/db/pgboss-migrate.js
+
   backend:
     build:
       context: ./backend
@@ -38,4 +50,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      pgboss-migrate:
+        condition: service_completed_successfully
     command: npm test


### PR DESCRIPTION
## Summary

When tests import `digestQueue.js` or `profileQueue.js` without calling `boss.start()`, the `pgboss` schema may not exist in the test database because pg-boss only creates its schema automatically during `start()`.

## Changes

### New: `backend/src/db/pgboss-migrate.js`
A standalone migration script that initializes the pg-boss schema by calling `boss.start()` (which triggers pg-boss's internal schema migration) and then `boss.stop()`. This separates schema creation from worker startup.

### Updated: `docker-compose.test.yml`
- Added a new `pgboss-migrate` service that builds from the same `test` Docker stage and runs the migration script
- `pgboss-migrate` depends on `postgres` being healthy
- The `backend` (test) service now depends on `pgboss-migrate` with `condition: service_completed_successfully`, ensuring the schema exists before any test runs

## Why

- Prevents test failures when queue modules are imported but their `start()` function hasn't been called yet
- Decouples pg-boss schema creation from the queue worker lifecycle
- Follows the same pattern used by the existing `db:migrate` script for application schema migrations

Closes #776