### PR TITLE
fix(recurring-donations): enforce 1 XLM minimum

### DIFF
--- a/backend/src/routes/recurring-donations.js
+++ b/backend/src/routes/recurring-donations.js
@@ -1,0 +1,73 @@
+/**
+ * src/routes/recurring-donations.js
+ * POST /api/recurring-donations — create a recurring donation
+ * Enforces a minimum amount of 1 XLM on the server side.
+ */
+"use strict";
+const express = require("express");
+const router  = express.Router();
+const { z } = require("zod");
+const { validateBody } = require("../middleware/validation");
+const { createRateLimiter } = require("../middleware/rateLimiter");
+
+const MIN_RECURRING_AMOUNT_XLM = 1;
+
+const recurringDonationSchema = z.object({
+  projectId: z.string().min(1, "projectId is required"),
+  donorAddress: z.string().min(1, "donorAddress is required"),
+  amountXLM: z.union([z.string(), z.number()]).transform((value) => String(value)),
+  durationMonths: z.union([z.number(), z.null()]).optional().default(null),
+});
+
+const recurringDonationLimiter = createRateLimiter(10, 1);
+
+function validateKey(k) {
+  if (!k || !/^G[A-Z0-9]{55}$/.test(k)) {
+    const e = new Error("Invalid Stellar public key");
+    e.status = 400;
+    throw e;
+  }
+}
+
+/**
+ * Create a recurring donation record.
+ *
+ * @route POST /api/recurring-donations
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+async function createRecurringDonation(req, res, next) {
+  try {
+    const { projectId, donorAddress, amountXLM } = req.body;
+
+    validateKey(donorAddress);
+
+    const parsedAmount = parseFloat(amountXLM);
+    if (isNaN(parsedAmount) || parsedAmount < MIN_RECURRING_AMOUNT_XLM) {
+      const e = new Error(`Minimum recurring donation is ${MIN_RECURRING_AMOUNT_XLM} XLM`);
+      e.status = 400;
+      throw e;
+    }
+
+    res.status(201).json({
+      success: true,
+      data: {
+        id: `rec_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        projectId,
+        donorAddress,
+        amountXLM: parsedAmount.toFixed(7),
+        durationMonths: req.body.durationMonths ?? null,
+        status: "active",
+        createdAt: new Date().toISOString(),
+      },
+    });
+  } catch (e) {
+    next(e);
+  }
+}
+
+router.post("/", recurringDonationLimiter, validateBody(recurringDonationSchema), createRecurringDonation);
+
+module.exports = router;
+module.exports.createRecurringDonation = createRecurringDonation;

--- a/backend/src/routes/recurring-donations.test.js
+++ b/backend/src/routes/recurring-donations.test.js
@@ -1,0 +1,209 @@
+"use strict";
+
+jest.mock("../db/pool", () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+jest.mock("../middleware/rateLimiter", () => ({
+  createRateLimiter: () => (req, res, next) => next(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const recurringDonationsRouter = require("./recurring-donations");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/recurring-donations", recurringDonationsRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ error: err.message || "Internal server error" });
+  });
+  return app;
+}
+
+function makePublicKey(char = "A") {
+  return `G${char.repeat(55)}`;
+}
+
+describe("POST /api/recurring-donations", () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  test("creates a recurring donation with valid amount >= 1 XLM", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("A"),
+        amountXLM: "10",
+      })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.amountXLM).toBe("10.0000000");
+    expect(res.body.data.status).toBe("active");
+    expect(res.body.data.projectId).toBe("project-1");
+  });
+
+  test("creates a recurring donation with exactly 1 XLM", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("B"),
+        amountXLM: "1",
+      })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.amountXLM).toBe("1.0000000");
+  });
+
+  test("creates a recurring donation with amount > 1 XLM", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("C"),
+        amountXLM: "25.5",
+      })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.amountXLM).toBe("25.5000000");
+  });
+
+  test("rejects amount of 0", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("D"),
+        amountXLM: "0",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Minimum recurring donation is 1 XLM");
+  });
+
+  test("rejects amount below 1 XLM", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("E"),
+        amountXLM: "0.5",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Minimum recurring donation is 1 XLM");
+  });
+
+  test("rejects negative amount", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("F"),
+        amountXLM: "-5",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Minimum recurring donation is 1 XLM");
+  });
+
+  test("rejects non-numeric amount", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("G"),
+        amountXLM: "abc",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Minimum recurring donation is 1 XLM");
+  });
+
+  test("rejects empty amount", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("H"),
+        amountXLM: "",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Minimum recurring donation is 1 XLM");
+  });
+
+  test("rejects missing projectId", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        donorAddress: makePublicKey("I"),
+        amountXLM: "10",
+      })
+      .expect(422);
+
+    expect(res.body.error).toBe("Validation failed");
+  });
+
+  test("rejects missing donorAddress", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        amountXLM: "10",
+      })
+      .expect(422);
+
+    expect(res.body.error).toBe("Validation failed");
+  });
+
+  test("rejects invalid Stellar public key", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: "not-a-key",
+        amountXLM: "10",
+      })
+      .expect(400);
+
+    expect(res.body.error).toBe("Invalid Stellar public key");
+  });
+
+  test("accepts amount as number", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("J"),
+        amountXLM: 15,
+      })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.amountXLM).toBe("15.0000000");
+  });
+
+  test("rejects amount just below 1", async () => {
+    const res = await request(app)
+      .post("/api/recurring-donations")
+      .send({
+        projectId: "project-1",
+        donorAddress: makePublicKey("K"),
+        amountXLM: "0.9999999",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("Minimum recurring donation is 1 XLM");
+  });
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -84,6 +84,8 @@ function csrfTokenHandler(req, res) {
 app.get("/api/csrf-token", csrfTokenHandler);
 app.get("/api/v1/csrf-token", csrfTokenHandler);
 
+app.use("/api/recurring-donations", require("./routes/recurring-donations"));
+
 app.use((req, res) => res.status(404).json({ error: `${req.method} ${req.path} not found` }));
 // Sentry error handler — capture and send exceptions to Sentry
 app.use(Sentry.Handlers.errorHandler());

--- a/mobile/__tests__/RecurringDonation.test.tsx
+++ b/mobile/__tests__/RecurringDonation.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * __tests__/RecurringDonation.test.tsx
+ *
+ * Tests for the recurring donation creation form amount validation (issue #802).
+ *
+ * Verifies:
+ * - Minimum amount of 1 XLM is enforced on the frontend
+ * - Inline error "Minimum recurring donation is 1 XLM" is shown for invalid amounts
+ * - Submit button is disabled when amount is invalid
+ * - Submission does not occur for invalid amounts
+ * - Exactly 1 XLM and above are accepted
+ */
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+jest.mock('../hooks/useBiometricAuth', () => ({
+  useBiometricAuth: () => ({
+    available: true,
+    enrolled: true,
+    isAuthenticating: false,
+    label: 'Biometrics',
+    authenticate: jest.fn().mockResolvedValue({ success: true, outcome: 'success' }),
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock('../app/theme', () => ({
+  useTheme: () => ({
+    mode: 'light',
+    colors: {
+      background: '#f0f7f0',
+      surface: '#ffffff',
+      primary: '#227239',
+      accent: '#1a2e1a',
+      header: '#227239',
+      headerText: '#ffffff',
+      buttonBackground: '#227239',
+      buttonText: '#ffffff',
+      cardBorder: '#e8f3e8',
+      cardShadow: '#000000',
+      primaryText: '#1a2e1a',
+      secondaryText: '#5a7a5a',
+      muted: '#8aaa8a',
+      inputBackground: '#ffffff',
+      inputBorder: '#e8f3e8',
+      placeholder: '#8aaa8a',
+      border: '#d8e4d8',
+      statusBarStyle: 'dark',
+    },
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({ id: 'proj-1' }),
+  useFocusEffect: (cb: () => void) => { /* no-op */ },
+}));
+
+jest.mock('expo-linking', () => ({
+  canOpenURL: jest.fn().mockResolvedValue(false),
+  openURL: jest.fn(),
+}));
+
+jest.mock('expo-status-bar', () => ({ StatusBar: () => null }));
+
+jest.mock('axios', () => ({
+  get: jest.fn().mockResolvedValue({
+    data: { data: [{ id: 'proj-1', name: 'Test Project' }] },
+  }),
+  post: jest.fn().mockResolvedValue({ data: { success: true } }),
+}));
+
+const mockCreateRecurringDonation = jest.fn();
+jest.mock('../utils/recurringDonations', () => ({
+  loadRecurringDonations: jest.fn().mockResolvedValue([]),
+  createRecurringDonation: (...args: any[]) => mockCreateRecurringDonation(...args),
+  cancelRecurringDonation: jest.fn().mockResolvedValue(undefined),
+}));
+
+import RecurringScreen from '../app/recurring';
+
+describe('RecurringScreen – amount validation (issue #802)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateRecurringDonation.mockResolvedValue({
+      id: 'rec_1',
+      projectId: 'proj-1',
+      projectName: 'Test Project',
+      amountXLM: '10.0000000',
+      startDate: new Date().toISOString(),
+      nextDueDate: new Date().toISOString(),
+      durationMonths: null,
+      remainingMonths: null,
+      status: 'active',
+      createdAt: new Date().toISOString(),
+    });
+  });
+
+  it('shows the create button initially', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+  });
+
+  it('shows the form when the create button is pressed', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+    await waitFor(() => {
+      expect(getByTestId('recurring-form')).toBeTruthy();
+    });
+  });
+
+  it('displays error and disables submit for amount below 1 XLM', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '0.5');
+
+    await waitFor(() => {
+      expect(getByTestId('recurring-amount-error')).toBeTruthy();
+      expect(getByTestId('recurring-amount-error').props.children).toBe(
+        'Minimum recurring donation is 1 XLM'
+      );
+    });
+  });
+
+  it('disables submit button for amount below 1 XLM', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '0.5');
+
+    await waitFor(() => {
+      const submitBtn = getByTestId('recurring-submit-button');
+      expect(submitBtn.props.accessibilityState?.disabled).toBe(true);
+    });
+  });
+
+  it('shows error for zero amount', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '0');
+
+    await waitFor(() => {
+      expect(getByTestId('recurring-amount-error').props.children).toBe(
+        'Minimum recurring donation is 1 XLM'
+      );
+    });
+  });
+
+  it('shows error for negative amount', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '-5');
+
+    await waitFor(() => {
+      expect(getByTestId('recurring-amount-error').props.children).toBe(
+        'Minimum recurring donation is 1 XLM'
+      );
+    });
+  });
+
+  it('does NOT show error for exactly 1 XLM', async () => {
+    const { getByTestId, queryByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '1');
+
+    await waitFor(() => {
+      expect(queryByTestId('recurring-amount-error')).toBeNull();
+    });
+  });
+
+  it('does NOT show error for amount above 1 XLM', async () => {
+    const { getByTestId, queryByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '25');
+
+    await waitFor(() => {
+      expect(queryByTestId('recurring-amount-error')).toBeNull();
+    });
+  });
+
+  it('enables submit button for valid amount', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '10');
+
+    await waitFor(() => {
+      const submitBtn = getByTestId('recurring-submit-button');
+      expect(submitBtn.props.accessibilityState?.disabled).toBe(false);
+    });
+  });
+
+  it('does not call createRecurringDonation when amount is below minimum', async () => {
+    const { getByTestId } = render(<RecurringScreen />);
+    await waitFor(() => {
+      expect(getByTestId('create-recurring-button')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('create-recurring-button'));
+
+    const input = getByTestId('recurring-amount-input');
+    fireEvent.changeText(input, '0.5');
+
+    await waitFor(() => {
+      const submitBtn = getByTestId('recurring-submit-button');
+      expect(submitBtn.props.accessibilityState?.disabled).toBe(true);
+    });
+
+    fireEvent.press(getByTestId('recurring-submit-button'));
+    expect(mockCreateRecurringDonation).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/app/recurring.tsx
+++ b/mobile/app/recurring.tsx
@@ -10,16 +10,28 @@ import {
   ScrollView,
   StyleSheet,
   TouchableOpacity,
+  TextInput,
   Alert,
   ActivityIndicator,
 } from 'react-native';
 import { useEffect, useState, useCallback } from 'react';
 import { useFocusEffect } from 'expo-router';
+import axios from 'axios';
 import {
   loadRecurringDonations,
+  createRecurringDonation,
   cancelRecurringDonation,
   type RecurringDonation,
 } from '../utils/recurringDonations';
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:4000';
+const MIN_RECURRING_AMOUNT_XLM = 1;
+const RECURRING_ERROR_MESSAGE = 'Minimum recurring donation is 1 XLM';
+
+interface ClimateProject {
+  id: string;
+  name: string;
+}
 
 function formatNextDate(isoDate: string): string {
   return new Date(isoDate).toLocaleDateString(undefined, {
@@ -86,6 +98,14 @@ function DonationCard({
 export default function RecurringScreen() {
   const [donations, setDonations] = useState<RecurringDonation[]>([]);
   const [loading, setLoading] = useState(true);
+  const [projects, setProjects] = useState<ClimateProject[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string>('');
+  const [amountXLM, setAmountXLM] = useState('');
+  const [showForm, setShowForm] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  const amount = parseFloat(amountXLM);
+  const amountValid = amountXLM !== '' && !isNaN(amount) && amount >= MIN_RECURRING_AMOUNT_XLM;
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -96,12 +116,51 @@ export default function RecurringScreen() {
 
   useFocusEffect(refresh);
 
+  useEffect(() => {
+    if (showForm && projects.length === 0) {
+      axios
+        .get(`${API_URL}/api/projects`)
+        .then((res) => {
+          const list: ClimateProject[] = Array.isArray(res.data?.data) ? res.data.data : [];
+          setProjects(list);
+          if (list.length > 0 && !selectedProjectId) {
+            setSelectedProjectId(list[0].id);
+          }
+        })
+        .catch(() => {});
+    }
+  }, [showForm]);
+
   const handleCancel = async (id: string) => {
     await cancelRecurringDonation(id);
     setDonations((prev) => prev.filter((d) => d.id !== id));
   };
 
-  if (loading) {
+  const handleCreate = async () => {
+    if (!amountValid || !selectedProjectId) return;
+
+    const project = projects.find((p) => p.id === selectedProjectId);
+    if (!project) return;
+
+    setCreating(true);
+    try {
+      await createRecurringDonation({
+        projectId: selectedProjectId,
+        projectName: project.name,
+        amountXLM: amount.toFixed(7),
+        durationMonths: null,
+      });
+      setShowForm(false);
+      setAmountXLM('');
+      await refresh();
+    } catch {
+      Alert.alert('Error', 'Failed to create recurring donation. Please try again.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (loading && !showForm) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" color="#227239" />
@@ -116,12 +175,96 @@ export default function RecurringScreen() {
         <Text style={styles.headerSub}>Manage your recurring donations</Text>
       </View>
 
-      {donations.length === 0 ? (
+      {!showForm && (
+        <TouchableOpacity
+          style={styles.createBtn}
+          onPress={() => setShowForm(true)}
+          activeOpacity={0.7}
+          accessibilityLabel="Set up a new recurring donation"
+          accessibilityRole="button"
+          testID="create-recurring-button"
+        >
+          <Text style={styles.createBtnText}>+ New Recurring Donation</Text>
+        </TouchableOpacity>
+      )}
+
+      {showForm && (
+        <View style={styles.formCard} testID="recurring-form">
+          <Text style={styles.formTitle}>New Recurring Donation</Text>
+
+          <Text style={styles.label}>Project</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.projectRow}>
+            {projects.map((project) => {
+              const isActive = project.id === selectedProjectId;
+              return (
+                <TouchableOpacity
+                  key={project.id}
+                  style={[styles.projectChip, isActive && styles.projectChipActive]}
+                  onPress={() => setSelectedProjectId(project.id)}
+                  accessibilityLabel={`Select ${project.name}`}
+                  accessibilityRole="button"
+                >
+                  <Text style={[styles.projectChipText, isActive && styles.projectChipTextActive]}>
+                    {project.name}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </ScrollView>
+
+          <Text style={styles.label}>Amount (XLM)</Text>
+          <TextInput
+            style={[styles.input, !amountValid && amountXLM !== '' && styles.inputError]}
+            placeholder="e.g. 10"
+            placeholderTextColor="#8aaa8a"
+            value={amountXLM}
+            onChangeText={setAmountXLM}
+            keyboardType="decimal-pad"
+            accessibilityLabel="Recurring donation amount in XLM"
+            testID="recurring-amount-input"
+          />
+
+          {!amountValid && amountXLM !== '' && (
+            <Text style={styles.errorText} testID="recurring-amount-error">
+              {RECURRING_ERROR_MESSAGE}
+            </Text>
+          )}
+
+          <View style={styles.formActions}>
+            <TouchableOpacity
+              style={styles.cancelFormBtn}
+              onPress={() => { setShowForm(false); setAmountXLM(''); }}
+              activeOpacity={0.7}
+              accessibilityLabel="Cancel creating recurring donation"
+              accessibilityRole="button"
+            >
+              <Text style={styles.cancelFormBtnText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.submitBtn, (!amountValid || creating) && styles.submitBtnDisabled]}
+              onPress={handleCreate}
+              disabled={!amountValid || creating}
+              activeOpacity={0.7}
+              accessibilityLabel="Save recurring donation"
+              accessibilityRole="button"
+              testID="recurring-submit-button"
+            >
+              {creating ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <Text style={styles.submitBtnText}>Save</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+
+      {donations.length === 0 && !showForm ? (
         <View style={styles.emptyState}>
           <Text style={styles.emptyIcon}>🌱</Text>
           <Text style={styles.emptyTitle}>No active recurring donations</Text>
           <Text style={styles.emptyText}>
-            Set up a monthly donation from any project page to support ongoing impact.
+            Set up a monthly donation to support ongoing impact.
           </Text>
         </View>
       ) : (
@@ -160,6 +303,120 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: '#c8e6c9',
     marginTop: 4,
+  },
+  createBtn: {
+    marginHorizontal: 16,
+    marginTop: 16,
+    backgroundColor: '#227239',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  createBtnText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  formCard: {
+    backgroundColor: '#fff',
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 12,
+    padding: 16,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 3,
+  },
+  formTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1a2e1a',
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1a2e1a',
+    marginBottom: 8,
+  },
+  projectRow: {
+    flexDirection: 'row',
+    marginBottom: 16,
+  },
+  projectChip: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: '#d8e4d8',
+    backgroundColor: '#f0f7f0',
+    marginRight: 8,
+  },
+  projectChipActive: {
+    backgroundColor: '#227239',
+    borderColor: '#227239',
+  },
+  projectChipText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1a2e1a',
+  },
+  projectChipTextActive: {
+    color: '#fff',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d8e4d8',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#1a2e1a',
+    backgroundColor: '#fff',
+  },
+  inputError: {
+    borderColor: '#c62828',
+  },
+  errorText: {
+    color: '#c62828',
+    fontSize: 13,
+    marginTop: 6,
+  },
+  formActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 12,
+    marginTop: 16,
+  },
+  cancelFormBtn: {
+    borderWidth: 1.5,
+    borderColor: '#d8e4d8',
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    alignItems: 'center',
+  },
+  cancelFormBtnText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#5a7a5a',
+  },
+  submitBtn: {
+    backgroundColor: '#227239',
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+    minWidth: 80,
+  },
+  submitBtnDisabled: {
+    opacity: 0.5,
+  },
+  submitBtnText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#fff',
   },
   emptyState: {
     alignItems: 'center',

--- a/mobile/utils/recurringDonations.ts
+++ b/mobile/utils/recurringDonations.ts
@@ -41,6 +41,11 @@ export async function createRecurringDonation(input: {
   amountXLM: string;
   durationMonths: number | null;
 }): Promise<RecurringDonation> {
+  const parsed = parseFloat(input.amountXLM);
+  if (isNaN(parsed) || parsed < 1) {
+    throw new Error('Minimum recurring donation is 1 XLM');
+  }
+
   const now = new Date().toISOString();
   const donation: RecurringDonation = {
     id: `rec_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`,


### PR DESCRIPTION
## Summary

Enforce a minimum recurring donation amount of 1 XLM on both the mobile creation form and the backend API.

## Changes

- Added a recurring donation creation form to the mobile `recurring.tsx` screen with amount validation requiring amountXLM >= 1 XLM.
- Displayed the inline error `Minimum recurring donation is 1 XLM` when the amount is below 1.
- Disabled submission when the amount is below 1 XLM.
- Added backend route `POST /api/recurring-donations` with server-side validation enforcing the same minimum.
- Added minimum validation to the `createRecurringDonation` utility function.
- Added backend tests (13 tests) covering accepted amounts (1, 10, 25.5), rejected amounts (0, 0.5, -5, 0.9999999, empty, non-numeric), validation failures (missing fields, invalid key), and numeric input.
- Added frontend tests (10 tests) covering form display, error messages, submit button state, and validation behavior.

## Testing

- Backend tests: `cd backend && npx jest src/routes/recurring-donations.test.js` — 13 passed
- Mobile tests: written with same patterns as existing `DonateScreen.test.tsx` (pre-existing Babel 8 incompatibility with jest-expo prevents all mobile tests from running — not caused by this change)
- No regressions in existing backend route behavior

## Issue

Closes #802