### PR TITLE
feat: add recurring donation reminder push notification

### DIFF
--- a/backend/src/db/migrations/003_recurring_donations.js
+++ b/backend/src/db/migrations/003_recurring_donations.js
@@ -1,0 +1,43 @@
+/**
+ * 003_recurring_donations.js — Recurring donation schedules
+ *
+ * Adds a recurring_donations table so that donors can set up weekly,
+ * bi-weekly, or monthly recurring donations to their favourite projects.
+ * The recurring-donation reminder queue (recurringDonationQueue.js) polls
+ * next_due_date daily and sends push notifications when a payment is
+ * due within the next 24 hours.
+ */
+"use strict";
+
+module.exports = {
+  name: "003_recurring_donations",
+
+  async up(client) {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS recurring_donations (
+        id UUID PRIMARY KEY,
+        project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        donor_address TEXT NOT NULL,
+        amount_xlm NUMERIC(20, 7) NOT NULL,
+        frequency TEXT NOT NULL DEFAULT 'monthly'
+          CHECK (frequency IN ('weekly', 'biweekly', 'monthly')),
+        next_due_date TIMESTAMPTZ NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active'
+          CHECK (status IN ('active', 'paused', 'cancelled')),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_recurring_donations_next_due
+        ON recurring_donations (next_due_date)
+        WHERE status = 'active'
+    `);
+  },
+
+  async down(client) {
+    await client.query("DROP INDEX IF EXISTS idx_recurring_donations_next_due");
+    await client.query("DROP TABLE IF EXISTS recurring_donations");
+  },
+};

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -170,6 +170,24 @@ CREATE TABLE IF NOT EXISTS device_tokens (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- recurring_donations: recurring donation schedules set by donors.
+-- next_due_date is calculated from the schedule when the donation is created
+-- or renewed; the recurring-donation queue polls this column daily.
+CREATE TABLE IF NOT EXISTS recurring_donations (
+  id UUID PRIMARY KEY,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  donor_address TEXT NOT NULL,
+  amount_xlm NUMERIC(20, 7) NOT NULL,
+  frequency TEXT NOT NULL DEFAULT 'monthly' CHECK (frequency IN ('weekly', 'biweekly', 'monthly')),
+  next_due_date TIMESTAMPTZ NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'paused', 'cancelled')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_recurring_donations_next_due
+  ON recurring_donations (next_due_date)
+  WHERE status = 'active';
+
 -- project_follows: many-to-many join between projects and device_tokens.
 -- A device "follows" a project to receive push notifications.
 -- UNIQUE(project_id, device_token_id) prevents duplicate follows.

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,6 +18,7 @@ const http = require("http");
 const { Server } = require("socket.io");
 const { start: startSummaryQueue } = require("./services/summaryQueue");
 const { start: startProfileQueue } = require("./services/profileQueue");
+const { start: startRecurringDonationQueue } = require("./services/recurringDonationQueue");
 const { startIndexer } = require("./services/indexerService");
 const { createCorsMiddleware, getAllowedOrigins } = require("./middleware/corsPolicy");
 
@@ -107,6 +108,7 @@ async function startServer() {
 
   const { start: startDigestQueue } = require("./services/digestQueue");
   await startDigestQueue();
+  await startRecurringDonationQueue();
 
   startIndexer(io).catch(err => logger.error({ event: "indexer_startup_error", err }, err.message));
 

--- a/backend/src/services/push.js
+++ b/backend/src/services/push.js
@@ -9,7 +9,42 @@ const pool = require("../db/pool");
 const expo = new Expo();
 
 /**
- * Send push notification to device tokens following a project
+ * Push a single message to a single Expo push token.
+ * Validates the token before sending.
+ *
+ * @param {string}  token  - Expo push token
+ * @param {string}  title  - Notification title
+ * @param {string}  body   - Notification body
+ * @param {object}  [data] - Optional payload data
+ */
+async function sendPushToToken(token, title, body, data = {}) {
+  if (!Expo.isExpoPushToken(token)) {
+    console.error(`[Push] Invalid expo push token: ${token}`);
+    return;
+  }
+
+  const message = {
+    to: token,
+    sound: "default",
+    title,
+    body,
+    data,
+  };
+
+  try {
+    const chunk = expo.chunkPushNotifications([message]);
+    if (chunk.length > 0) {
+      await expo.sendPushNotificationsAsync(chunk[0]);
+      console.log(`[Push] Sent notification to token ${token.slice(0, 16)}...`);
+    }
+  } catch (error) {
+    console.error("[Push] Error sending to token:", error);
+  }
+}
+
+/**
+ * Send push notifications to all device tokens following a project.
+ *
  * @param {Object} params - { project, update }
  */
 async function sendUpdatePushNotifications({ project, update }) {
@@ -65,6 +100,44 @@ async function sendUpdatePushNotifications({ project, update }) {
   }
 }
 
+/**
+ * Send a recurring-donation reminder push notification to a donor.
+ * Looks up the donor's registered device tokens and sends the reminder.
+ *
+ * @param {string} donorAddress - Stellar wallet address of the donor
+ * @param {string} projectName  - Name of the project
+ * @param {number} amountXlm    - Donation amount in XLM
+ * @param {string} projectId    - Project UUID (for deep-link data)
+ */
+async function sendRecurringReminder(donorAddress, projectName, amountXlm, projectId) {
+  try {
+    const result = await pool.query(
+      "SELECT token FROM device_tokens WHERE wallet_address = $1",
+      [donorAddress],
+    );
+
+    if (result.rows.length === 0) {
+      console.log(`[Push] No device tokens for donor ${donorAddress.slice(0, 8)}...`);
+      return;
+    }
+
+    const title = "Recurring Donation Reminder";
+    const body = "Your " + amountXlm + " XLM donation to " + projectName + " is due tomorrow. Tap to donate.";
+    const data = {
+      projectId,
+      type: "recurring_reminder",
+    };
+
+    for (const row of result.rows) {
+      await sendPushToToken(row.token, title, body, data);
+    }
+  } catch (error) {
+    console.error("[Push] Error sending recurring reminder:", error);
+  }
+}
+
 module.exports = {
+  sendPushToToken,
   sendUpdatePushNotifications,
+  sendRecurringReminder,
 };

--- a/backend/src/services/recurringDonationQueue.js
+++ b/backend/src/services/recurringDonationQueue.js
@@ -1,0 +1,116 @@
+/**
+ * src/services/recurringDonationQueue.js
+ *
+ * Daily pg-boss cron job that queries recurring_donations where the next
+ * due date is within the next 24 hours and sends a push notification
+ * reminder via the push.js service.
+ *
+ * The cron schedule is controlled by the RECURRING_REMINDER_CRON env var
+ * (default: daily at 09:00 UTC). Set RECURRING_REMINDER_CRON="disabled" to
+ * turn it off entirely.
+ */
+"use strict";
+
+const PgBoss = require("pg-boss");
+const pool = require("../db/pool");
+const logger = require("../logger");
+const { sendRecurringReminder } = require("./push");
+
+const QUEUE = "recurring-donation-reminder";
+// Default: daily at 09:00 UTC
+const DEFAULT_CRON = "0 9 * * *";
+
+let boss = null;
+
+/**
+ * Run the recurring-donation reminder check.
+ * Queries active recurring donations due within the next 24 hours and sends
+ * push notifications to the donor's registered device tokens.
+ */
+async function runReminderCheck() {
+  logger.info({ event: "recurring_reminder_run_start" }, "[recurringDonationQueue] Starting reminder check");
+
+  const result = await pool.query(
+    `SELECT rd.id, rd.donor_address, rd.amount_xlm, rd.frequency,
+            p.id AS project_id, p.name AS project_name
+     FROM recurring_donations rd
+     JOIN projects p ON p.id = rd.project_id
+     WHERE rd.status = 'active'
+       AND rd.next_due_date BETWEEN NOW() AND NOW() + INTERVAL '24 hours'`,
+  );
+
+  if (result.rows.length === 0) {
+    logger.info({ event: "recurring_reminder_no_donations" }, "[recurringDonationQueue] No donations due in the next 24 hours");
+    return;
+  }
+
+  let sent = 0;
+  let errors = 0;
+
+  for (const row of result.rows) {
+    try {
+      await sendRecurringReminder(
+        row.donor_address,
+        row.project_name,
+        Number.parseFloat(row.amount_xlm),
+        row.project_id,
+      );
+      sent++;
+      logger.info({
+        event: "recurring_reminder_sent",
+        recurringDonationId: row.id,
+        donorAddress: row.donor_address,
+        projectId: row.project_id,
+      }, "[recurringDonationQueue] Reminder sent");
+    } catch (err) {
+      errors++;
+      logger.error({
+        event: "recurring_reminder_error",
+        recurringDonationId: row.id,
+        err: err.message,
+      }, "[recurringDonationQueue] Failed to send reminder");
+    }
+  }
+
+  logger.info({
+    event: "recurring_reminder_run_complete",
+    sent,
+    errors,
+  }, `[recurringDonationQueue] Reminder check complete — ${sent} sent, ${errors} errors`);
+}
+
+/**
+ * Start the pg-boss scheduler and register the recurring-donation reminder
+ * worker. Safe to call multiple times (guards with module-level `boss`).
+ */
+async function start() {
+  const cronOverride = process.env.RECURRING_REMINDER_CRON;
+  if (cronOverride === "disabled") {
+    logger.info({ event: "recurring_reminder_disabled" }, "[recurringDonationQueue] Reminder queue disabled via env");
+    return;
+  }
+
+  const cronSchedule = cronOverride || DEFAULT_CRON;
+  const connectionString =
+    process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/greenpay";
+
+  boss = new PgBoss(connectionString);
+  boss.on("error", (err) => logger.error({ event: "recurring_reminder_pgboss_error", err }, err.message));
+
+  await boss.start();
+
+  // Register the cron schedule (idempotent — pg-boss deduplicates by name)
+  await boss.schedule(QUEUE, cronSchedule, {}, { tz: "UTC" });
+
+  // Register the worker
+  await boss.work(QUEUE, { teamSize: 1, teamConcurrency: 1 }, async () => {
+    await runReminderCheck();
+  });
+
+  logger.info({
+    event: "recurring_reminder_scheduled",
+    cron: cronSchedule,
+  }, `[recurringDonationQueue] Recurring donation reminder scheduled: ${cronSchedule}`);
+}
+
+module.exports = { start, runReminderCheck };


### PR DESCRIPTION
Closes #717

## Summary

Adds a daily pg-boss cron job that sends push notification reminders to donors when their recurring donation is due within the next 24 hours.

## Changes

### `backend/src/db/schema.sql` + `backend/src/db/migrations/003_recurring_donations.js` (new)
- New `recurring_donations` table with columns: `id`, `project_id`, `donor_address`, `amount_xlm`, `frequency` (weekly/biweekly/monthly), `next_due_date`, `status` (active/paused/cancelled)
- Partial index: `idx_recurring_donations_next_due` on `next_due_date WHERE status = 'active'` for efficient polling

### `backend/src/services/push.js`
- New `sendPushToToken(token, title, body, data)` — reusable helper for sending a single Expo push notification
- New `sendRecurringReminder(donorAddress, projectName, amountXlm, projectId)` — looks up the donor's registered device tokens by wallet address and sends the reminder

### `backend/src/services/recurringDonationQueue.js` (new)
- pg-boss cron job scheduled daily at 09:00 UTC (configurable via `RECURRING_REMINDER_CRON` env var; set to `"disabled"` to turn off)
- Queries `recurring_donations WHERE status = 'active' AND next_due_date BETWEEN NOW() AND NOW() + INTERVAL '24 hours'`
- Joins with `projects` to include the project name in the notification message
- Sends push via `sendRecurringReminder()`

### `backend/src/server.js`
- Wired `recurringDonationQueue.start()` into the server startup sequence

## Notification Message
> "Your 25 XLM donation to Amazon Reforestation is due tomorrow. Tap to donate."

## Testing
- Lint: no errors on new/modified files
- Requires Node.js 22+ (pg-boss dependency) and a running PostgreSQL instance