### PR TITLE
fix: include USDC donations in CO₂ offset calculation across all impact endpoints

### DIFF
--- a/backend/src/routes/impact.js
+++ b/backend/src/routes/impact.js
@@ -57,11 +57,10 @@ router.get("/project/:id", async (req, res, next) => {
 
     const aggResult = await pool.query(
       `SELECT
-        COALESCE(SUM(d.amount_xlm), 0) AS "totalDonationsXLM",
+        COALESCE(SUM(COALESCE(d.amount_xlm, d.amount)), 0) AS "totalDonationsXLM",
         COUNT(DISTINCT d.donor_address)::int AS "donorCount"
        FROM donations d
-       WHERE d.project_id = $1
-         AND (d.currency = 'XLM' OR d.currency IS NULL)`,
+       WHERE d.project_id = $1`,
       [req.params.id],
     );
 
@@ -97,12 +96,12 @@ router.get("/global", async (req, res, next) => {
 
     const totalsResult = await pool.query(
       `SELECT
-        COALESCE(SUM(d.amount_xlm), 0) AS "totalDonationsXLM",
+        COALESCE(SUM(COALESCE(d.amount_xlm, d.amount)), 0) AS "totalDonationsXLM",
         COUNT(DISTINCT d.donor_address)::int AS "donorCount",
         COALESCE(
           SUM(
             CASE
-              WHEN p.raised_xlm > 0 THEN (d.amount_xlm * (p.co2_offset_kg::numeric / p.raised_xlm))
+              WHEN p.raised_xlm > 0 THEN (COALESCE(d.amount_xlm, d.amount) * (p.co2_offset_kg::numeric / p.raised_xlm))
               ELSE 0
             END
           ),
@@ -110,18 +109,18 @@ router.get("/global", async (req, res, next) => {
         ) AS "co2OffsetKg"
        FROM donations d
        JOIN projects p ON p.id = d.project_id
-       WHERE (d.currency = 'XLM' OR d.currency IS NULL)`,
+`,
     );
 
     const breakdownResult = await pool.query(
       `SELECT
         p.category AS category,
-        COALESCE(SUM(d.amount_xlm), 0) AS "totalDonationsXLM",
+        COALESCE(SUM(COALESCE(d.amount_xlm, d.amount)), 0) AS "totalDonationsXLM",
         COUNT(DISTINCT d.donor_address)::int AS "donorCount",
         COALESCE(
           SUM(
             CASE
-              WHEN p.raised_xlm > 0 THEN (d.amount_xlm * (p.co2_offset_kg::numeric / p.raised_xlm))
+              WHEN p.raised_xlm > 0 THEN (COALESCE(d.amount_xlm, d.amount) * (p.co2_offset_kg::numeric / p.raised_xlm))
               ELSE 0
             END
           ),
@@ -129,7 +128,6 @@ router.get("/global", async (req, res, next) => {
         ) AS "co2OffsetKg"
        FROM donations d
        JOIN projects p ON p.id = d.project_id
-       WHERE (d.currency = 'XLM' OR d.currency IS NULL)
        GROUP BY p.category
        ORDER BY "totalDonationsXLM" DESC, p.category ASC`,
     );
@@ -172,12 +170,12 @@ router.get("/donor/:publicKey", async (req, res, next) => {
 
     const totalsResult = await pool.query(
       `SELECT
-        COALESCE(SUM(d.amount_xlm), 0) AS "totalDonatedXLM",
+        COALESCE(SUM(COALESCE(d.amount_xlm, d.amount)), 0) AS "totalDonatedXLM",
         COUNT(DISTINCT d.project_id)::int AS "projectsSupported",
         COALESCE(
           SUM(
             CASE
-              WHEN p.raised_xlm > 0 THEN (d.amount_xlm * (p.co2_offset_kg::numeric / p.raised_xlm))
+              WHEN p.raised_xlm > 0 THEN (COALESCE(d.amount_xlm, d.amount) * (p.co2_offset_kg::numeric / p.raised_xlm))
               ELSE 0
             END
           ),
@@ -185,19 +183,17 @@ router.get("/donor/:publicKey", async (req, res, next) => {
         ) AS "co2OffsetKg"
        FROM donations d
        JOIN projects p ON p.id = d.project_id
-       WHERE d.donor_address = $1
-         AND (d.currency = 'XLM' OR d.currency IS NULL)`,
+       WHERE d.donor_address = $1`,
       [req.params.publicKey],
     );
 
     const topCategoryResult = await pool.query(
       `SELECT
         p.category AS category,
-        COALESCE(SUM(d.amount_xlm), 0) AS total
+        COALESCE(SUM(COALESCE(d.amount_xlm, d.amount)), 0) AS total
        FROM donations d
        JOIN projects p ON p.id = d.project_id
        WHERE d.donor_address = $1
-         AND (d.currency = 'XLM' OR d.currency IS NULL)
        GROUP BY p.category
        ORDER BY total DESC
        LIMIT 1`,


### PR DESCRIPTION
## Description

Closes #671

The `GET /api/impact/global` (and other impact endpoints) were filtering donations with `WHERE (d.currency = 'XLM' OR d.currency IS NULL)`, which **excluded USDC donations** from the CO₂ offset calculation. This understated total platform impact for projects that accept USDC.

### Changes

1. **Removed the currency filter** from all 5 queries across `GET /api/impact/project/:id`, `GET /api/impact/global`, and `GET /api/impact/donor/:publicKey` — now includes USDC and any other currency donations.

2. **Added NULL-safe amount handling** — replaced bare `d.amount_xlm` with `COALESCE(d.amount_xlm, d.amount)` so donations where the XLM-equivalent was not stored still contribute using their original amount.

### Why this works

The `donations` table stores the XLM-equivalent value in `amount_xlm` regardless of the original currency. Removing the currency filter lets all donations (XLM, USDC, etc.) contribute to the totals. The `COALESCE` safely falls back to `amount` when `amount_xlm` is NULL.

### Endpoints affected

- `GET /api/impact/project/:id`
- `GET /api/impact/global` (totals + breakdownByCategory)
- `GET /api/impact/donor/:publicKey` (totals + topCategory)