### PR TITLE
Add SSRF protection for project webhook URLs

### DIFF
--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -21,6 +21,7 @@ const { enqueueAISummary } = require("../services/summaryQueue");
 const { Contract, TransactionBuilder } = require("@stellar/stellar-sdk");
 const redis = require("../services/redis");
 const { adminRequired } = require("../middleware/auth");
+const { assertPublicHttpUrl, SsrfValidationError } = require("../utils/ssrf");
 
 const PROJECTS_LIST_CACHE_TTL = 60; // seconds
 const PROJECTS_LIST_CACHE_PREFIX = "projects:list:";
@@ -1214,6 +1215,79 @@ router.patch("/:id/status", async (req, res, next) => {
     if (typeof redis.deletePattern === "function") await redis.deletePattern("stats:*");
 
     res.json({ success: true, data: mapProjectRow(result.rows[0]) });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * POST /api/projects/:id/webhook
+ *
+ * Register or update the webhook URL for milestone notifications.
+ * Body: { webhookUrl: string, adminAddress: string }
+ *
+ * Only the project owner (wallet_address === adminAddress) can set the webhook.
+ * webhookUrl is validated against SSRF (must be a public http/https address —
+ * no localhost, private ranges, or cloud metadata addresses).
+ * Returns the generated webhook secret once so the owner can verify signatures.
+ */
+router.post("/:id/webhook", async (req, res, next) => {
+  try {
+    const { webhookUrl, adminAddress } = req.body || {};
+
+    if (!adminAddress || typeof adminAddress !== "string") {
+      return res.status(400).json({ error: "adminAddress is required" });
+    }
+
+    if (!webhookUrl || typeof webhookUrl !== "string") {
+      return res.status(400).json({ error: "webhookUrl is required" });
+    }
+
+    const projectResult = await pool.query(
+      "SELECT id, wallet_address, webhook_secret FROM projects WHERE id = $1",
+      [req.params.id],
+    );
+    const project = projectResult.rows[0];
+    if (!project) return res.status(404).json({ error: "Project not found" });
+    if (project.wallet_address !== adminAddress) {
+      return res.status(403).json({ error: "Only the project owner can set a webhook" });
+    }
+
+    try {
+      await assertPublicHttpUrl(webhookUrl);
+    } catch (err) {
+      if (err instanceof SsrfValidationError) {
+        return res.status(400).json({ error: err.message });
+      }
+      throw err;
+    }
+
+    // Generate a new secret on each update
+    const webhookSecret = crypto.randomBytes(32).toString("hex");
+
+    await pool.query(
+      `UPDATE projects
+       SET webhook_url = $1, webhook_secret = $2, updated_at = NOW()
+       WHERE id = $3`,
+      [webhookUrl, webhookSecret, req.params.id],
+    );
+
+    logAdminAction({
+      actor: adminAddress,
+      action: "project.webhook.update",
+      targetType: "project",
+      targetId: req.params.id,
+      metadata: { webhookUrl },
+      ipAddress: req.ip,
+    });
+
+    res.json({
+      success: true,
+      data: {
+        webhookUrl,
+        webhookSecret,
+      },
+    });
   } catch (e) {
     next(e);
   }

--- a/backend/src/routes/projects.test.js
+++ b/backend/src/routes/projects.test.js
@@ -23,6 +23,14 @@ jest.mock("../services/summaryQueue", () => ({
   enqueueAISummary: jest.fn(),
 }));
 
+jest.mock("dns", () => ({
+  promises: {
+    resolve4: jest.fn(),
+    resolve6: jest.fn(),
+  },
+}));
+
+const dns = require("dns");
 const pool = require("../db/pool");
 const redis = require("../services/redis");
 const { server } = require("../services/stellar");
@@ -722,6 +730,105 @@ describe("GET /api/projects/:id/impact-certificate", () => {
     expect(res.body.data.donations).toHaveLength(2);
     // 300 XLM × (5000/1000 kg/XLM) = 1500 kg
     expect(res.body.data.co2OffsetKg).toBe(1500);
+  });
+});
+
+describe("POST /api/projects/:id/webhook", () => {
+  let app;
+  const OWNER_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("rejects webhook_url pointing at localhost", async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [{ id: "proj-1", wallet_address: OWNER_ADDRESS, webhook_secret: null }],
+    });
+
+    const res = await request(app)
+      .post("/api/projects/proj-1/webhook")
+      .send({ webhookUrl: "http://localhost:8080/internal", adminAddress: OWNER_ADDRESS });
+
+    expect(res.status).toBe(400);
+    // No UPDATE was issued once SSRF validation rejected the URL.
+    const updateCall = pool.query.mock.calls.find(
+      ([sql]) => typeof sql === "string" && sql.includes("UPDATE projects"),
+    );
+    expect(updateCall).toBeUndefined();
+    expect(dns.promises.resolve4).not.toHaveBeenCalled();
+  });
+
+  test("rejects webhook_url pointing at the cloud metadata IP", async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [{ id: "proj-1", wallet_address: OWNER_ADDRESS, webhook_secret: null }],
+    });
+
+    const res = await request(app)
+      .post("/api/projects/proj-1/webhook")
+      .send({ webhookUrl: "http://169.254.169.254/metadata", adminAddress: OWNER_ADDRESS });
+
+    expect(res.status).toBe(400);
+    const updateCall = pool.query.mock.calls.find(
+      ([sql]) => typeof sql === "string" && sql.includes("UPDATE projects"),
+    );
+    expect(updateCall).toBeUndefined();
+  });
+
+  test("accepts a legitimate external webhook_url", async () => {
+    dns.promises.resolve4.mockResolvedValue(["104.21.0.1"]);
+    dns.promises.resolve6.mockRejectedValue(new Error("ENODATA"));
+    pool.query.mockResolvedValueOnce({
+      rows: [{ id: "proj-1", wallet_address: OWNER_ADDRESS, webhook_secret: null }],
+    });
+    pool.query.mockResolvedValueOnce({ rows: [] }); // UPDATE
+
+    const res = await request(app)
+      .post("/api/projects/proj-1/webhook")
+      .send({ webhookUrl: "https://webhook.site/xyz", adminAddress: OWNER_ADDRESS });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.webhookUrl).toBe("https://webhook.site/xyz");
+    expect(res.body.data.webhookSecret).toEqual(expect.any(String));
+
+    const updateCall = pool.query.mock.calls.find(
+      ([sql]) => typeof sql === "string" && sql.includes("UPDATE projects"),
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall[1][0]).toBe("https://webhook.site/xyz");
+  });
+
+  test("returns 400 when webhookUrl is missing", async () => {
+    const res = await request(app)
+      .post("/api/projects/proj-1/webhook")
+      .send({ adminAddress: OWNER_ADDRESS });
+
+    expect(res.status).toBe(400);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when the project does not exist", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post("/api/projects/missing/webhook")
+      .send({ webhookUrl: "https://webhook.site/xyz", adminAddress: OWNER_ADDRESS });
+
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 403 when adminAddress does not match the project owner", async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [{ id: "proj-1", wallet_address: OWNER_ADDRESS, webhook_secret: null }],
+    });
+
+    const res = await request(app)
+      .post("/api/projects/proj-1/webhook")
+      .send({ webhookUrl: "https://webhook.site/xyz", adminAddress: "GDIFFERENTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" });
+
+    expect(res.status).toBe(403);
   });
 });
 

--- a/backend/src/services/webhook.js
+++ b/backend/src/services/webhook.js
@@ -9,15 +9,36 @@ const https = require("https");
 const http = require("http");
 const pool = require("../db/pool");
 const logger = require("../logger");
+const { assertPublicHttpUrl } = require("../utils/ssrf");
 
 /**
  * POST a signed JSON payload to a webhook URL.
+ *
+ * Re-validates the URL against SSRF (private IPs, localhost, cloud metadata
+ * addresses) on every delivery, not just at registration time, since DNS
+ * answers can change between when a webhook was registered and when it's
+ * actually delivered.
  *
  * @param {string} url    - The webhook URL to deliver to.
  * @param {string} secret - HMAC-SHA256 secret for signing.
  * @param {object} payload - The JSON body to send.
  */
-function deliverPayload(url, secret, payload) {
+async function deliverPayload(url, secret, payload) {
+  try {
+    await assertPublicHttpUrl(url);
+  } catch (err) {
+    // Never reject: this is called fire-and-forget (no await/catch at the
+    // call site in checkAndDeliverMilestones), so any rejection here would
+    // become an unhandled promise rejection.
+    logger.error({
+      event: "webhook_blocked_ssrf",
+      url,
+      err: err.message,
+      payload: { projectId: payload.projectId, milestone: payload.milestone },
+    }, "Webhook delivery blocked by SSRF protection");
+    return;
+  }
+
   const body = JSON.stringify(payload);
   const signature = crypto
     .createHmac("sha256", secret)
@@ -158,3 +179,8 @@ async function checkAndDeliverMilestones(projectId) {
 module.exports = {
   checkAndDeliverMilestones,
 };
+
+// Export internal functions for testing
+if (process.env.NODE_ENV === "test") {
+  module.exports.deliverPayload = deliverPayload;
+}

--- a/backend/src/services/webhook.test.js
+++ b/backend/src/services/webhook.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+process.env.NODE_ENV = "test";
+
+jest.mock("../db/pool", () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+jest.mock("../logger", () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("http", () => ({ request: jest.fn() }));
+jest.mock("https", () => ({ request: jest.fn() }));
+
+jest.mock("dns", () => ({
+  promises: {
+    resolve4: jest.fn(),
+    resolve6: jest.fn(),
+  },
+}));
+
+const dns = require("dns");
+const http = require("http");
+const https = require("https");
+const logger = require("../logger");
+const { deliverPayload } = require("./webhook");
+
+function mockRequest(lib) {
+  const req = {
+    on: jest.fn().mockReturnThis(),
+    write: jest.fn(),
+    end: jest.fn(),
+  };
+  lib.request.mockReturnValue(req);
+  return req;
+}
+
+describe("deliverPayload SSRF defense-in-depth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("blocks delivery to a private/blocked address and never makes an outbound request", async () => {
+    const req = mockRequest(https);
+
+    await deliverPayload(
+      "http://169.254.169.254/metadata",
+      "secret",
+      { projectId: "proj-1", milestone: "50%" },
+    );
+
+    expect(https.request).not.toHaveBeenCalled();
+    expect(http.request).not.toHaveBeenCalled();
+    expect(req.write).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "webhook_blocked_ssrf" }),
+      expect.any(String),
+    );
+  });
+
+  test("blocks delivery to localhost", async () => {
+    mockRequest(http);
+
+    await deliverPayload("http://localhost:8080/internal", "secret", {
+      projectId: "proj-1",
+      milestone: "50%",
+    });
+
+    expect(http.request).not.toHaveBeenCalled();
+    expect(https.request).not.toHaveBeenCalled();
+  });
+
+  test("does not reject even when the URL is blocked (fire-and-forget safe)", async () => {
+    await expect(
+      deliverPayload("http://127.0.0.1/", "secret", { projectId: "p", milestone: "m" }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("delivers normally to a public URL", async () => {
+    dns.promises.resolve4.mockResolvedValue(["104.21.0.1"]);
+    dns.promises.resolve6.mockRejectedValue(new Error("ENODATA"));
+    const req = mockRequest(https);
+
+    await deliverPayload("https://webhook.site/xyz", "secret", {
+      projectId: "proj-1",
+      milestone: "50%",
+    });
+
+    expect(https.request).toHaveBeenCalledTimes(1);
+    expect(req.write).toHaveBeenCalledTimes(1);
+    expect(req.end).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({ event: "webhook_blocked_ssrf" }),
+      expect.any(String),
+    );
+  });
+});

--- a/backend/src/utils/ssrf.js
+++ b/backend/src/utils/ssrf.js
@@ -1,0 +1,149 @@
+/**
+ * backend/src/utils/ssrf.js
+ * SSRF guard for outbound webhook URLs: blocks localhost, private/reserved
+ * IP ranges, and cloud metadata addresses (e.g. 169.254.169.254).
+ */
+"use strict";
+
+const net = require("net");
+
+class SsrfValidationError extends Error {}
+
+const BARE_NUMERIC_HOST_RE = /^(0x[0-9a-f]+|[0-9]+)$/i;
+
+function ipv4ToLong(ip) {
+  return ip
+    .split(".")
+    .reduce((acc, octet) => (acc << 8) + Number.parseInt(octet, 10), 0) >>> 0;
+}
+
+function ipv4InRange(ip, base, prefixLength) {
+  const mask = prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0;
+  return (ipv4ToLong(ip) & mask) === (ipv4ToLong(base) & mask);
+}
+
+const IPV4_BLOCKED_RANGES = [
+  ["127.0.0.0", 8], // loopback
+  ["0.0.0.0", 8], // "this" network / unspecified
+  ["10.0.0.0", 8], // RFC1918
+  ["172.16.0.0", 12], // RFC1918
+  ["192.168.0.0", 16], // RFC1918
+  ["169.254.0.0", 16], // link-local (covers 169.254.169.254 metadata IP)
+  ["100.64.0.0", 10], // CGNAT
+];
+
+function isBlockedIpv4(ip) {
+  return IPV4_BLOCKED_RANGES.some(([base, prefix]) => ipv4InRange(ip, base, prefix));
+}
+
+/** Expand a valid IPv6 address (no zone id, no brackets) into its 8 hex groups. */
+function expandIpv6Groups(ip) {
+  const [headStr, tailStr] = ip.includes("::") ? ip.split("::") : [ip, undefined];
+  const headParts = headStr ? headStr.split(":") : [];
+  const tailParts = tailStr ? tailStr.split(":") : [];
+  const missing = 8 - (headParts.length + tailParts.length);
+  const zeros = new Array(Math.max(missing, 0)).fill("0");
+  return [...headParts, ...zeros, ...tailParts];
+}
+
+/** Extract the embedded IPv4 address from an IPv4-mapped IPv6 address, or null. */
+function extractMappedIpv4(groups) {
+  const isMapped = groups.slice(0, 5).every((g) => Number.parseInt(g || "0", 16) === 0) &&
+    Number.parseInt(groups[5] || "0", 16) === 0xffff;
+  if (!isMapped) return null;
+  const high = Number.parseInt(groups[6] || "0", 16);
+  const low = Number.parseInt(groups[7] || "0", 16);
+  return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join(".");
+}
+
+function isBlockedIpv6(ip) {
+  const lower = ip.toLowerCase();
+
+  // The "::ffff:a.b.c.d" dotted-quad shorthand mixes a literal IPv4 address
+  // into what is otherwise a colon-separated hex-group address, so it must
+  // be detected before generic group expansion (which assumes every segment
+  // is a hex group).
+  const dottedMapped = lower.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dottedMapped) return isBlockedIpv4(dottedMapped[1]);
+
+  const groups = expandIpv6Groups(lower);
+  const mappedV4 = extractMappedIpv4(groups);
+  if (mappedV4) return isBlockedIpv4(mappedV4);
+  if (groups.every((g) => Number.parseInt(g || "0", 16) === 0)) return true; // ::
+  if (groups.slice(0, 7).every((g) => Number.parseInt(g || "0", 16) === 0) && groups[7] === "1") return true; // ::1
+  const first = Number.parseInt(groups[0] || "0", 16);
+  if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  return false;
+}
+
+function isPrivateOrReservedIp(ip) {
+  const type = net.isIP(ip);
+  if (type === 4) return isBlockedIpv4(ip);
+  if (type === 6) return isBlockedIpv6(ip);
+  return true; // not a valid IP at all — treat as unsafe
+}
+
+async function resolveAllIps(hostname, dnsResolver) {
+  const [v4, v6] = await Promise.all([
+    dnsResolver.resolve4(hostname).catch(() => []),
+    dnsResolver.resolve6(hostname).catch(() => []),
+  ]);
+  const addresses = [...v4, ...v6];
+  if (addresses.length === 0) {
+    throw new SsrfValidationError(`Could not resolve hostname: ${hostname}`);
+  }
+  return addresses;
+}
+
+/**
+ * Throws SsrfValidationError if the URL is not a safe, publicly-routable
+ * http/https destination. Resolves with no value on success.
+ */
+async function assertPublicHttpUrl(rawUrl, dnsResolver = require("dns").promises) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new SsrfValidationError("Invalid URL");
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new SsrfValidationError("URL must use http or https");
+  }
+
+  if (url.hostname.includes("%")) {
+    throw new SsrfValidationError("IPv6 zone identifiers are not allowed");
+  }
+
+  // WHATWG URL keeps brackets around IPv6 literals in `.hostname` (e.g. "[::1]").
+  const hostname =
+    url.hostname.startsWith("[") && url.hostname.endsWith("]")
+      ? url.hostname.slice(1, -1)
+      : url.hostname;
+
+  const ipType = net.isIP(hostname);
+  if (ipType) {
+    if (isPrivateOrReservedIp(hostname)) {
+      throw new SsrfValidationError(`Blocked private/reserved IP: ${hostname}`);
+    }
+    return;
+  }
+
+  if (hostname.toLowerCase() === "localhost") {
+    throw new SsrfValidationError("localhost is not allowed");
+  }
+
+  if (BARE_NUMERIC_HOST_RE.test(hostname)) {
+    throw new SsrfValidationError("Numeric IP obfuscation is not allowed");
+  }
+
+  const addresses = await resolveAllIps(hostname, dnsResolver);
+  for (const ip of addresses) {
+    if (isPrivateOrReservedIp(ip)) {
+      throw new SsrfValidationError(`Hostname resolves to blocked address: ${ip}`);
+    }
+  }
+}
+
+module.exports = { assertPublicHttpUrl, isPrivateOrReservedIp, SsrfValidationError };

--- a/backend/src/utils/ssrf.test.js
+++ b/backend/src/utils/ssrf.test.js
@@ -1,0 +1,121 @@
+"use strict";
+
+jest.mock("dns", () => ({
+  promises: {
+    resolve4: jest.fn(),
+    resolve6: jest.fn(),
+  },
+}));
+
+const dns = require("dns");
+const { assertPublicHttpUrl, isPrivateOrReservedIp, SsrfValidationError } = require("./ssrf");
+
+describe("isPrivateOrReservedIp", () => {
+  test.each([
+    ["127.0.0.1", true],
+    ["127.255.255.255", true],
+    ["169.254.169.254", true], // cloud metadata IP
+    ["10.0.0.5", true],
+    ["172.16.0.1", true],
+    ["172.31.255.255", true],
+    ["192.168.1.1", true],
+    ["0.0.0.0", true],
+    ["100.64.0.1", true],
+    ["::1", true],
+    ["::", true],
+    ["fe80::1", true],
+    ["fc00::1", true],
+    ["fd12:3456::1", true],
+    ["::ffff:127.0.0.1", true],
+    ["8.8.8.8", false],
+    ["1.1.1.1", false],
+    ["93.184.216.34", false],
+    ["2606:4700:4700::1111", false],
+  ])("%s -> blocked=%s", (ip, expected) => {
+    expect(isPrivateOrReservedIp(ip)).toBe(expected);
+  });
+});
+
+describe("assertPublicHttpUrl", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("rejects http://localhost:8080/internal", async () => {
+    await expect(assertPublicHttpUrl("http://localhost:8080/internal")).rejects.toThrow(
+      SsrfValidationError,
+    );
+    expect(dns.promises.resolve4).not.toHaveBeenCalled();
+  });
+
+  test("rejects http://169.254.169.254/metadata", async () => {
+    await expect(assertPublicHttpUrl("http://169.254.169.254/metadata")).rejects.toThrow(
+      SsrfValidationError,
+    );
+    expect(dns.promises.resolve4).not.toHaveBeenCalled();
+  });
+
+  test("rejects loopback IP literal", async () => {
+    await expect(assertPublicHttpUrl("http://127.0.0.1/x")).rejects.toThrow(SsrfValidationError);
+  });
+
+  test("rejects IPv6 loopback literal", async () => {
+    await expect(assertPublicHttpUrl("http://[::1]/x")).rejects.toThrow(SsrfValidationError);
+  });
+
+  test("rejects RFC1918 ranges", async () => {
+    await expect(assertPublicHttpUrl("http://10.1.2.3/")).rejects.toThrow(SsrfValidationError);
+    await expect(assertPublicHttpUrl("http://172.16.5.5/")).rejects.toThrow(SsrfValidationError);
+    await expect(assertPublicHttpUrl("http://192.168.0.1/")).rejects.toThrow(SsrfValidationError);
+  });
+
+  test("rejects IPv6 unique-local and link-local literals", async () => {
+    await expect(assertPublicHttpUrl("http://[fc00::1]/")).rejects.toThrow(SsrfValidationError);
+    await expect(assertPublicHttpUrl("http://[fe80::1]/")).rejects.toThrow(SsrfValidationError);
+  });
+
+  test("rejects IPv4-mapped IPv6 loopback", async () => {
+    await expect(assertPublicHttpUrl("http://[::ffff:127.0.0.1]/")).rejects.toThrow(
+      SsrfValidationError,
+    );
+  });
+
+  test("rejects decimal IP obfuscation", async () => {
+    await expect(assertPublicHttpUrl("http://2130706433/")).rejects.toThrow(SsrfValidationError);
+  });
+
+  test("rejects non-http(s) schemes", async () => {
+    await expect(assertPublicHttpUrl("file:///etc/passwd")).rejects.toThrow(SsrfValidationError);
+    await expect(assertPublicHttpUrl("javascript:alert(1)")).rejects.toThrow(SsrfValidationError);
+  });
+
+  test("rejects an invalid URL string", async () => {
+    await expect(assertPublicHttpUrl("not a url")).rejects.toThrow(SsrfValidationError);
+  });
+
+  test("rejects a hostname that only resolves to blocked addresses", async () => {
+    dns.promises.resolve4.mockResolvedValue(["169.254.169.254"]);
+    dns.promises.resolve6.mockRejectedValue(new Error("ENODATA"));
+    await expect(assertPublicHttpUrl("http://internal.example.com/")).rejects.toThrow(
+      SsrfValidationError,
+    );
+  });
+
+  test("rejects a hostname that fails to resolve entirely", async () => {
+    dns.promises.resolve4.mockRejectedValue(new Error("ENOTFOUND"));
+    dns.promises.resolve6.mockRejectedValue(new Error("ENOTFOUND"));
+    await expect(assertPublicHttpUrl("http://does-not-exist.invalid/")).rejects.toThrow(
+      SsrfValidationError,
+    );
+  });
+
+  test("accepts a hostname that resolves to a public IP (e.g. webhook.site)", async () => {
+    dns.promises.resolve4.mockResolvedValue(["104.21.0.1"]);
+    dns.promises.resolve6.mockRejectedValue(new Error("ENODATA"));
+    await expect(assertPublicHttpUrl("https://webhook.site/xyz")).resolves.toBeUndefined();
+  });
+
+  test("accepts a public IP literal", async () => {
+    await expect(assertPublicHttpUrl("https://8.8.8.8/")).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Adds SSRF protection for project webhook URLs (`webhook_url` on `projects`), which previously had none — `deliverPayload()` would send outbound requests to any address, including `localhost`, private/RFC1918 ranges, and the cloud metadata IP (`169.254.169.254`). Also restores the `POST /api/projects/:id/webhook` registration route, which had been silently dropped from `projects.js` in an earlier merge.

Changes:
- `backend/src/utils/ssrf.js` (new): `assertPublicHttpUrl()` rejects localhost, RFC1918/loopback/link-local ranges, the cloud metadata IP, IPv6 equivalents (`::1`, `fe80::/10`, `fc00::/7`), IPv4-mapped IPv6, and decimal/hex IP obfuscation. Resolves hostnames via `dns.promises` (never `dns.lookup`, to avoid `/etc/hosts` bypass).
- `backend/src/routes/projects.js`: restores `POST /:id/webhook`, now validating `webhookUrl` with the new SSRF guard before persisting it.
- `backend/src/services/webhook.js`: `deliverPayload()` re-validates the URL on every delivery (not just at registration), closing the DNS-rebinding/TOCTOU gap between registering a webhook and it firing later. Fails safe — logs and skips rather than throwing, since it's called fire-and-forget.
- Tests covering both the utility and the two integration points, including the specific cases: `http://localhost:8080/internal` and `http://169.254.169.254/metadata` rejected, a legitimate external URL (e.g. `https://webhook.site/xyz`) accepted.

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #762

## Testing
- [ ] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [ ] Docs updated if needed

`backend/src/utils/ssrf.test.js` and `backend/src/services/webhook.test.js` run and pass locally (37 tests). `backend/src/routes/projects.test.js` could not be executed locally due to a **pre-existing, unrelated** issue: the repo's pinned `uuid@14.0.1` is ESM-only while `projects.js` uses CommonJS `require("uuid")`, which breaks Jest module loading for that file (and 7 other test suites) regardless of this change — confirmed via `git diff` that this predates this PR. The new webhook-route tests were verified by manual code review instead. Flagging this separately as it blocks the full test suite and may be worth its own fix.

## Screenshots (if UI change)
N/A — backend-only change, no UI affected.
