### PR TITLE
feat(health): add pg-boss health check endpoint (Closes #779)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,6 +30,9 @@ DB_POOL_MAX=20
 DB_POOL_IDLE_TIMEOUT=30000
 DB_POOL_CONNECT_TIMEOUT=2000
 
+# pg-boss health check — GET /api/health alerts (503) when failed jobs exceed this
+PGBOSS_MAX_FAILED_JOBS=10
+
 # Verification Request admin notification (defaults to EMAIL_FROM)
 # Used by /api/verification-requests to email admins on new submissions.
 ADMIN_NOTIFICATION_EMAIL=

--- a/backend/src/routes/health.js
+++ b/backend/src/routes/health.js
@@ -10,23 +10,56 @@ const indexerService = require("../services/indexerService");
 const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ||
   process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
 
+function getMaxFailedJobs() {
+  const parsed = Number.parseInt(process.env.PGBOSS_MAX_FAILED_JOBS ?? "10", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 10;
+}
+
 router.get("/", async (req, res) => {
   let dbStatus = "ok";
+  let failedJobs = null;
+  let pgbossStatus = "ok";
+  const maxFailedJobs = getMaxFailedJobs();
+
   try {
     await pool.query("SELECT 1");
   } catch {
     dbStatus = "unreachable";
   }
 
-  const status = dbStatus === "ok" ? "ok" : "degraded";
-  const httpStatus = dbStatus === "ok" ? 200 : 503;
+  if (dbStatus === "ok") {
+    try {
+      const result = await pool.query(
+        "SELECT COUNT(*)::int AS count FROM pgboss.job WHERE state = $1",
+        ["failed"]
+      );
+      failedJobs = result.rows[0].count;
+      if (failedJobs > maxFailedJobs) {
+        pgbossStatus = "alert";
+      }
+    } catch {
+      pgbossStatus = "unreachable";
+    }
+  } else {
+    pgbossStatus = "unreachable";
+  }
+
+  const status = dbStatus === "ok" && pgbossStatus === "ok" ? "ok" : "degraded";
+  const httpStatus = status === "ok" ? 200 : 503;
 
   res.status(httpStatus).json({
     status,
     service: "stellar-greenpay-api",
     network: process.env.STELLAR_NETWORK || "testnet",
     timestamp: new Date().toISOString(),
-    checks: { db: dbStatus },
+    checks: {
+      db: dbStatus,
+      pgboss: {
+        status: pgbossStatus,
+        failedJobs,
+        maxFailedJobs,
+      },
+    },
     indexer: indexerService.getStatus(),
   });
 });

--- a/backend/src/routes/health.test.js
+++ b/backend/src/routes/health.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({ query: jest.fn() }));
+jest.mock("../services/indexerService", () => ({
+  getStatus: jest.fn(() => ({
+    isRunning: false,
+    lastProcessedLedger: 0,
+    projectWalletsCount: 0,
+    timestamp: "2026-01-01T00:00:00.000Z",
+  })),
+}));
+
+const request = require("supertest");
+const express = require("express");
+const pool = require("../db/pool");
+const healthRouter = require("./health");
+
+function buildApp() {
+  const app = express();
+  app.use("/api/health", healthRouter);
+  return app;
+}
+
+describe("GET /api/health", () => {
+  let app;
+  const originalMaxFailed = process.env.PGBOSS_MAX_FAILED_JOBS;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+    process.env.PGBOSS_MAX_FAILED_JOBS = "5";
+  });
+
+  afterAll(() => {
+    if (originalMaxFailed === undefined) {
+      delete process.env.PGBOSS_MAX_FAILED_JOBS;
+    } else {
+      process.env.PGBOSS_MAX_FAILED_JOBS = originalMaxFailed;
+    }
+  });
+
+  test("includes pg-boss failed job count when under threshold", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ "?column?": 1 }] })
+      .mockResolvedValueOnce({ rows: [{ count: 2 }] });
+
+    const res = await request(app).get("/api/health").expect(200);
+
+    expect(res.body.status).toBe("ok");
+    expect(res.body.checks.db).toBe("ok");
+    expect(res.body.checks.pgboss).toEqual({
+      status: "ok",
+      failedJobs: 2,
+      maxFailedJobs: 5,
+    });
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      "SELECT COUNT(*)::int AS count FROM pgboss.job WHERE state = $1",
+      ["failed"]
+    );
+  });
+
+  test("returns degraded and alerts when failed jobs exceed PGBOSS_MAX_FAILED_JOBS", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ "?column?": 1 }] })
+      .mockResolvedValueOnce({ rows: [{ count: 12 }] });
+
+    const res = await request(app).get("/api/health").expect(503);
+
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.checks.pgboss).toEqual({
+      status: "alert",
+      failedJobs: 12,
+      maxFailedJobs: 5,
+    });
+  });
+
+  test("returns degraded when database is unreachable", async () => {
+    pool.query.mockRejectedValueOnce(new Error("connection refused"));
+
+    const res = await request(app).get("/api/health").expect(503);
+
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.checks.db).toBe("unreachable");
+    expect(res.body.checks.pgboss).toEqual({
+      status: "unreachable",
+      failedJobs: null,
+      maxFailedJobs: 5,
+    });
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This PR implements the pg-boss health check functionality for issue #779. The feature has been completed on branch feat/pgboss-health-check-779 and is ready for review.

What was implemented
Added a dedicated health check for pg-boss to expose the status of the background job system.
Integrated the health check into the application's health monitoring so deployments can verify pg-boss availability alongside other services.
Ensured the implementation aligns with the project's existing health check patterns and response structure.
Notes
An earlier local check reported that the GitHub CLI (gh) was not authenticated. This only affected GitHub operations such as pushing branches or creating pull requests.
The issue implementation itself was completed successfully using repository information obtained through other means.
No additional code changes are required.
Validation
Feature implementation is complete on branch feat/pgboss-health-check-779.
Push and PR creation can be completed once GitHub CLI authentication is available.

Closes #779