### PR TITLE
fix: add Redis health check to readiness endpoint

### DIFF
--- a/backend/src/routes/readiness.js
+++ b/backend/src/routes/readiness.js
@@ -5,6 +5,7 @@
 const express = require("express");
 const router = express.Router();
 const pool = require("../db/pool");
+const redis = require("../services/redis");
 
 const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ||
   process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -12,19 +13,21 @@ const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ||
 router.get("/", async (req, res) => {
   let dbStatus = "ok";
   let horizonStatus = "ok";
+  let redisStatus = "ok";
 
   await Promise.all([
     pool.query("SELECT 1").catch(() => { dbStatus = "unreachable"; }),
     fetch(`${HORIZON_URL}/fee_stats`, { signal: AbortSignal.timeout(4000) })
       .then((r) => { if (!r.ok) horizonStatus = "unreachable"; })
       .catch(() => { horizonStatus = "unreachable"; }),
+    redis.ping().catch(() => { redisStatus = "unreachable"; }),
   ]);
 
-  const healthy = dbStatus === "ok" && horizonStatus === "ok";
+  const healthy = dbStatus === "ok" && horizonStatus === "ok" && redisStatus === "ok";
   res.status(healthy ? 200 : 503).json({
     status: healthy ? "ready" : "not ready",
     timestamp: new Date().toISOString(),
-    checks: { db: dbStatus, horizon: horizonStatus },
+    checks: { db: dbStatus, horizon: horizonStatus, redis: redisStatus },
   });
 });
 

--- a/backend/src/services/redis.js
+++ b/backend/src/services/redis.js
@@ -55,4 +55,16 @@ async function deletePattern(pattern) {
   }
 }
 
-module.exports = { get, set, deletePattern };
+async function ping() {
+  const c = getClient();
+  if (c.status !== "ready") {
+    await c.connect();
+  }
+  const result = await c.ping();
+  if (result !== "PONG") {
+    throw new Error("Redis ping failed");
+  }
+  return result;
+}
+
+module.exports = { get, set, deletePattern, ping };


### PR DESCRIPTION
## Summary
- Add redis.ping() to GET /api/readiness
- Return 503 when Redis is unreachable

Closes #781

Made with [Cursor](https://cursor.com)