### PR TITLE
feat(webhooks): add delivery history table fields and GET history endpoint #679

### DIFF
--- a/backend/src/db/migrations/004_webhook_deliveries_history_fields.js
+++ b/backend/src/db/migrations/004_webhook_deliveries_history_fields.js
@@ -1,0 +1,31 @@
+"use strict";
+
+module.exports = {
+  name: "004_webhook_deliveries_history_fields",
+
+  async up(client) {
+    await client.query(`
+      ALTER TABLE webhook_deliveries
+        ADD COLUMN IF NOT EXISTS event TEXT,
+        ADD COLUMN IF NOT EXISTS payload_hash TEXT,
+        ADD COLUMN IF NOT EXISTS response_status INTEGER
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_project_created
+        ON webhook_deliveries (project_id, created_at DESC)
+    `);
+  },
+
+  async down(client) {
+    await client.query(`
+      DROP INDEX IF EXISTS idx_webhook_deliveries_project_created
+    `);
+    await client.query(`
+      ALTER TABLE webhook_deliveries
+        DROP COLUMN IF EXISTS event,
+        DROP COLUMN IF EXISTS payload_hash,
+        DROP COLUMN IF EXISTS response_status
+    `);
+  },
+};

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -275,6 +275,33 @@ CREATE INDEX IF NOT EXISTS verification_requests_status_idx
 CREATE INDEX IF NOT EXISTS verification_requests_wallet_idx
   ON verification_requests (wallet_address);
 
+-- webhook_deliveries: history of outbound webhook delivery attempts.
+-- Populated when milestone.reached (and similar) events are sent to a
+-- project's webhook_url. Used by GET /api/webhooks/:projectId/history.
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id UUID PRIMARY KEY,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  url TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  event TEXT,
+  payload_hash TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'delivered', 'failed')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  last_attempt_at TIMESTAMPTZ,
+  next_attempt_at TIMESTAMPTZ,
+  response_status INTEGER,
+  delivered_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status
+  ON webhook_deliveries (status);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_project_id
+  ON webhook_deliveries (project_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_project_created
+  ON webhook_deliveries (project_id, created_at DESC);
+
 -- global_stats_mv: pre-aggregated landing-page totals refreshed by pg-boss.
 CREATE MATERIALIZED VIEW IF NOT EXISTS global_stats_mv AS
 SELECT

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -1,6 +1,7 @@
 /**
  * src/routes/webhooks.js
  * GET /api/webhooks/:projectId — list configured webhook for a project (owner only)
+ * GET /api/webhooks/:projectId/history — paginated delivery history (owner only)
  */
 "use strict";
 
@@ -27,32 +28,109 @@ function maskWebhookSecret(secret) {
   return `${"*".repeat(maskedLength)}${visible}`;
 }
 
+function mapDeliveryRow(row) {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    event: row.event || null,
+    payloadHash: row.payload_hash || null,
+    status: row.status,
+    attempts: row.attempt_count,
+    lastAttemptAt: row.last_attempt_at,
+    nextAttemptAt: row.next_attempt_at,
+    responseStatus: row.response_status ?? null,
+    lastError: row.last_error || null,
+    deliveredAt: row.delivered_at || null,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * Ensure the caller is the project owner. Returns the project row or sends an
+ * error response and returns null.
+ */
+async function requireProjectOwner(req, res) {
+  const walletAddress = getWalletAddressFromRequest(req);
+  if (!walletAddress) {
+    res.status(401).json({ error: "X-Wallet-Address header is required" });
+    return null;
+  }
+  if (!STELLAR_ADDRESS_RE.test(walletAddress)) {
+    res.status(400).json({ error: "X-Wallet-Address must be a valid Stellar address" });
+    return null;
+  }
+
+  const projectResult = await pool.query(
+    "SELECT id, wallet_address, webhook_url, webhook_secret FROM projects WHERE id = $1",
+    [req.params.projectId],
+  );
+  const project = projectResult.rows[0];
+  if (!project) {
+    res.status(404).json({ error: "Project not found" });
+    return null;
+  }
+
+  if (!isProjectOwner(req, project.wallet_address)) {
+    res.status(403).json({ error: "Only the project owner can view webhook configuration" });
+    return null;
+  }
+
+  return project;
+}
+
+/**
+ * GET /api/webhooks/:projectId/history
+ * Paginated list of recent webhook delivery attempts for a project.
+ */
+router.get("/:projectId/history", async (req, res, next) => {
+  try {
+    const project = await requireProjectOwner(req, res);
+    if (!project) return;
+
+    const page = Math.max(Number.parseInt(String(req.query.page || "1"), 10) || 1, 1);
+    const pageSize = Math.min(
+      Math.max(Number.parseInt(String(req.query.pageSize || "20"), 10) || 20, 1),
+      100,
+    );
+    const offset = (page - 1) * pageSize;
+
+    const [listResult, countResult] = await Promise.all([
+      pool.query(
+        `SELECT id, project_id, event, payload_hash, status, attempt_count,
+                last_attempt_at, next_attempt_at, response_status, last_error,
+                delivered_at, created_at
+         FROM webhook_deliveries
+         WHERE project_id = $1
+         ORDER BY created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [project.id, pageSize, offset],
+      ),
+      pool.query(
+        "SELECT COUNT(*)::int AS total FROM webhook_deliveries WHERE project_id = $1",
+        [project.id],
+      ),
+    ]);
+
+    res.json({
+      success: true,
+      data: listResult.rows.map(mapDeliveryRow),
+      total: countResult.rows[0]?.total || 0,
+      page,
+      pageSize,
+    });
+  } catch (e) {
+    next(e);
+  }
+});
+
 /**
  * GET /api/webhooks/:projectId
  * Project owners can view their configured webhook URL and a masked secret.
  */
 router.get("/:projectId", async (req, res, next) => {
   try {
-    const walletAddress = getWalletAddressFromRequest(req);
-    if (!walletAddress) {
-      return res.status(401).json({ error: "X-Wallet-Address header is required" });
-    }
-    if (!STELLAR_ADDRESS_RE.test(walletAddress)) {
-      return res.status(400).json({ error: "X-Wallet-Address must be a valid Stellar address" });
-    }
-
-    const projectResult = await pool.query(
-      "SELECT id, wallet_address, webhook_url, webhook_secret FROM projects WHERE id = $1",
-      [req.params.projectId],
-    );
-    const project = projectResult.rows[0];
-    if (!project) {
-      return res.status(404).json({ error: "Project not found" });
-    }
-
-    if (!isProjectOwner(req, project.wallet_address)) {
-      return res.status(403).json({ error: "Only the project owner can view webhook configuration" });
-    }
+    const project = await requireProjectOwner(req, res);
+    if (!project) return;
 
     const configured = Boolean(project.webhook_url);
 

--- a/backend/src/routes/webhooks.test.js
+++ b/backend/src/routes/webhooks.test.js
@@ -172,3 +172,93 @@ describe("GET /api/webhooks/:projectId", () => {
     expect(res.body.error).toBe("Only the project owner can view webhook configuration");
   });
 });
+
+describe("GET /api/webhooks/:projectId/history", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+  });
+
+  test("returns paginated delivery history for project owner", async () => {
+    pool.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: PROJECT_ID,
+          wallet_address: OWNER_ADDRESS,
+          webhook_url: "https://example.com/hook",
+          webhook_secret: "secret",
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: "del-1",
+          project_id: PROJECT_ID,
+          event: "milestone.reached",
+          payload_hash: "abc123",
+          status: "delivered",
+          attempt_count: 1,
+          last_attempt_at: "2026-07-01T12:00:00.000Z",
+          next_attempt_at: null,
+          response_status: 200,
+          last_error: null,
+          delivered_at: "2026-07-01T12:00:00.000Z",
+          created_at: "2026-07-01T12:00:00.000Z",
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: 1 }] });
+
+    const res = await request(app)
+      .get(`/api/webhooks/${PROJECT_ID}/history?page=1&pageSize=20`)
+      .set("X-Wallet-Address", OWNER_ADDRESS)
+      .expect(200);
+
+    expect(res.body).toEqual({
+      success: true,
+      data: [{
+        id: "del-1",
+        projectId: PROJECT_ID,
+        event: "milestone.reached",
+        payloadHash: "abc123",
+        status: "delivered",
+        attempts: 1,
+        lastAttemptAt: "2026-07-01T12:00:00.000Z",
+        nextAttemptAt: null,
+        responseStatus: 200,
+        lastError: null,
+        deliveredAt: "2026-07-01T12:00:00.000Z",
+        createdAt: "2026-07-01T12:00:00.000Z",
+      }],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  test("rejects non-owners from viewing history", async () => {
+    pool.query.mockResolvedValue({
+      rows: [{
+        id: PROJECT_ID,
+        wallet_address: OWNER_ADDRESS,
+        webhook_url: "https://example.com/hook",
+        webhook_secret: "secret",
+      }],
+    });
+
+    const res = await request(app)
+      .get(`/api/webhooks/${PROJECT_ID}/history`)
+      .set("X-Wallet-Address", OTHER_ADDRESS)
+      .expect(403);
+
+    expect(res.body.error).toBe("Only the project owner can view webhook configuration");
+  });
+
+  test("rejects requests without X-Wallet-Address", async () => {
+    const res = await request(app)
+      .get(`/api/webhooks/${PROJECT_ID}/history`)
+      .expect(401);
+
+    expect(res.body.error).toBe("X-Wallet-Address header is required");
+  });
+});

--- a/backend/src/services/webhook.js
+++ b/backend/src/services/webhook.js
@@ -412,6 +412,61 @@ async function deliverPayload(url, secret, payload) {
 }
 
 /**
+ * Persist a delivery row, attempt the HTTP POST, then update status/history fields.
+ *
+ * @param {{ projectId: string, url: string, secret: string, payload: object }} opts
+ * @returns {Promise<void>}
+ */
+async function recordAndDeliver({ projectId, url, secret, payload }) {
+  const id = crypto.randomUUID();
+  const body = JSON.stringify(payload);
+  const payloadHash = crypto.createHash("sha256").update(body).digest("hex");
+  const event = typeof payload?.event === "string" ? payload.event : null;
+
+  await pool.query(
+    `INSERT INTO webhook_deliveries (
+       id, project_id, url, payload, event, payload_hash, status, attempt_count
+     ) VALUES ($1, $2, $3, $4::jsonb, $5, $6, 'pending', 0)`,
+    [id, projectId, url, body, event, payloadHash],
+  );
+
+  try {
+    const { statusCode } = await deliverPayload(url, secret, payload);
+    const delivered = statusCode >= 200 && statusCode < 300;
+    await pool.query(
+      `UPDATE webhook_deliveries
+       SET status = $2,
+           attempt_count = 1,
+           last_attempt_at = NOW(),
+           response_status = $3,
+           delivered_at = CASE WHEN $4 THEN NOW() ELSE NULL END,
+           last_error = CASE WHEN $4 THEN NULL ELSE $5 END,
+           next_attempt_at = NULL
+       WHERE id = $1`,
+      [
+        id,
+        delivered ? "delivered" : "failed",
+        statusCode,
+        delivered,
+        delivered ? null : `Webhook responded with HTTP ${statusCode}`,
+      ],
+    );
+  } catch (err) {
+    await pool.query(
+      `UPDATE webhook_deliveries
+       SET status = 'failed',
+           attempt_count = 1,
+           last_attempt_at = NOW(),
+           last_error = $2,
+           next_attempt_at = NULL
+       WHERE id = $1`,
+      [id, err.message],
+    );
+    throw err;
+  }
+}
+
+/**
  * Check project milestones after a donation and deliver webhooks for any
  * newly reached milestones. Runs asynchronously (fire-and-forget enqueue).
  *
@@ -470,7 +525,7 @@ async function checkAndDeliverMilestones(projectId) {
 
     if (project.webhook_url && project.webhook_secret) {
       // Fire all webhook deliveries concurrently so a slow DNS timeout on one
-      // URL doesn't block the rest.
+      // URL doesn't block the rest. Each attempt is persisted for history.
       const deliveries = milestones.map((milestone) => {
         const payload = {
           event: "milestone.reached",
@@ -481,15 +536,19 @@ async function checkAndDeliverMilestones(projectId) {
           timestamp: new Date().toISOString(),
         };
 
-        return deliverPayload(project.webhook_url, project.webhook_secret, payload)
-          .catch((err) => {
-            logger.error({
-              event: "webhook_url_rejected",
-              projectId,
-              url: project.webhook_url,
-              reason: err.message,
-            }, "Skipping webhook delivery — URL rejected");
-          });
+        return recordAndDeliver({
+          projectId,
+          url: project.webhook_url,
+          secret: project.webhook_secret,
+          payload,
+        }).catch((err) => {
+          logger.error({
+            event: "webhook_url_rejected",
+            projectId,
+            url: project.webhook_url,
+            reason: err.message,
+          }, "Skipping webhook delivery — URL rejected");
+        });
       });
 
       await Promise.allSettled(deliveries);
@@ -503,8 +562,18 @@ async function checkAndDeliverMilestones(projectId) {
   }
 }
 
+/**
+ * No-op queue start — delivery history is recorded inline.
+ * Kept so server.js can await start() without a separate pg-boss worker.
+ * @returns {Promise<void>}
+ */
+async function start() {
+  return;
+}
+
 module.exports = {
   checkAndDeliverMilestones,
+  start,
   // Exported for unit testing
   validateUrl,
   checkPrivateIPv4,
@@ -513,6 +582,7 @@ module.exports = {
   ip4ToInt,
   stripBrackets,
   PRIVATE_IPV4_RANGES,
+  recordAndDeliver,
 };
 
 // Export internal functions for testing

--- a/backend/src/services/webhook.test.js
+++ b/backend/src/services/webhook.test.js
@@ -505,6 +505,9 @@ describe("Webhook signature validation (testcontainers)", () => {
 
     // No webhook should have been delivered
     expect(received.length).toBe(0);
+  }, 15000);
+});
+
 process.env.NODE_ENV = "test";
 const dns = require("dns");
 const net = require("net");


### PR DESCRIPTION
## Overview

This PR tracks every webhook delivery attempt and exposes a paginated owner-only history API. Deliveries are persisted when milestones fire, including event name, payload hash, status, attempts, and HTTP response status.

## Related Issue

Closes #679

## Changes

### 📬 Webhook Delivery History

* **[ADD]** `backend/src/db/migrations/004_webhook_deliveries_history_fields.js`
  * Adds `event`, `payload_hash`, and `response_status` to `webhook_deliveries`.
  * Adds `(project_id, created_at DESC)` index for history queries.

* **[MODIFY]** `backend/src/db/schema.sql`
  * Documents the full `webhook_deliveries` table.

* **[MODIFY]** `backend/src/services/webhook.js`
  * `recordAndDeliver()` inserts a pending row, attempts delivery, then updates status/attempts/response fields.
  * Milestone webhook sends now go through `recordAndDeliver`.
  * Exports a no-op `start()` so server startup stays compatible.

* **[MODIFY]** `backend/src/routes/webhooks.js`
  * Adds `GET /api/webhooks/:projectId/history` (owner-only, `page`/`pageSize` pagination).
  * Response maps `attempt_count` → `attempts` and includes event/hash/status timestamps.

* **[MODIFY]** Tests
  * `webhooks.test.js` — history auth + pagination shape.
  * `webhook.test.js` — fixes a pre-existing truncated describe close so the SSRF suite parses.

## Verification Results

```
SKIP_INTEGRATION=1 npx jest --runInBand src/routes/webhooks.test.js src/services/webhook.test.js --no-coverage
✅ 94/94 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Delivery history fields available | ✅ `event`, `payload_hash`, `response_status` (+ existing attempt/status columns) |
| Deliveries are persisted on send | ✅ `recordAndDeliver` |
| `GET /api/webhooks/:projectId/history` paginated | ✅ owner-gated `page`/`pageSize` |