### PR TITLE
feat(storage): pin IPFS uploads via Pinata to prevent garbage collection #680

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -36,6 +36,8 @@ const envSchema = z.object({
   PRESIGN_EXPIRY_SECONDS: z.string().optional().default("300"),
   IPFS_API_URL: z.string().optional().default(""),
   IPFS_GATEWAY_URL: z.string().optional().default(""),
+  // Optional Pinata JWT used to pin CIDs after IPFS upload (prevents GC).
+  PINATA_JWT: z.string().optional().default(""),
 });
 
 function validateEnv() {

--- a/backend/src/services/storage.js
+++ b/backend/src/services/storage.js
@@ -15,7 +15,9 @@
  *                Requires an IPFS_API_URL (Infura, Pinata cluster, or local
  *                IPFS daemon). Returns the content identifier (CID); the
  *                gateway URL is derived from IPFS_GATEWAY_URL or
- *                https://ipfs.io/ipfs/<cid>.
+ *                https://ipfs.io/ipfs/<cid>. When PINATA_JWT is set, the CID
+ *                is also pinned via Pinata's pinByHash API so the content is
+ *                not garbage-collected from the IPFS network.
  *
  * The active backend is selected by STORAGE_BACKEND env var. If
  * STORAGE_BACKEND is "s3" or "ipfs" but the required credentials or
@@ -186,6 +188,9 @@ async function uploadIpfs(buffer, originalName, contentType) {
   if (!last || !last.Hash) {
     throw new Error("IPFS upload succeeded but response did not include a CID");
   }
+
+  await pinCidWithPinata(last.Hash, originalName);
+
   const gateway = (process.env.IPFS_GATEWAY_URL || "https://ipfs.io/ipfs").replace(/\/$/, "");
   return {
     key: last.Hash,
@@ -194,6 +199,56 @@ async function uploadIpfs(buffer, originalName, contentType) {
     contentType: contentType || "application/octet-stream",
     backend: "ipfs",
   };
+}
+
+/**
+ * Pin an already-uploaded CID via Pinata so it is not garbage-collected.
+ * No-ops when PINATA_JWT is unset. Failures are logged but do not fail the
+ * upload — the file is already on IPFS; pinning is a durability best-effort.
+ *
+ * @param {string} cid - IPFS content identifier (CID) from /api/v0/add.
+ * @param {string} [originalName] - Optional filename for Pinata metadata.
+ * @returns {Promise<void>}
+ */
+async function pinCidWithPinata(cid, originalName) {
+  const jwt = process.env.PINATA_JWT;
+  if (!jwt) {
+    logger.warn(
+      { event: "storage_pinata_jwt_missing", cid },
+      "IPFS upload succeeded without PINATA_JWT — content may be garbage-collected"
+    );
+    return;
+  }
+
+  try {
+    const res = await fetch("https://api.pinata.cloud/pinning/pinByHash", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        hashToPin: cid,
+        pinataMetadata: originalName ? { name: String(originalName).slice(0, 255) } : undefined,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      logger.error(
+        { event: "storage_pinata_pin_failed", cid, status: res.status, body: body.slice(0, 500) },
+        "Pinata pinByHash failed — CID may not be permanently pinned"
+      );
+      return;
+    }
+
+    logger.info({ event: "storage_pinata_pinned", cid }, "Pinned CID via Pinata");
+  } catch (err) {
+    logger.error(
+      { event: "storage_pinata_pin_error", cid, err: err.message },
+      "Pinata pinByHash request failed — CID may not be permanently pinned"
+    );
+  }
 }
 
 /**
@@ -218,4 +273,4 @@ function backendName() {
   return STORAGE_BACKEND;
 }
 
-module.exports = { uploadFile, backendName, UPLOAD_DIR, buildKey };
+module.exports = { uploadFile, backendName, UPLOAD_DIR, buildKey, pinCidWithPinata };

--- a/backend/src/services/storage.test.js
+++ b/backend/src/services/storage.test.js
@@ -34,3 +34,118 @@ describe("buildKey", () => {
     expect(key).toMatch(/^[0-9a-f]{24}-upload$/);
   });
 });
+
+describe("pinCidWithPinata", () => {
+  const originalFetch = global.fetch;
+  const originalJwt = process.env.PINATA_JWT;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalJwt === undefined) delete process.env.PINATA_JWT;
+    else process.env.PINATA_JWT = originalJwt;
+    jest.resetModules();
+  });
+
+  it("no-ops without calling Pinata when PINATA_JWT is unset", async () => {
+    delete process.env.PINATA_JWT;
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock;
+
+    const { pinCidWithPinata } = require("./storage");
+    await pinCidWithPinata("QmTestCid123");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs pinByHash to Pinata when PINATA_JWT is set", async () => {
+    process.env.PINATA_JWT = "test-jwt-token";
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => "",
+    });
+    global.fetch = fetchMock;
+
+    const { pinCidWithPinata } = require("./storage");
+    await pinCidWithPinata("QmPinnedCid", "report.pdf");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.pinata.cloud/pinning/pinByHash",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-jwt-token",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({
+      hashToPin: "QmPinnedCid",
+      pinataMetadata: { name: "report.pdf" },
+    });
+  });
+
+  it("does not throw when Pinata returns a non-OK response", async () => {
+    process.env.PINATA_JWT = "test-jwt-token";
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "unauthorized",
+    });
+
+    const { pinCidWithPinata } = require("./storage");
+    await expect(pinCidWithPinata("QmFail")).resolves.toBeUndefined();
+  });
+});
+
+describe("uploadFile IPFS + Pinata", () => {
+  const originalFetch = global.fetch;
+  const originalBackend = process.env.STORAGE_BACKEND;
+  const originalApi = process.env.IPFS_API_URL;
+  const originalJwt = process.env.PINATA_JWT;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalBackend === undefined) delete process.env.STORAGE_BACKEND;
+    else process.env.STORAGE_BACKEND = originalBackend;
+    if (originalApi === undefined) delete process.env.IPFS_API_URL;
+    else process.env.IPFS_API_URL = originalApi;
+    if (originalJwt === undefined) delete process.env.PINATA_JWT;
+    else process.env.PINATA_JWT = originalJwt;
+    jest.resetModules();
+  });
+
+  it("pins the CID with Pinata after a successful IPFS add", async () => {
+    process.env.STORAGE_BACKEND = "ipfs";
+    process.env.IPFS_API_URL = "http://ipfs.local:5001";
+    process.env.PINATA_JWT = "pinata-jwt";
+    process.env.IPFS_GATEWAY_URL = "https://gateway.example/ipfs";
+
+    global.fetch = jest.fn(async (url) => {
+      if (String(url).includes("/api/v0/add")) {
+        return {
+          ok: true,
+          text: async () => JSON.stringify({ Hash: "QmUploadedCid", Size: "12" }),
+        };
+      }
+      if (String(url).includes("pinata.cloud")) {
+        return { ok: true, text: async () => "" };
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    const { uploadFile } = require("./storage");
+    const result = await uploadFile(Buffer.from("hello world"), "doc.pdf", "application/pdf");
+
+    expect(result).toMatchObject({
+      key: "QmUploadedCid",
+      url: "https://gateway.example/ipfs/QmUploadedCid",
+      backend: "ipfs",
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.pinata.cloud/pinning/pinByHash",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});


### PR DESCRIPTION
## Overview

This PR integrates Pinata pinning after IPFS uploads so supporting documents are not garbage-collected. When `PINATA_JWT` is set, each successful CID from `/api/v0/add` is pinned via Pinata’s `pinByHash` API.

## Related Issue

Closes #680

## Changes

### 📌 Pinata IPFS Pinning

* **[MODIFY]** `backend/src/services/storage.js`
  * After a successful IPFS add, calls `pinCidWithPinata(cid)`.
  * Uses `POST https://api.pinata.cloud/pinning/pinByHash` with `Authorization: Bearer $PINATA_JWT`.
  * Missing JWT / pin failures are logged and do not fail the upload (file is already on IPFS).

* **[MODIFY]** `backend/src/config/env.js`
  * Adds optional `PINATA_JWT` to the env schema (already documented in `.env.example`).

* **[MODIFY]** `backend/src/services/storage.test.js`
  * Coverage for no-op without JWT, successful pinByHash call, non-OK Pinata response, and end-to-end IPFS upload + pin.

## Verification Results

```
npx jest --runInBand src/services/storage.test.js --no-coverage
✅ 9/9 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Pin after IPFS upload when `PINATA_JWT` set | ✅ `pinByHash` integration |
| Upload still succeeds if pinning fails/missing JWT | ✅ warn/error logs only |
| Env documented / validated | ✅ `.env.example` + `env.js` |