### PR TITLE
feat: add pagination to leaderboard endpoint (#369)

### DIFF
--- a/backend/src/routes/leaderboard.js
+++ b/backend/src/routes/leaderboard.js
@@ -9,6 +9,8 @@ const pool = require("../db/pool");
 router.get("/", async (req, res, next) => {
   try {
     const limit = Math.min(parseInt(req.query.limit, 10) || 20, 100);
+    const cursor = parseInt(req.query.cursor, 10) || 0;
+    const offset = cursor;
     const period = req.query.period || "all";
     const sortBy = req.query.sortBy === "impactScore" ? "impact_score" : "total_donated_xlm";
 
@@ -69,14 +71,18 @@ router.get("/", async (req, res, next) => {
     query += `
       LEFT JOIN projects pr ON pr.id = d.project_id
       GROUP BY p.public_key, p.display_name, p.badges
-      ORDER BY ${sortBy} DESC
-      LIMIT $1
+      ORDER BY ${sortBy} DESC, p.public_key ASC
+      LIMIT $1 OFFSET $2
     `;
 
     // eslint-disable-next-line sql-injection/no-sql-injection
-    const result = await pool.query(query, [limit]);
-    const entries = result.rows.map((p, i) => ({
-      rank: i + 1,
+    const result = await pool.query(query, [limit + 1, offset]);
+    
+    const hasMore = result.rows.length > limit;
+    const rows = hasMore ? result.rows.slice(0, limit) : result.rows;
+
+    const entries = rows.map((p, i) => ({
+      rank: offset + i + 1,
       publicKey: p.public_key,
       displayName: p.display_name || null,
       totalDonatedXLM: p.total_donated_xlm?.toString() || "0",
@@ -85,7 +91,15 @@ router.get("/", async (req, res, next) => {
       impactScore: p.impact_score?.toString() || "0",
       totalCO2OffsetKg: p.total_co2_offset_kg?.toString() || "0",
     }));
-    res.json({ success: true, data: entries });
+
+    const nextCursor = hasMore ? offset + limit : null;
+
+    res.json({ 
+      success: true, 
+      data: entries,
+      has_more: hasMore,
+      next_cursor: nextCursor
+    });
   } catch (e) {
     next(e);
   }


### PR DESCRIPTION
## Summary
This PR adds cursor-based pagination support to the `GET /api/leaderboard` endpoint. It introduces a `limit` parameter (defaults to 20, max 100) and a `cursor` parameter to allow fetching subsequent pages. The JSON response now returns `has_more` and `next_cursor` fields. The `rank` parameter is accurately calculated across paginated views by applying the cursor offset, ensuring consistent ordering of leaderboard entries.

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Related Issue
Closes #369

## Testing
- [ ] Tested locally on Testnet
- [x] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
N/A
