### PR TITLE
performance: add composite index on donations(donor_address, project_id)

### DIFF
--- a/backend/src/db/migrations/003_add_donations_composite_index.js
+++ b/backend/src/db/migrations/003_add_donations_composite_index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+  name: "003_add_donations_composite_index",
+
+  async up(client) {
+    await client.query(`CREATE INDEX CONCURRENTLY idx_donations_donor_project ON donations(donor_address, project_id)`);
+  },
+
+  async down(client) {
+    await client.query(`DROP INDEX CONCURRENTLY IF EXISTS idx_donations_donor_project`);
+  }
+};

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS donations (
   transaction_hash TEXT NOT NULL UNIQUE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+CREATE INDEX IF NOT EXISTS idx_donations_donor_project ON donations(donor_address, project_id);
 
 -- profiles: aggregated donor stats and public profile for a Stellar wallet.
 -- total_donated_xlm and projects_supported are computed counters kept in


### PR DESCRIPTION
Closes #799 
This PR adds a composite index on the `donations` table on `(donor_address, project_id)` to optimize the profile queries and the impact donor endpoint.
