### PR TITLE
feat(verification): add admin DELETE endpoint to purge spam submissions #678

### DIFF
--- a/backend/src/routes/verification.js
+++ b/backend/src/routes/verification.js
@@ -19,6 +19,8 @@
  *   - PATCH /api/verification-requests/:id/status   Approve / reject.
  *       Body: { status: "in_review" | "approved" | "rejected",
  *               reviewerNotes?: string, reviewerBy?: string }
+ *   - DELETE /api/verification-requests/:id   Hard-delete spam/test rows
+ *       (admin-only). Allowed only when status is pending or rejected.
  *
  * Admin endpoints expect a Bearer JWT issued by /api/admin/login, the same
  * mechanism already used by projects.admin/register (see middleware/auth.js).
@@ -408,6 +410,52 @@ router.patch("/:id/status", adminRequired, async (req, res, next) => {
     });
 
     res.json({ success: true, data: mapRequestRow(updated.rows[0]) });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * DELETE /api/verification-requests/:id
+ * Admin only. Hard-deletes spam or test submissions.
+ * Only pending or rejected rows may be deleted (not approved / in_review).
+ */
+router.delete("/:id", adminRequired, async (req, res, next) => {
+  try {
+    const existing = await pool.query("SELECT * FROM verification_requests WHERE id = $1", [
+      req.params.id,
+    ]);
+    const row = existing.rows[0];
+    if (!row) return res.status(404).json({ error: "Verification request not found" });
+
+    if (row.status !== "pending" && row.status !== "rejected") {
+      return res.status(400).json({
+        error: `Cannot delete verification request with status "${row.status}"; only pending or rejected rows may be deleted`,
+      });
+    }
+
+    await pool.query("DELETE FROM verification_requests WHERE id = $1", [req.params.id]);
+
+    const actor = (req.admin && req.admin.sub) || "admin";
+    logAdminAction({
+      actor,
+      action: "verification.delete",
+      targetType: "verification_request",
+      targetId: req.params.id,
+      metadata: {
+        status: row.status,
+        organizationName: row.organization_name,
+        projectName: row.project_name,
+        walletAddress: row.wallet_address,
+        contactEmail: row.contact_email,
+      },
+      ipAddress: req.ip,
+    });
+
+    res.json({
+      success: true,
+      data: { id: req.params.id, deleted: true },
+    });
   } catch (e) {
     next(e);
   }

--- a/backend/src/routes/verification.test.js
+++ b/backend/src/routes/verification.test.js
@@ -1,5 +1,9 @@
 "use strict";
 
+jest.mock("uuid", () => ({
+  v4: () => "11111111-1111-1111-1111-111111111111",
+}));
+
 jest.mock("../db/pool", () => ({
   query: jest.fn(),
   connect: jest.fn(),
@@ -293,5 +297,81 @@ describe("PATCH /api/verification-requests/:id/status (admin)", () => {
       .set("Authorization", `Bearer ${token}`)
       .send({ status: "shipped" });
     expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/verification-requests/:id (admin)", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("returns 401 without admin auth", async () => {
+    const res = await request(app).delete(`/api/verification-requests/${MOCK_DB_ROW.id}`);
+    expect(res.status).toBe(401);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 when the row does not exist", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .delete("/api/verification-requests/missing-id")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  test("hard-deletes a pending submission", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "pending" }] })
+      .mockResolvedValueOnce({ rows: [] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .delete(`/api/verification-requests/${MOCK_DB_ROW.id}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual({ id: MOCK_DB_ROW.id, deleted: true });
+    expect(pool.query).toHaveBeenNthCalledWith(
+      2,
+      "DELETE FROM verification_requests WHERE id = $1",
+      [MOCK_DB_ROW.id],
+    );
+  });
+
+  test("hard-deletes a rejected submission", async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "rejected" }] })
+      .mockResolvedValueOnce({ rows: [] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .delete(`/api/verification-requests/${MOCK_DB_ROW.id}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.deleted).toBe(true);
+  });
+
+  test("rejects deletion of an approved submission", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "approved" }] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .delete(`/api/verification-requests/${MOCK_DB_ROW.id}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/approved/);
+    expect(pool.query).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects deletion of an in_review submission", async () => {
+    pool.query.mockResolvedValueOnce({ rows: [{ ...MOCK_DB_ROW, status: "in_review" }] });
+    const token = signToken({ role: "admin", sub: "admin" }, "1h");
+    const res = await request(app)
+      .delete(`/api/verification-requests/${MOCK_DB_ROW.id}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/in_review/);
   });
 });


### PR DESCRIPTION
## Overview

This PR adds an admin-only **`DELETE /api/verification-requests/:id`** endpoint so maintainers can hard-delete spam or test verification submissions. Deletions are audit-logged, and only `pending` or `rejected` rows may be removed (not `approved`).

## Related Issue

Closes #678

## Changes

### 🗑️ Admin Verification Cleanup

* **[MODIFY]** `backend/src/routes/verification.js`
  * Adds `DELETE /:id` behind `adminRequired`.
  * Hard-deletes the row when status is `pending` or `rejected`.
  * Returns `400` for `approved` / `in_review`, `404` when missing.
  * Logs `verification.delete` via `logAdminAction` with a submission snapshot in metadata.

* **[MODIFY]** `backend/src/routes/verification.test.js`
  * Adds coverage for auth, 404, pending/rejected deletes, and blocked approved/in_review cases.
  * Mocks `uuid` for Jest compatibility with uuid v14 ESM.

## Verification Results

```
npm test -- src/routes/verification.test.js
✅ 23/23 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Admin-only `DELETE /api/verification-requests/:id` | ✅ `adminRequired` middleware |
| Hard-delete spam/test submissions | ✅ `DELETE FROM verification_requests` |
| Log deletion in audit log | ✅ `action: "verification.delete"` |
| Only allow `rejected` or `pending` (not `approved`) | ✅ Status guard + tests for approved/in_review |