### PR TITLE
feat(middleware): emit X-RateLimit-* headers on every response

### DIFF
--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,8 +1,23 @@
 const rateLimit = require("express-rate-limit");
 const logger = require("../logger");
 
+/**
+ * Sets X-RateLimit-{Limit,Remaining,Reset} from the req.rateLimit object
+ * that express-rate-limit attaches on every request (including allowed ones).
+ */
+function setRateLimitHeaders(req, res, next) {
+  const info = req.rateLimit;
+  if (info) {
+    res.set("X-RateLimit-Limit", String(info.limit));
+    res.set("X-RateLimit-Remaining", String(info.remaining));
+    // resetTime is a Date; convert to Unix epoch seconds
+    res.set("X-RateLimit-Reset", String(Math.ceil(info.resetTime.getTime() / 1000)));
+  }
+  next();
+}
+
 const createRateLimiter = (maxRequests, windowMinutes) => {
-  return rateLimit({
+  const limiter = rateLimit({
     windowMs: windowMinutes * 60 * 1000,
     max: maxRequests,
     standardHeaders: true,
@@ -22,6 +37,10 @@ const createRateLimiter = (maxRequests, windowMinutes) => {
       });
     },
   });
+
+  // Return both middleware in order: limiter first (populates req.rateLimit),
+  // then the header setter. Express flattens middleware arrays automatically.
+  return [limiter, setRateLimitHeaders];
 };
 
 module.exports = { createRateLimiter };

--- a/backend/src/middleware/rateLimiter.test.js
+++ b/backend/src/middleware/rateLimiter.test.js
@@ -41,6 +41,23 @@ describe("Rate limiting middleware — donation endpoint", () => {
     }
   });
 
+  it("sets X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset on allowed requests", async () => {
+    const res = await request(app).get("/ping");
+    expect(res.status).toBe(200);
+    expect(res.headers["x-ratelimit-limit"]).toBe("10");
+    expect(res.headers["x-ratelimit-remaining"]).toBe("9");
+    expect(Number(res.headers["x-ratelimit-reset"])).toBeGreaterThan(0);
+  });
+
+  it("sets X-RateLimit-Remaining to 0 on the last allowed request", async () => {
+    for (let i = 0; i < 9; i++) {
+      await request(app).get("/ping");
+    }
+    const res = await request(app).get("/ping");
+    expect(res.status).toBe(200);
+    expect(res.headers["x-ratelimit-remaining"]).toBe("0");
+  });
+
   it("blocks the 11th request with HTTP 429", async () => {
     for (let i = 0; i < 10; i++) {
       await request(app).get("/ping");


### PR DESCRIPTION

## Related Issue
Closes #360 

Add X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset (Unix epoch seconds) to all rate-limited responses, including allowed ones — not just 429s.

express-rate-limit already populates req.rateLimit (with limit, remaining, and resetTime) on every request. A small setRateLimitHeaders middleware reads that object and sets the three headers. createRateLimiter now returns [limiter, setRateLimitHeaders] instead of a bare limiter; Express 5 flattens middleware arrays transparently so all eight call sites (server.js + six route files) are unaffected.

Tests: added three assertions to rateLimiter.test.js covering X-RateLimit-Limit value, decrement of X-RateLimit-Remaining, and presence of a positive X-RateLimit-Reset timestamp.

## Summary
<!-- What does this PR do? -->

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Smart contract change

## Testing
- [ ] Tested locally on Testnet
- [ ] No TypeScript / Rust errors
- [ ] Docs updated if needed

## Screenshots (if UI change)
