### PR TITLE
feat(smart-contract): add get_verification_status for governance UI (…

### DIFF
--- a/contracts/greenpay-contract/src/lib.rs
+++ b/contracts/greenpay-contract/src/lib.rs
@@ -129,6 +129,17 @@ pub struct VoteProposal {
     pub resolved: bool,
 }
 
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VerificationStatus {
+    pub has_proposal: bool,
+    pub votes_for: u32,
+    pub votes_against: u32,
+    pub deadline_ledger: u32,
+    pub resolved: bool,
+    pub approved: bool,
+}
+
 /// Aggregated platform-wide counters returned by `get_global_stats`.
 ///
 /// Bundles the four values that the landing page hero section needs in a
@@ -935,6 +946,30 @@ impl GreenPayContract {
             .instance()
             .get(&DataKey::Proposal(project_id))
             .expect("Proposal not found")
+    }
+
+    pub fn get_verification_status(env: Env, project_id: String) -> VerificationStatus {
+        if env.storage().instance().has(&DataKey::Proposal(project_id.clone())) {
+            let proposal: VoteProposal = env.storage().instance().get(&DataKey::Proposal(project_id)).unwrap();
+            let approved = proposal.resolved && proposal.votes_for > proposal.votes_against;
+            VerificationStatus {
+                has_proposal: true,
+                votes_for: proposal.votes_for,
+                votes_against: proposal.votes_against,
+                deadline_ledger: proposal.deadline_ledger,
+                resolved: proposal.resolved,
+                approved,
+            }
+        } else {
+            VerificationStatus {
+                has_proposal: false,
+                votes_for: 0,
+                votes_against: 0,
+                deadline_ledger: 0,
+                resolved: false,
+                approved: false,
+            }
+        }
     }
 
     /// Returns the list of voter addresses for a proposal.


### PR DESCRIPTION
#737 smart-contract: add get_verification_status returning full governance proposal state
Closes  #737
## Summary
This PR adds the `get_verification_status` getter to the GreenPay smart contract, returning a consolidated state for governance proposals. This eliminates the need for the frontend UI to make multiple RPC round trips when rendering project verification voting states.

Key changes:
- Defined the `VerificationStatus` struct to encapsulate all proposal fields.
- Added the `get_verification_status(env: Env, project_id: String) -> VerificationStatus` getter.
- The `approved` field is dynamically calculated on-chain (`resolved == true && votes_for > votes_against`).
- Safely handles cases where a project does not yet have an active governance proposal by returning a default/empty state instead of panicking.

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Smart contract change

## Related Issue
Closes #737

## Testing
- [x] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
N/A - Smart contract backend change only.
