### PR TITLE
feat(profiles): add avatar_url field and PATCH endpoint #370

### DIFF
--- a/backend/src/db/migrations/004_profile_avatar_url.js
+++ b/backend/src/db/migrations/004_profile_avatar_url.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+  name: "004_profile_avatar_url",
+
+  async up(client) {
+    await client.query(`
+      ALTER TABLE profiles
+      ADD COLUMN IF NOT EXISTS avatar_url TEXT
+    `);
+  },
+
+  async down(client) {
+    await client.query(`
+      ALTER TABLE profiles
+      DROP COLUMN IF EXISTS avatar_url
+    `);
+  },
+};

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -66,6 +66,7 @@ CREATE TABLE IF NOT EXISTS profiles (
   public_key TEXT PRIMARY KEY,
   display_name TEXT,
   bio TEXT,
+  avatar_url TEXT,
   total_donated_xlm NUMERIC(20, 7) NOT NULL DEFAULT 0,
   projects_supported INTEGER NOT NULL DEFAULT 0,
   badges JSONB NOT NULL DEFAULT '[]'::JSONB,

--- a/backend/src/routes/profiles.js
+++ b/backend/src/routes/profiles.js
@@ -16,11 +16,25 @@ function validateKey(k) {
 
 const profilePostLimiter = createRateLimiter(20, 1);
 
+const avatarUrlField = z
+  .union([z.string().url().max(2048), z.literal(""), z.null()])
+  .optional();
+
 const profileSchema = z.object({
   publicKey: z.string().min(1, "publicKey is required"),
   displayName: sanitizedStringField({ required: false, maxLength: 30, message: "must not contain HTML" }).optional(),
   bio: sanitizedStringField({ required: false, maxLength: 300, message: "must not contain HTML" }).optional(),
+  avatarUrl: avatarUrlField,
 });
+
+const profilePatchSchema = z.object({
+  displayName: sanitizedStringField({ required: false, maxLength: 30, message: "must not contain HTML" }).optional(),
+  bio: sanitizedStringField({ required: false, maxLength: 300, message: "must not contain HTML" }).optional(),
+  avatarUrl: avatarUrlField,
+}).refine(
+  (body) => body.displayName !== undefined || body.bio !== undefined || body.avatarUrl !== undefined,
+  { message: "At least one of displayName, bio, or avatarUrl is required" },
+);
 
 router.get("/:publicKey", async (req, res, next) => {
   try {
@@ -57,23 +71,72 @@ router.get("/:publicKey", async (req, res, next) => {
 
 router.post("/", profilePostLimiter, validateBody(profileSchema), async (req, res, next) => {
   try {
-    const { publicKey, displayName, bio } = req.body;
+    const { publicKey, displayName, bio, avatarUrl } = req.body;
     validateKey(publicKey);
     const trimmedDisplayName = displayName?.trim().slice(0, 30) || null;
     const trimmedBio = bio?.trim().slice(0, 300) || null;
+    // null/empty keeps existing avatar on conflict via COALESCE; a URL sets it.
+    const normalizedAvatarUrl = avatarUrl ? String(avatarUrl).trim() : null;
 
     const result = await pool.query(
       `INSERT INTO profiles (
-        public_key, display_name, bio, total_donated_xlm, projects_supported, badges, created_at, updated_at
+        public_key, display_name, bio, avatar_url, total_donated_xlm, projects_supported, badges, created_at, updated_at
       )
-      VALUES ($1, $2, $3, 0, 0, '[]'::jsonb, NOW(), NOW())
+      VALUES ($1, $2, $3, $4, 0, 0, '[]'::jsonb, NOW(), NOW())
       ON CONFLICT (public_key) DO UPDATE SET
         display_name = COALESCE($2, profiles.display_name),
         bio = COALESCE($3, profiles.bio),
+        avatar_url = COALESCE($4, profiles.avatar_url),
         updated_at = NOW()
       RETURNING *`,
-      [publicKey, trimmedDisplayName, trimmedBio],
+      [publicKey, trimmedDisplayName, trimmedBio, normalizedAvatarUrl],
     );
+
+    res.json({ success: true, data: mapProfileRow(result.rows[0]) });
+  } catch (e) { next(e); }
+});
+
+/**
+ * PATCH /api/profiles/:publicKey
+ * Partially update displayName, bio, and/or avatarUrl for an existing profile.
+ * Passing avatarUrl as "" or null clears the avatar.
+ */
+router.patch("/:publicKey", profilePostLimiter, validateBody(profilePatchSchema), async (req, res, next) => {
+  try {
+    validateKey(req.params.publicKey);
+
+    const sets = [];
+    const values = [];
+
+    if (req.body.displayName !== undefined) {
+      values.push(req.body.displayName?.trim().slice(0, 30) || null);
+      sets.push(`display_name = $${values.length}`);
+    }
+    if (req.body.bio !== undefined) {
+      values.push(req.body.bio?.trim().slice(0, 300) || null);
+      sets.push(`bio = $${values.length}`);
+    }
+    if (req.body.avatarUrl !== undefined) {
+      const avatar = req.body.avatarUrl === "" || req.body.avatarUrl === null
+        ? null
+        : String(req.body.avatarUrl).trim();
+      values.push(avatar);
+      sets.push(`avatar_url = $${values.length}`);
+    }
+
+    sets.push("updated_at = NOW()");
+    values.push(req.params.publicKey);
+
+    const result = await pool.query(
+      `UPDATE profiles SET ${sets.join(", ")} WHERE public_key = $${values.length} RETURNING *`,
+      values,
+    );
+
+    if (!result.rows[0]) {
+      const e = new Error("Profile not found");
+      e.status = 404;
+      throw e;
+    }
 
     res.json({ success: true, data: mapProfileRow(result.rows[0]) });
   } catch (e) { next(e); }

--- a/backend/src/routes/profiles.test.js
+++ b/backend/src/routes/profiles.test.js
@@ -23,6 +23,8 @@ function buildApp() {
   return app;
 }
 
+const PUBLIC_KEY = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
 describe("POST /api/profiles", () => {
   let app;
 
@@ -35,7 +37,7 @@ describe("POST /api/profiles", () => {
     const res = await request(app)
       .post("/api/profiles")
       .send({
-        publicKey: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        publicKey: PUBLIC_KEY,
         displayName: "<b>Bad</b>",
         bio: "A short bio",
       })
@@ -43,5 +45,98 @@ describe("POST /api/profiles", () => {
 
     expect(res.body.error).toBe("Validation failed");
     expect(res.body.details.displayName).toBeDefined();
+  });
+
+  test("rejects invalid avatarUrl with 422", async () => {
+    const res = await request(app)
+      .post("/api/profiles")
+      .send({
+        publicKey: PUBLIC_KEY,
+        avatarUrl: "not-a-url",
+      })
+      .expect(422);
+
+    expect(res.body.error).toBe("Validation failed");
+    expect(res.body.details.avatarUrl).toBeDefined();
+  });
+});
+
+describe("PATCH /api/profiles/:publicKey", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("updates avatarUrl for an existing profile", async () => {
+    pool.query.mockResolvedValue({
+      rows: [{
+        public_key: PUBLIC_KEY,
+        display_name: "Ada",
+        bio: "Donor",
+        avatar_url: "https://cdn.example.com/avatar.png",
+        total_donated_xlm: "10.0000000",
+        projects_supported: 1,
+        badges: [],
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-02T00:00:00.000Z",
+      }],
+    });
+
+    const res = await request(app)
+      .patch(`/api/profiles/${PUBLIC_KEY}`)
+      .send({ avatarUrl: "https://cdn.example.com/avatar.png" })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.avatarUrl).toBe("https://cdn.example.com/avatar.png");
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE profiles SET"),
+      expect.arrayContaining(["https://cdn.example.com/avatar.png", PUBLIC_KEY]),
+    );
+  });
+
+  test("clears avatarUrl when null is sent", async () => {
+    pool.query.mockResolvedValue({
+      rows: [{
+        public_key: PUBLIC_KEY,
+        display_name: "Ada",
+        bio: "Donor",
+        avatar_url: null,
+        total_donated_xlm: "0",
+        projects_supported: 0,
+        badges: [],
+        created_at: null,
+        updated_at: null,
+      }],
+    });
+
+    const res = await request(app)
+      .patch(`/api/profiles/${PUBLIC_KEY}`)
+      .send({ avatarUrl: null })
+      .expect(200);
+
+    expect(res.body.data.avatarUrl).toBeNull();
+  });
+
+  test("returns 404 when profile does not exist", async () => {
+    pool.query.mockResolvedValue({ rows: [] });
+
+    const res = await request(app)
+      .patch(`/api/profiles/${PUBLIC_KEY}`)
+      .send({ avatarUrl: "https://cdn.example.com/a.png" })
+      .expect(404);
+
+    expect(res.body.error).toBe("Profile not found");
+  });
+
+  test("rejects empty patch body with 422", async () => {
+    const res = await request(app)
+      .patch(`/api/profiles/${PUBLIC_KEY}`)
+      .send({})
+      .expect(422);
+
+    expect(res.body.error).toBe("Validation failed");
   });
 });

--- a/backend/src/services/store.js
+++ b/backend/src/services/store.js
@@ -220,6 +220,7 @@ function mapProfileRow(row) {
     publicKey: row.public_key,
     displayName: row.display_name,
     bio: row.bio,
+    avatarUrl: row.avatar_url || null,
     totalDonatedXLM: row.total_donated_xlm?.toString() || "0",
     projectsSupported: row.projects_supported,
     badges: row.badges || [],

--- a/backend/src/services/store.test.js
+++ b/backend/src/services/store.test.js
@@ -184,6 +184,7 @@ describe("store utility functions", () => {
         public_key: "GUSER",
         display_name: "Asraf",
         bio: "Donor",
+        avatar_url: "https://cdn.example.com/a.png",
         total_donated_xlm: 100,
         projects_supported: 2,
         badges: [{ tier: "tree" }],
@@ -193,12 +194,28 @@ describe("store utility functions", () => {
     ).toMatchObject({
       publicKey: "GUSER",
       displayName: "Asraf",
+      avatarUrl: "https://cdn.example.com/a.png",
       totalDonatedXLM: "100",
       projectsSupported: 2,
       badges: [{ tier: "tree" }],
       createdAt: null,
       updatedAt: null,
     });
+  });
+
+  test("mapProfileRow defaults missing avatar_url to null", () => {
+    expect(
+      mapProfileRow({
+        public_key: "GUSER",
+        display_name: "Asraf",
+        bio: null,
+        total_donated_xlm: 0,
+        projects_supported: 0,
+        badges: [],
+        created_at: null,
+        updated_at: null,
+      }).avatarUrl
+    ).toBeNull();
   });
 
   test("row mappers convert snake_case fields to camelCase", () => {


### PR DESCRIPTION
## Overview

This PR adds an `avatar_url` field so donors can set a profile picture URL. The column is added via migration, exposed through `mapProfileRow`, and writable via `PATCH /api/profiles/:publicKey` (also accepted on the existing POST upsert).

## Related Issue

Closes #370

## Changes

### 🖼️ Profile Avatar Support

* **[ADD]** `backend/src/db/migrations/004_profile_avatar_url.js`
  * Adds nullable `avatar_url TEXT` column to `profiles`.

* **[MODIFY]** `backend/src/db/schema.sql`
  * Keeps canonical schema in sync with the migration.

* **[MODIFY]** `backend/src/services/store.js`
  * `mapProfileRow` now returns `avatarUrl` (defaults to `null`).

* **[MODIFY]** `backend/src/routes/profiles.js`
  * Accepts optional `avatarUrl` on POST upsert.
  * Adds `PATCH /api/profiles/:publicKey` for partial updates (`displayName`, `bio`, `avatarUrl`); empty/`null` clears the avatar.

* **[MODIFY]** Tests
  * `profiles.test.js` — PATCH success/clear/404/validation coverage.
  * `store.test.js` — `avatarUrl` mapping coverage.

## Verification Results

```
npx jest --runInBand src/routes/profiles.test.js src/services/store.test.js --no-coverage
✅ 37/37 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| `avatar_url` column added via migration | ✅ `004_profile_avatar_url.js` |
| Exposed in `mapProfileRow` | ✅ `avatarUrl` field |
| Writable via `PATCH /api/profiles/:publicKey` | ✅ Partial update + clear support |